### PR TITLE
Add a spec for rendering arrays with escape sequences

### DIFF
--- a/specs/liquid_ruby/array_to_s.yml
+++ b/specs/liquid_ruby/array_to_s.yml
@@ -1,0 +1,10 @@
+- template: "{{ array }}"
+  environment:
+    array:
+    - hello
+    - "hel\nlo"
+    - nested:
+      - foo
+      - bar
+  expected: "hellohel\nlo{\"nested\"=>[\"foo\", \"bar\"]}"
+  name: Array to_s handles escape sequences


### PR DESCRIPTION
I couldn't find an existing spec nor Liquid test for it.

Came up in: https://github.com/Shopify/liquid-wasm/pull/95.
