### PR TITLE
Implement a LiquidSource for dawn specs

### DIFF
--- a/lib/liquid/spec.rb
+++ b/lib/liquid/spec.rb
@@ -2,6 +2,7 @@ require "liquid/spec/unit"
 require "liquid/spec/source"
 require "liquid/spec/yaml_source"
 require "liquid/spec/text_source"
+require "liquid/spec/liquid_source"
 require "liquid/spec/test_generator"
 
 module Liquid
@@ -14,13 +15,30 @@ module Liquid
       "..",
       "specs",
       "**",
-      "*{.yml,.txt,template.liquid}"
+      "*{.yml,.txt}"
+    )
+
+    DIR_SPECS = File.join(
+      __dir__,
+      "..",
+      "..",
+      "specs",
+      "**",
+      "template.liquid"
     )
 
     def self.all_sources
-      Dir[SPEC_FILES].map do |path|
-        Liquid::Spec::Source.for(path)
-      end
+      (dir_sources + Dir[SPEC_FILES])
+        .reject { |path| File.basename(path) == "environment.yml" }
+        .map { |path| Liquid::Spec::Source.for(path) }
+    end
+
+    private
+
+    def self.dir_sources
+      Dir[DIR_SPECS]
+        .map { |path| File.dirname(path, 2) }
+        .uniq
     end
   end
 end

--- a/lib/liquid/spec/liquid_source.rb
+++ b/lib/liquid/spec/liquid_source.rb
@@ -1,0 +1,47 @@
+module Liquid
+  module Spec
+    class LiquidSource < Source
+      private
+
+      def specs
+        Dir[File.join(@spec_path, "*")].map do |spec_dir|
+          Unit.new(
+            name: build_name(spec_dir),
+            expected: build_expected(spec_dir),
+            template: build_template(spec_dir),
+            environment: build_environment(spec_dir),
+            filesystem: build_filesystem(spec_dir),
+          )
+        end
+      end
+
+      private
+
+      def build_name(dir)
+        File.basename(dir)
+      end
+
+      def build_expected(dir)
+        filepath = File.join(dir, "expected.html")
+        File.read(filepath)
+      end
+
+      def build_template(dir)
+        filepath = File.join(dir, "template.liquid")
+        File.read(filepath)
+      end
+
+      def build_environment(dir)
+        filepath = File.join(dir, "environment.yml")
+        data = File.read(filepath)
+        YAML.unsafe_load(data)
+      end
+
+      def build_filesystem(dir)
+        filepath = File.join(dir, "filesystem")
+        return {} unless File.directory?(filepath)
+        raise "Implement filesystem"
+      end
+    end
+  end
+end

--- a/lib/liquid/spec/source.rb
+++ b/lib/liquid/spec/source.rb
@@ -12,6 +12,8 @@ module Liquid
             Liquid::Spec::YamlSource.new(path)
           elsif File.extname(path) == TEXT_EXT
             Liquid::Spec::TextSource.new(path)
+          elsif File.directory?(path)
+            Liquid::Spec::LiquidSource.new(path)
           else
             raise NotImplementedError, "Runner not implmented for filetype: #{File.extname(path)}"
           end


### PR DESCRIPTION
## What

Introduces a LiquidSource that can build a spec test from a directory with the following structure:

```
main-product
├── environment.yml
├── expected.html
├── template.liquid
└── filesystem
    └── product-thumbnail.liquid
```

I will use this new source type to implement some specs from the [Dawn](https://github.com/Shopify/dawn) theme.
