### PR TITLE
Avoid truncation from tty-box frames for spec data

### DIFF
--- a/lib/liquid/spec/failure_message.rb
+++ b/lib/liquid/spec/failure_message.rb
@@ -7,7 +7,7 @@ module Liquid
 
       Differ = Object.new.extend(Minitest::Assertions)
 
-      def initialize(spec, actual, width: 80)
+      def initialize(spec, actual, width: nil)
         @spec = spec
         @actual = actual
         @width = width


### PR DESCRIPTION
## Problem

There is a bug in the latest release of tty-box that calculates the height of the box before wrapping, which results in the box being truncated, not showing the extra lines from wrapping lines longer than the given width.

## Solution

Get rid of the fixed width being given to tty-box and let it calculate the width based on actual output width.  This not only avoids the bug, but seems more appropriate for longer output by being able to show it without wrapping using a wider terminal window.  Also, we care about the output matching precisely, where the injected newlines from wrapping could cause confusion.  This also has the benefit of the box width better showing the actual width of the output if there are trailing spaces, at least for the longest line.

This avoids the need to add a dependency on pre-release commits for tty-box, where the upstream bug has been fixed.