### PR TITLE
Revert "Make `IntegerDrop` comparable"

### DIFF
--- a/lib/liquid/spec/deps/liquid_ruby.rb
+++ b/lib/liquid/spec/deps/liquid_ruby.rb
@@ -91,19 +91,13 @@ class TableRowTest
 end
 
 class IntegerDrop < Liquid::Drop
-  include Comparable
-
   def initialize(value)
     super()
     @value = value.to_i
   end
 
-  def <=>(other)
-    @value <=> other.to_i
-  end
-
-  def to_i
-    @value
+  def ==(other)
+    @value == other
   end
 
   def to_s


### PR DESCRIPTION
Reverts Shopify/liquid-spec#28

@ianks in that PR you wrote

> Since `IntegerDrop` doesn't implement comparison in liquid-spec, there are couple options we have in order to make the spec pass
> 
> 1. Implement the logic within liquid-wasm (i.e. call `to_liquid_value` ourselves)
> 2. Make it so `IntegerDrop` implements `Comparable`
> 
> In SFR, [comparison is already implemented for IntegerDrop](https://github.com/Shopify/storefront-renderer/blob/7e6314a43453c5126ea620e5949f073244f42980/app/liquid/drops/metafields/integer_drop.rb#L9) so option 2 makes the most sense for now.

but that misses the point of the test, which was to make sure that `to_liquid_value` was being called.  It wasn't specifically about that `IntegerDrop` SRR drop, but the feature in general.

In fact, in https://github.com/Shopify/liquid-wasm/pull/664#issuecomment-1382193010 you said yourself

> Can you add some tests to make sure this is covered? Surprised it wasn't covered in any of the existing specs TBH...

when this PR I'm proposing to revert was a big reason for the lack of test coverage for this feature.