### PR TITLE
use Timecop to hardcode test time

### DIFF
--- a/lib/liquid/spec/test_generator.rb
+++ b/lib/liquid/spec/test_generator.rb
@@ -1,8 +1,11 @@
+require "timecop"
 require_relative "failure_message"
 
 module Liquid
   module Spec
     class TestGenerator
+      TEST_TIME = Time.utc(2022, 01, 01, 0, 1, 58).freeze
+
       class << self
         def generate(klass, sources, adapter)
           new(klass, sources, adapter).generate
@@ -19,8 +22,10 @@ module Liquid
           source.each do |spec|
             @klass.class_exec(@adapter) do |adapter|
               define_method("test_#{spec.name}") do
-                actual = adapter.render(spec)
-                assert spec.expected == actual, FailureMessage.new(spec, actual)
+                Timecop.freeze(TEST_TIME) do
+                  actual = adapter.render(spec)
+                  assert spec.expected == actual, FailureMessage.new(spec, actual)
+                end
               end
             end
           end

--- a/liquid-spec.gemspec
+++ b/liquid-spec.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "tty-box"
+  spec.add_dependency "timecop"
   spec.require_paths = ["lib"]
 end


### PR DESCRIPTION
### Problem 

Spec tests with `{{ 'now' | date: "%Y" }}` Liquid templates are failing because the expected response is hard coded to `2022`.

### Solution

Use `timecop` to set the time to `2022-01-01 00:01:58` to have tests not depend on the actual time. 