### PR TITLE
Make `IntegerDrop` comparable

### DIFF
--- a/lib/liquid/spec/deps/liquid_ruby.rb
+++ b/lib/liquid/spec/deps/liquid_ruby.rb
@@ -91,13 +91,19 @@ class TableRowTest
 end
 
 class IntegerDrop < Liquid::Drop
+  include Comparable
+
   def initialize(value)
     super()
     @value = value.to_i
   end
 
-  def ==(other)
-    @value == other
+  def <=>(other)
+    @value <=> other.to_i
+  end
+
+  def to_i
+    @value
   end
 
   def to_s


### PR DESCRIPTION
# Problem

Currently, we are failing [this spec](https://github.com/Shopify/liquid-spec/blob/720d75e36ff5bf027fcebb4e00af665a88130e1a/specs/liquid_ruby/specs.yml#L5126) that tests comparison with `IntegerDrop`.

```
        Failures:
        ┌Template──────────────────────────────────────────────────────────────────────┐
        │{% if foo > 0 %}one{% endif %}                                                │
        └──────────────────────────────────────────────────────────────────────────────┘
        
        ┌Environment───────────────────────────────────────────────────────────────────┐
        │{"foo"=>IntegerDrop}                                                          │
        └──────────────────────────────────────────────────────────────────────────────┘
        
        ┌Diff──────────────────────────────────────────────────────────────────────────┐
        │Expected: "one"                                                               │
        │  Actual: ""                                                                  │
        └──────────────────────────────────────────────────────────────────────────────┘
```

# Solution

Since `IntegerDrop` doesn't implement comparison in liquid-spec, there are couple options we have in order to make the spec pass

1. Implement the logic within liquid-wasm (i.e. call `to_liquid_value` ourselves)
2. Make it so `IntegerDrop` implements `Comparable`

In SFR, [comparison is already implemented for IntegerDrop](https://github.com/Shopify/storefront-renderer/blob/7e6314a43453c5126ea620e5949f073244f42980/app/liquid/drops/metafields/integer_drop.rb#L9) so option 2 makes the most sense for now.