### PR TITLE
`bundle exec rake generate:liquid_ruby`

### DIFF
--- a/specs/liquid_ruby/specs.yml
+++ b/specs/liquid_ruby/specs.yml
@@ -2,19 +2,19 @@
 - template: "{% assign foo = ('X' | downcase) %}"
   expected: ''
   name: AssignTest#test_assign_uses_error_mode_93a264f2a779749a8accc6292e8abaca
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/assign_test.rb#L39
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/assign_test.rb#L39
 - template: '{% assign foo = values | split: "," %}.{{ foo[1] }}.'
   environment:
     values: foo,bar,baz
   expected: ".bar."
   name: AssignTest#test_assign_with_filter_4622aa3cc1bcffe322d31afabace2b33
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/assign_test.rb#L27
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/assign_test.rb#L27
 - template: |
     {% assign this-thing = 'Print this-thing' -%}
     {{ this-thing -}}
   expected: Print this-thing
   name: AssignTest#test_assign_with_hyphen_in_variable_name_5a8bcf706c2a1e8cc656c56af5ba252b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/assign_test.rb#L13
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/assign_test.rb#L13
 - template: "{% assign foo = values %}.{{ foo[1] }}."
   environment:
     values:
@@ -23,7 +23,7 @@
     - baz
   expected: ".bar."
   name: AssignTest#test_assigned_variable_19fff35daf2e988c6cd01308e9bbebc6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/assign_test.rb#L21
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/assign_test.rb#L21
 - template: "{% assign foo = values %}.{{ foo[0] }}."
   environment:
     values:
@@ -32,73 +32,73 @@
     - baz
   expected: ".foo."
   name: AssignTest#test_assigned_variable_49a3f1e9a2a85183dd20eb781369e976
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/assign_test.rb#L17
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/assign_test.rb#L17
 - template: "{% assign r = a[ 'b' ] %}{{ r }}"
   environment:
     a:
       b: result
   expected: result
   name: AssignTest#test_expression_with_whitespace_in_square_brackets_928e018177c35e521d55e14c83a8ccb3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/assign_test.rb#L44
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/assign_test.rb#L44
 - template: '{% for i in (1..10) %} {% assign foo = "bar" %} {% endfor %}{% if true
     %} {% assign foo = "bar" %} {% endif %}'
   expected: ''
   name: BlankTest#test_assigns_are_blank_340a7943b10a3909a056c81cdb4d5ac7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L66
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L66
 - template: "{% for i in (1..10) %} {% capture foo %} whatever {% endcapture %} {%
     endfor %}{% if true %} {% capture foo %} whatever {% endcapture %} {% endif %}"
   expected: ''
   name: BlankTest#test_captures_are_blank_df580fd7b41871c277dc54a279b6e90b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L55
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L55
 - template: "{% for i in (1..10) %} {% assign foo = 'else' %} {% case foo %} {% when
     'bar' %} {% when 'whatever' %} {% else %} x {% endcase %} {% endfor %}{% if true
     %} {% assign foo = 'else' %} {% case foo %} {% when 'bar' %} {% when 'whatever'
     %} {% else %} x {% endcase %} {% endif %}"
   expected: "   x     x     x     x     x     x     x     x     x     x     x  "
   name: BlankTest#test_case_is_blank_5cf0d98002b5cb24d09a4448e2df0bd2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L103
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L103
 - template: "{% for i in (1..10) %} {% assign foo = 'bar' %} {% case foo %} {% when
     'bar' %} {% when 'whatever' %} {% else %} {% endcase %} {% endfor %}{% if true
     %} {% assign foo = 'bar' %} {% case foo %} {% when 'bar' %} {% when 'whatever'
     %} {% else %} {% endcase %} {% endif %}"
   expected: ''
   name: BlankTest#test_case_is_blank_6bdb479115667ea04d1066613588c3c9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L101
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L101
 - template: "{% for i in (1..10) %} {% assign foo = 'else' %} {% case foo %} {% when
     'bar' %} {% when 'whatever' %} {% else %} {% endcase %} {% endfor %}{% if true
     %} {% assign foo = 'else' %} {% case foo %} {% when 'bar' %} {% when 'whatever'
     %} {% else %} {% endcase %} {% endif %}"
   expected: ''
   name: BlankTest#test_case_is_blank_bc7e6b846387234d56ba6f8d5faf5bf0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L102
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L102
 - template: "{% for i in (1..10) %} {% comment %} whatever {% endcomment %} {% endfor
     %}{% if true %} {% comment %} whatever {% endcomment %} {% endif %}"
   expected: ''
   name: BlankTest#test_comments_are_blank_9c6e5291f13c8e0d69d89bf1a247ab4e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L51
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L51
 - template: "{% for i in (1..10) %}{% cycle ' ', ' ' %}{% endfor %}{% if true %}{%
     cycle ' ', ' ' %}{% endif %}"
   expected: "           "
   name: BlankTest#test_cycle_is_not_blank_0029fe160be52e74a36c236f3d620a19
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L84
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L84
 - template: "{% if true %} {% elsif false %} {% else %} {% endif %}"
   expected: ''
   name: BlankTest#test_if_else_are_blank_89ed8cdad81319df8cf3dd8847393487
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L39
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L39
 - template: "{% for i in (1..10) %}{% include 'foobar' %}{% endfor %}{% if true %}{%
     include 'foobar' %}{% endif %}"
   expected: foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar
   name: BlankTest#test_include_is_blank_38e4c39200a5506fe42d0ff8aa2cb05a
   filesystem:
     foobar: foobar
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L92
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L92
 - template: "{% for i in (1..10) %} {% include ' ' %} {% endfor %}{% if true %} {%
     include ' ' %} {% endif %}"
   expected: "                                 "
   name: BlankTest#test_include_is_blank_48d3fd2f3d4e9d907583fc6e25f41fe0
   filesystem:
     " ": " "
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L96
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L96
 - template: "{% for i in (1..10) %}{% include ' foobar ' %}{% endfor %}{% if true
     %}{% include ' foobar ' %}{% endif %}"
   expected: " foobar  foobar  foobar  foobar  foobar  foobar  foobar  foobar  foobar
@@ -106,29 +106,29 @@
   name: BlankTest#test_include_is_blank_9c66cc191460ba81a45b6d388458fc94
   filesystem:
     " foobar ": " foobar "
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L94
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L94
 - template: "{% for i in (1..10) %}{% assign foo = 0 %} {% increment foo %} {% decrement
     foo %}{% endfor %}{% if true %}{% assign foo = 0 %} {% increment foo %} {% decrement
     foo %}{% endif %}"
   expected: " 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
   name: BlankTest#test_increment_is_not_blank_e9a16e5e8069c4573e65d2aa54e9841f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L80
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L80
 - template: "{% for i in (1..10) %} {% endfor %}"
   expected: ''
   name: BlankTest#test_loops_are_blank_6bebf53adf8256f3d3f0fa778d5f6fd1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L35
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L35
 - template: "{% for i in (1..10) %} {% if false %} this never happens, but still,
     this block is not blank {% endif %}{% endfor %}{% if true %} {% if false %} this
     never happens, but still, this block is not blank {% endif %}{% endif %}"
   expected: "           "
   name: BlankTest#test_mark_as_blank_only_during_parsing_7802a01834098eef20cb34a9c24c1abd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L47
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L47
 - template: "{% for i in (1..10) %}{% for i in (1..10) %} {% endfor %}{% if true %}
     {% endif %}{% endfor %}{% if true %}{% for i in (1..10) %} {% endfor %}{% if true
     %} {% endif %}{% endif %}"
   expected: ''
   name: BlankTest#test_nested_blocks_are_blank_but_only_if_all_children_are_0e3216697077decefdb5591e7155aadb
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L59
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L59
 - template: |-
     {% for i in (1..10) %}{% if true %} {% comment %} this is blank {% endcomment %} {% endif %}
           {% if true %} but this is not {% endif %}{% endfor %}{% if true %}{% if true %} {% comment %} this is blank {% endcomment %} {% endif %}
@@ -138,37 +138,37 @@
     \n       but this is not \n       but this is not \n       but this is not \n
     \      but this is not \n       but this is not "
   name: BlankTest#test_nested_blocks_are_blank_but_only_if_all_children_are_8e207e76f56712c98aeebfc2e14ba96d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L60
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L60
 - template: "{% for i in (1..10) %} {% raw %} {% endraw %}{% endfor %}{% if true %}
     {% raw %} {% endraw %}{% endif %}"
   expected: "                      "
   name: BlankTest#test_raw_is_not_blank_7f94d7b056c6a46a14202ff470bd1007
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L88
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L88
 - template: "{% for i in (1..10) %}{% unless true %} {% endunless %}{% endfor %}{%
     if true %}{% unless true %} {% endunless %}{% endif %}"
   expected: ''
   name: BlankTest#test_unless_is_blank_bfc1765cfb64fe1e5e260873b7a44fd0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L43
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L43
 - template: "{% for i in (1..10) %} {% endfor %}{% if true %} {% endif %}"
   expected: ''
   name: BlankTest#test_whitespace_is_blank_dc35fb75e596e50089178227f845310d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L70
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L70
 - template: "{% for i in (1..10) %}\t{% endfor %}{% if true %}\t{% endif %}"
   expected: ''
   name: BlankTest#test_whitespace_is_blank_e75e304b8ef995ae055e07fc03811243
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L71
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L71
 - template: "{% for i in (1..10) %}     x {% endfor %}{% if true %}     x {% endif
     %}"
   expected: "     x      x      x      x      x      x      x      x      x      x
     \     x "
   name: BlankTest#test_whitespace_is_not_blank_if_other_stuff_is_present_44107d4366c46a01da0281884b85527c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/blank_test.rb#L76
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/blank_test.rb#L76
 - template: before{% break %}after
   environment:
     i: 1
   expected: before
   name: BreakTagTest#test_break_with_no_block_4ab51d54f399f18257f332d9fb0f708a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/break_tag_test.rb#L15
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/break_tag_test.rb#L15
 - template: |
     {% assign first = '' -%}
     {% assign second = '' -%}
@@ -179,7 +179,7 @@
     {{ first }}-{{ second -}}
   expected: 3-3
   name: CaptureTest#test_assigning_from_capture_98f219440ea230d5c0dfd9fcee1f365a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/capture_test.rb#L44
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/capture_test.rb#L44
 - template: |
     {% assign var = '' -%}
     {% if true -%}
@@ -191,17 +191,17 @@
     {{var-}}
   expected: test-string
   name: CaptureTest#test_capture_to_variable_from_outer_scope_if_existing_a7f1d3d8e0df936af3c01c5cdbebf8b2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/capture_test.rb#L31
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/capture_test.rb#L31
 - template: |
     {% capture this-thing %}Print this-thing{% endcapture -%}
     {{ this-thing -}}
   expected: Print this-thing
   name: CaptureTest#test_capture_with_hyphen_in_variable_name_41adce913d179f118272c05f6052e5c1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/capture_test.rb#L17
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/capture_test.rb#L17
 - template: "{% capture 'var' %}test string{% endcapture %}{{var}}"
   expected: test string
   name: CaptureTest#test_captures_block_content_in_variable_e975850345b768b98b7ec8eefdb9ad71
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/capture_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/capture_test.rb#L9
 - template: "{{ products[nested.var].last }}"
   environment:
     var: tags
@@ -214,7 +214,7 @@
       - freestyle
   expected: freestyle
   name: ContextTest#test_access_hashes_with_hash_access_variables_1dc003c3ca250e04dcd9b4a0bb9c24b1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L282
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L282
 - template: "{{ products[var].first }}"
   environment:
     var: tags
@@ -227,7 +227,7 @@
       - freestyle
   expected: deepsnow
   name: ContextTest#test_access_hashes_with_hash_access_variables_28c4eed5f8ccbbf4978339523f2350d7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L281
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L281
 - template: '{{ product["variants"][1]["title"] }}'
   environment:
     product:
@@ -236,7 +236,7 @@
       - title: element151cm
   expected: element151cm
   name: ContextTest#test_access_hashes_with_hash_notation_15a1c028295cb4f6d750da87372ac0b5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L264
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L264
 - template: '{{ product["variants"][0]["title"] }}'
   environment:
     product:
@@ -245,7 +245,7 @@
       - title: element151cm
   expected: draft151cm
   name: ContextTest#test_access_hashes_with_hash_notation_1d779e13a0ab9ab1024c85c191706ab5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L263
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L265
 - template: '{{ product["variants"][0]["title"] }}'
   environment:
     product:
@@ -254,7 +254,7 @@
       - title: element151cm
   expected: draft151cm
   name: ContextTest#test_access_hashes_with_hash_notation_1d779e13a0ab9ab1024c85c191706ab5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L265
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L263
 - template: '{{ products["tags"].first }}'
   environment:
     products:
@@ -264,7 +264,7 @@
       - freestyle
   expected: deepsnow
   name: ContextTest#test_access_hashes_with_hash_notation_2522906df9512f58e22ea2e0cd39d07e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L260
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L260
 - template: '{{ products["count"] }}'
   environment:
     products:
@@ -274,7 +274,7 @@
       - freestyle
   expected: '5'
   name: ContextTest#test_access_hashes_with_hash_notation_7f964bf39a03fc782819b5235e55403e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L258
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L258
 - template: '{{ product["variants"].last["title"] }}'
   environment:
     product:
@@ -283,7 +283,7 @@
       - title: element151cm
   expected: element151cm
   name: ContextTest#test_access_hashes_with_hash_notation_8cfab66c055289a27ffe41b6a5bdacfe
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L266
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L266
 - template: '{{ products["tags"][0] }}'
   environment:
     products:
@@ -293,20 +293,20 @@
       - freestyle
   expected: deepsnow
   name: ContextTest#test_access_hashes_with_hash_notation_9e3eb9db3cfe46db0e6c3b34a8b19cf3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L259
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L259
 - template: '{{ ["foo"] }}'
   environment:
     foo: baz
   expected: baz
   name: ContextTest#test_access_variable_with_hash_notation_28a724e158eae5ca7bea424a96dd94a4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L270
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L270
 - template: "{{ [bar] }}"
   environment:
     foo: baz
     bar: foo
   expected: baz
   name: ContextTest#test_access_variable_with_hash_notation_747deb8995e4ec541b64c1358e3ee665
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L271
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L271
 - template: "{{ test[0] }}"
   environment:
     test:
@@ -314,7 +314,7 @@
     - b
   expected: a
   name: ContextTest#test_array_notation_16e55c26711dca28dfd3260cc830a7ad
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L217
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L217
 - template: "{% if test[2] == nil %}pass{% endif %}"
   environment:
     test:
@@ -322,7 +322,7 @@
     - b
   expected: pass
   name: ContextTest#test_array_notation_36281fa043ca73e2fcc8a8febee45a77
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L219
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L219
 - template: "{{ test[1] }}"
   environment:
     test:
@@ -330,19 +330,19 @@
     - b
   expected: b
   name: ContextTest#test_array_notation_8c17170efd0e5c061abc1fddfb24aa87
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L218
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L218
 - template: "{% if 100 == expect %}pass{% endif %}"
   environment:
     expect: 100
   expected: pass
   name: ContextTest#test_digits_3a2f62dec22d847aed7ba8ba469133c1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L198
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L198
 - template: "{% if 100.00 == expect %}pass{% endif %}"
   environment:
     expect: 100.0
   expected: pass
   name: ContextTest#test_digits_4defaf1a615001bed0da4b26ca639001
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L199
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L199
 - template: "{{ product.variants[0].title }}"
   environment:
     product:
@@ -351,7 +351,7 @@
       - title: element151cm
   expected: draft151cm
   name: ContextTest#test_first_can_appear_in_middle_of_callchain_059334cdfd860a29a31d1cd42781ddb8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L296
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L296
 - template: "{{ product.variants.last.title }}"
   environment:
     product:
@@ -360,7 +360,7 @@
       - title: element151cm
   expected: element151cm
   name: ContextTest#test_first_can_appear_in_middle_of_callchain_9ba66bd216655a2ec3953b3f8be14ca6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L299
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L299
 - template: "{{ product.variants[1].title }}"
   environment:
     product:
@@ -369,7 +369,7 @@
       - title: element151cm
   expected: element151cm
   name: ContextTest#test_first_can_appear_in_middle_of_callchain_c5a5c0ff02b70747bc38edf772ebac7d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L297
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L297
 - template: "{{ product.variants.first.title }}"
   environment:
     product:
@@ -378,7 +378,7 @@
       - title: element151cm
   expected: draft151cm
   name: ContextTest#test_first_can_appear_in_middle_of_callchain_ea1854d103065ba8fd0310f5599b1d02
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L298
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L298
 - template: "{{ array.first }}"
   environment:
     array:
@@ -389,7 +389,7 @@
     - 5
   expected: '1'
   name: ContextTest#test_hash_notation_only_for_hash_access_047abb9c98ccd5bce8836af9fc181d79
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L287
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L287
 - template: '{% if array["first"] == nil %}pass{% endif %}'
   environment:
     array:
@@ -400,14 +400,14 @@
     - 5
   expected: pass
   name: ContextTest#test_hash_notation_only_for_hash_access_7266a477e3f4a963812212455369dd66
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L288
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L288
 - template: '{{ hash["first"] }}'
   environment:
     hash:
       first: Hello
   expected: Hello
   name: ContextTest#test_hash_notation_only_for_hash_access_e15514d94a9d797f6893293d73a393eb
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L290
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L290
 - template: "{{ colors.Red[3] }}"
   environment:
     colors:
@@ -433,7 +433,7 @@
       - FF9999
   expected: FF9999
   name: ContextTest#test_hash_to_array_transition_314ca7a5c0a18c39b4a2cd6edc6460ef
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L239
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L239
 - template: "{{ colors.Blue[0] }}"
   environment:
     colors:
@@ -459,39 +459,39 @@
       - FF9999
   expected: '003366'
   name: ContextTest#test_hash_to_array_transition_7bb8bc45de4c9a1b09d7f0e5cfcf87a2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L238
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L238
 - template: "{{ hash.name }}"
   environment:
     hash:
       name: tobi
   expected: tobi
   name: ContextTest#test_hierachical_data_b86776e98a29955352942456755af20e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L188
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L188
 - template: '{{ hash["name"] }}'
   environment:
     hash:
       name: tobi
   expected: tobi
   name: ContextTest#test_hierachical_data_cad9e4454586e1ae69eab8275fa9ccd5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L189
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L189
 - template: "{{ oh-my }}"
   environment:
     oh-my: godz
   expected: godz
   name: ContextTest#test_hyphenated_variable_1c547474be4e3ffca6bf3c7bef422a5a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L135
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L135
 - template: "{% if false == expect %}pass{% endif %}"
   environment:
     expect: false
   expected: pass
   name: ContextTest#test_keywords_197422316eeba20d8ebce4432086d49a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L194
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L194
 - template: "{% if true == expect %}pass{% endif %}"
   environment:
     expect: true
   expected: pass
   name: ContextTest#test_keywords_f6bd69fb47b4394e8a645d9bd43b122b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L193
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L193
 - template: "{% if numbers.size == 1000 %}true{% endif %}"
   environment:
     numbers:
@@ -502,7 +502,7 @@
       size: 1000
   expected: 'true'
   name: ContextTest#test_length_query_56f2bbc7a0f4aec2cdffe96deeb640a1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L130
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L130
 - template: "{% if numbers.size == 4 %}true{% endif %}"
   environment:
     numbers:
@@ -512,7 +512,7 @@
       4: 4
   expected: 'true'
   name: ContextTest#test_length_query_5f41d5e6c5bc65e0548ae64199c9ea78
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L127
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L127
 - template: "{% if numbers.size == 4 %}true{% endif %}"
   environment:
     numbers:
@@ -522,23 +522,23 @@
     - 4
   expected: 'true'
   name: ContextTest#test_length_query_e774bf7d92621800f39b85949ed34623
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L124
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L124
 - template: "{{ (test..test) }}"
   environment:
     test: '5'
   expected: 5..5
   name: ContextTest#test_ranges_0bedd75105590c2576d2c8632e8fe97c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L346
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L346
 - template: "{{ (1..5) }}"
   expected: 1..5
   name: ContextTest#test_ranges_5d7eed43126e20b59b91da9a2dac7f0d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L341
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L341
 - template: "{{ (1..test) }}"
   environment:
     test: '5'
   expected: 1..5
   name: ContextTest#test_ranges_69b38bda7624e74945cba315b8b16442
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L345
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L345
 - template: "{% if (1..5) == expect %}pass{% endif %}"
   environment:
     expect: !ruby/range
@@ -547,7 +547,7 @@
       excl: false
   expected: pass
   name: ContextTest#test_ranges_70f8b7a0cebaf88b83e8c8793551e889
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L342
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L342
 - template: "{{ test.test[0] }}"
   environment:
     test:
@@ -559,22 +559,22 @@
       - 5
   expected: '1'
   name: ContextTest#test_recoursive_array_notation_84a7d7c414e7ca5fafb9b27e7a849652
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L224
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L224
 - template: "{{ test[0].test }}"
   environment:
     test:
     - test: worked
   expected: worked
   name: ContextTest#test_recoursive_array_notation_d6f66814a2b63f34ab6c356bdf64f7b4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L227
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L227
 - template: '{{ "hello!" }}'
   expected: hello!
   name: ContextTest#test_strings_75c8ea95f50e51d0800bc48dd5125bb6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L203
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L203
 - template: "{{ 'hello!' }}"
   expected: hello!
   name: ContextTest#test_strings_c86b8e7984d921d6f08bd994fb117174
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L204
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L204
 - template: "{{ test.first }}"
   environment:
     test:
@@ -585,7 +585,7 @@
     - 5
   expected: '1'
   name: ContextTest#test_try_first_541a7353840d7392b013a56c91deb566
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L244
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L244
 - template: "{{ test.test.last }}"
   environment:
     test:
@@ -597,7 +597,7 @@
       - 5
   expected: '5'
   name: ContextTest#test_try_first_66b57ee86493cc04dc69236853ac9b43
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L249
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L249
 - template: "{{ test.test.first }}"
   environment:
     test:
@@ -609,21 +609,21 @@
       - 5
   expected: '1'
   name: ContextTest#test_try_first_7876c0a2ac646fd9879f74e1756bad9a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L248
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L248
 - template: "{{ test.first }}"
   environment:
     test:
     - 1
   expected: '1'
   name: ContextTest#test_try_first_80f29592507c6a749f1a635c16913290
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L252
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L252
 - template: "{{ test.last }}"
   environment:
     test:
     - 1
   expected: '1'
   name: ContextTest#test_try_first_96c30e359d58f835a3b8de797554f2f1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L253
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L253
 - template: "{% if test.last == 5 %}pass{% endif %}"
   environment:
     test:
@@ -634,57 +634,57 @@
     - 5
   expected: pass
   name: ContextTest#test_try_first_99dbf646ab394c34b232c649baccfae0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L245
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L245
 - template: "{% if does_not_exist == nil %}true{% endif %}"
   expected: 'true'
   name: ContextTest#test_variables_not_existing_54bde9de564f4a47783b119353b2dc4f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/context_test.rb#L105
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/context_test.rb#L105
 - template: "{% continue %}"
   expected: ''
   name: ContinueTagTest#test_continue_with_no_block_7a08c7cfba8d325d51afe5a2b4525801
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/continue_tag_test.rb#L15
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/continue_tag_test.rb#L15
 - template: "{%- echo variable-name | upcase -%}\n"
   environment:
     variable-name: bar
   expected: BAR
   name: EchoTest#test_echo_outputs_its_input_640de406147b285fd203239631062b2c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/echo_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/echo_test.rb#L9
 - template: "{{ 2.5 }}"
   expected: '2.5'
   name: ExpressionTest#test_float_6d357f5c1a35f63c2d9e2941acbb198c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L25
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L25
 - template: "{% if expect == 1.5 %}pass{% else %}got {{ 1.5 }}{% endif %}"
   environment:
     expect: 1.5
   expected: pass
   name: ExpressionTest#test_float_da15300c27a334236c04d1ce48fa9d3a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L47
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L47
 - template: "{{ 456 }}"
   expected: '456'
   name: ExpressionTest#test_int_2129e39700082841308bc05f01fe676b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L19
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L19
 - template: "{% if expect == 012 %}pass{% else %}got {{ 012 }}{% endif %}"
   environment:
     expect: 12
   expected: pass
   name: ExpressionTest#test_int_4fb7440dc7ed8df044848096bab4321e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L47
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L47
 - template: "{% if expect == 123 %}pass{% else %}got {{ 123 }}{% endif %}"
   environment:
     expect: 123
   expected: pass
   name: ExpressionTest#test_int_5ffa86088a6958f626a620457c2c0a56
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L47
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L47
 - template: "{{ true }}"
   expected: 'true'
   name: ExpressionTest#test_keyword_literals_4fb26bfec5ffbc8d1f6d5197cb1e1bc4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L7
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L7
 - template: "{% if expect == true %}pass{% else %}got {{ true }}{% endif %}"
   environment:
     expect: true
   expected: pass
   name: ExpressionTest#test_keyword_literals_78bc161483b072ea3097f52d168d1aaa
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L47
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L47
 - template: "{% if expect == (1..2) %}pass{% else %}got {{ (1..2) }}{% endif %}"
   environment:
     expect: !ruby/range
@@ -693,33 +693,33 @@
       excl: false
   expected: pass
   name: ExpressionTest#test_range_628e1de999e735def75344225dfd4d0a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L47
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L47
 - template: "{{ ( 3 .. 4 ) }}"
   expected: 3..4
   name: ExpressionTest#test_range_6887a3f3219b4726b5f5585f4790860f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L30
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L30
 - template: '{{"double quoted"}}'
   expected: double quoted
   name: ExpressionTest#test_string_34b6b1b489c3789e7be3b8c29f15431d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L13
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L13
 - template: "{{'single quoted'}}"
   expected: single quoted
   name: ExpressionTest#test_string_6d01d4f8212df469613eb96bc59e783b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L12
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L12
 - template: "{{ 'spaced2' }}"
   expected: spaced2
   name: ExpressionTest#test_string_c51677e480798718077a1e70d345e433
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L15
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L15
 - template: "{{ 'spaced' }}"
   expected: spaced
   name: ExpressionTest#test_string_d4ee2fd38769fb54361c3a339ead86e2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/expression_test.rb#L14
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/expression_test.rb#L14
 - template: "{{ var | capitalize }}"
   environment:
     var: blub
   expected: Blub
   name: FiltersTest#test_capitalize_5a098e93331735d1e16638ea43417b43
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L117
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L117
 - template: "{{words | compact | join}}"
   environment:
     words:
@@ -730,7 +730,7 @@
     - c
   expected: a b c
   name: FiltersTest#test_compact_3fc51364692de3246c33759128c26d2d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L95
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L95
 - template: "{{hashes | compact: 'a' | map: 'a' | join}}"
   environment:
     hashes:
@@ -739,7 +739,7 @@
     - a: C
   expected: A C
   name: FiltersTest#test_compact_a4777920e9611282ea2d4e504cb1e582
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L99
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L99
 - template: "{{var | join}}"
   environment:
     var:
@@ -749,19 +749,19 @@
     - 4
   expected: 1 2 3 4
   name: FiltersTest#test_join_4f478786c0537fb4d75ca93145434703
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L66
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L66
 - template: "{{ var | xyzzy }}"
   environment:
     var: 1000
   expected: '1000'
   name: FiltersTest#test_nonexistent_filter_is_ignored_7c7bab956cead363172ad79edc468553
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L121
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L121
 - template: "{{var | size}}"
   environment:
     var: abcd
   expected: '4'
   name: FiltersTest#test_size_daaccdbab83e2e849fc9eb74b187741e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L62
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L62
 - template: "{{case_sensitive | sort | join}}"
   environment:
     case_sensitive:
@@ -770,13 +770,13 @@
     - case
   expected: Expected case sensitive
   name: FiltersTest#test_sort_45e46293ad30573dcbb1d592aedbd155
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L75
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L75
 - template: "{{value | sort}}"
   environment:
     value: 3
   expected: '3'
   name: FiltersTest#test_sort_6be27c83653248870fcd62c88b55df0e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L73
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L73
 - template: "{{arrays | sort | join}}"
   environment:
     arrays:
@@ -784,7 +784,7 @@
     - are
   expected: are flower
   name: FiltersTest#test_sort_74d91a4e5f8613000f33de999e20ee31
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L74
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L74
 - template: "{{words | sort | join}}"
   environment:
     words:
@@ -793,7 +793,7 @@
     - alphabetic
   expected: alphabetic as expected
   name: FiltersTest#test_sort_c2cb39b9bd71402074414808a2b34af4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L71
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L71
 - template: "{{numbers | sort | join}}"
   environment:
     numbers:
@@ -803,7 +803,7 @@
     - 3
   expected: 1 2 3 4
   name: FiltersTest#test_sort_d39206c856339fb0f34e92596ec5b461
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L70
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L70
 - template: "{{words | sort_natural | join}}"
   environment:
     words:
@@ -812,7 +812,7 @@
     - Insensitive
   expected: Assert case Insensitive
   name: FiltersTest#test_sort_natural_17d50b3004e6ffcf62628b092e95f8d0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L81
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L81
 - template: "{{hashes | sort_natural: 'a' | map: 'a' | join}}"
   environment:
     hashes:
@@ -821,25 +821,25 @@
     - a: C
   expected: A b C
   name: FiltersTest#test_sort_natural_d951839a8629c04c91f4416721e2d147
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L85
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L85
 - template: "{{ var | strip_html }}"
   environment:
     var: "<b>bla blub</a>"
   expected: bla blub
   name: FiltersTest#test_strip_html_44fb6a6b562d6ce64d015d3447d1f1aa
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L108
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L108
 - template: "{{ var | strip_html }}"
   environment:
     var: "<!-- split and some <ul> tag --><b>bla blub</a>"
   expected: bla blub
   name: FiltersTest#test_strip_html_ignore_comments_with_html_8086574f1e9ac954fd61643e4c72eca8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/filter_test.rb#L112
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/filter_test.rb#L112
 - template: "{% for char in characters %}I WILL NOT BE OUTPUT{% endfor %}"
   environment:
     characters: ''
   expected: ''
   name: ForTagTest#test_blank_string_not_iterable_72beb69e4fdee5ee83b3853e073e68c0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L370
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L371
 - template: "{%for i in array limit: limit offset: offset %}{{ i }}{%endfor%}"
   environment:
     array:
@@ -857,14 +857,14 @@
     offset: 2
   expected: '34'
   name: ForTagTest#test_dynamic_variable_limiting_63b8a8ab5e4aa0a187caed1f3b740007
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L141
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L142
 - template: "{%for item in array%} yo {%endfor%}"
   environment:
     array:
     - 1
   expected: " yo "
   name: ForTagTest#test_for_192b384e7b698361064c8a513736721c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L17
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L17
 - template: |
     {%for item in array%}
       yo
@@ -883,7 +883,7 @@
       yo
 
   name: ForTagTest#test_for_337e9860e23794e91a128325331993e8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L33
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L33
 - template: "{%for item in array%} yo {%endfor%}"
   environment:
     array:
@@ -893,7 +893,7 @@
     - 4
   expected: " yo  yo  yo  yo "
   name: ForTagTest#test_for_3a22f9087a80ef098617b44cb095f6b8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L15
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L15
 - template: "{%for item in array%}{%endfor%}"
   environment:
     array:
@@ -901,7 +901,7 @@
     - 2
   expected: ''
   name: ForTagTest#test_for_59bd29d656d8d4734ceab5ebae121d3b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L18
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L18
 - template: "{%for item in array%}{% if forloop.first %}+{% else %}-{% endif %}{%endfor%}"
   environment:
     array:
@@ -910,7 +910,7 @@
     - 3
   expected: "+--"
   name: ForTagTest#test_for_and_if_31dd9c46373052d107a04c475db7928e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L89
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L89
 - template: "{%for item in array%}+{%else%}-{%endfor%}"
   environment:
     array:
@@ -919,19 +919,19 @@
     - 3
   expected: "+++"
   name: ForTagTest#test_for_else_3281604dea49f3374e1fbcb6b472c8c7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L95
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L95
 - template: "{%for item in array%}+{%else%}-{%endfor%}"
   environment:
     array:
   expected: "-"
   name: ForTagTest#test_for_else_b690b44735c935958564672dcfc44367
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L97
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L97
 - template: "{%for item in array%}+{%else%}-{%endfor%}"
   environment:
     array: []
   expected: "-"
   name: ForTagTest#test_for_else_b9bc6d87ae85f930db89e1a7b3be471a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L96
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L96
 - template: "{%for item in array%}yo{%endfor%}"
   environment:
     array:
@@ -939,7 +939,7 @@
     - 2
   expected: yoyo
   name: ForTagTest#test_for_f4388a5557ac215f14166adff69da690
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L16
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L16
 - template: "{%for item in array%} {{forloop.index0}} {%endfor%}"
   environment:
     array:
@@ -948,7 +948,7 @@
     - 3
   expected: " 0  1  2 "
   name: ForTagTest#test_for_helpers_833978cf93f73b4132b3044680e005e0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L80
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L80
 - template: "{%for item in array%} {{forloop.last}} {%endfor%}"
   environment:
     array:
@@ -957,7 +957,7 @@
     - 3
   expected: " false  false  true "
   name: ForTagTest#test_for_helpers_86b37f19561a7bbaf89f3227dbc69704
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L84
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L84
 - template: "{%for item in array%} {{forloop.rindex}} {%endfor%}"
   environment:
     array:
@@ -966,7 +966,7 @@
     - 3
   expected: " 3  2  1 "
   name: ForTagTest#test_for_helpers_93aa93f73340bfe33d920f7ef3938a7b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L82
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L82
 - template: "{%for item in array%} {{forloop.index}} {%endfor%}"
   environment:
     array:
@@ -975,7 +975,7 @@
     - 3
   expected: " 1  2  3 "
   name: ForTagTest#test_for_helpers_c715562ac5c96b0fdcbebb44a3c39c86
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L79
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L79
 - template: "{%for item in array%} {{forloop.index}}/{{forloop.length}} {%endfor%}"
   environment:
     array:
@@ -984,7 +984,7 @@
     - 3
   expected: " 1/3  2/3  3/3 "
   name: ForTagTest#test_for_helpers_ea322268b267ab66e8865f3ab69ae1b9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L76
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L76
 - template: "{%for item in array%} {{forloop.rindex0}} {%endfor%}"
   environment:
     array:
@@ -993,7 +993,7 @@
     - 3
   expected: " 2  1  0 "
   name: ForTagTest#test_for_helpers_f291c3626e95dfa17deb9acb42889667
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L81
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L81
 - template: "{%for item in array%} {{forloop.first}} {%endfor%}"
   environment:
     array:
@@ -1002,7 +1002,7 @@
     - 3
   expected: " true  false  false "
   name: ForTagTest#test_for_helpers_f3c32e88e5cc2ada020ee5fddd946a9b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L83
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L83
 - template: "{% for inner in outer %}{{ forloop.parentloop.index }}.{{ forloop.index
     }} {% endfor %}"
   environment:
@@ -1015,7 +1015,7 @@
       - 1
   expected: ".1 .2 "
   name: ForTagTest#test_for_parentloop_nil_when_not_present_ec8f4f00f8de56176454ddd2bf4ab9bc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L358
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L359
 - template: "{% for inner in outer %}{% for k in inner %}{{ forloop.parentloop.index
     }}.{{ forloop.index }} {% endfor %}{% endfor %}"
   environment:
@@ -1028,7 +1028,7 @@
       - 1
   expected: '1.1 1.2 1.3 2.1 2.2 2.3 '
   name: ForTagTest#test_for_parentloop_references_parent_loop_a39280022372004e37c009d7ec1eca79
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L350
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L351
 - template: "{%for item in array reversed %}{{item}}{%endfor%}"
   environment:
     array:
@@ -1037,25 +1037,25 @@
     - 3
   expected: '321'
   name: ForTagTest#test_for_reversed_d46aca36e0bb073935ad5d4746fd4355
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L38
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L38
 - template: "{%for val in string%}{{forloop.name}}-{{forloop.index}}-{{forloop.length}}-{{forloop.index0}}-{{forloop.rindex}}-{{forloop.rindex0}}-{{forloop.first}}-{{forloop.last}}-{{val}}{%endfor%}"
   environment:
     string: test string
   expected: val-string-1-1-0-1-0-true-true-test string
   name: ForTagTest#test_for_tag_string_16be4635d2c958c6d944b92c3028206f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L335
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L336
 - template: "{%for val in string%}{{val}}{%endfor%}"
   environment:
     string: test string
   expected: test string
   name: ForTagTest#test_for_tag_string_1e9ed7c109c60b5469f584cf6734ae3f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L327
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L328
 - template: "{%for val in string limit:1%}{{val}}{%endfor%}"
   environment:
     string: test string
   expected: test string
   name: ForTagTest#test_for_tag_string_2a2e1efd3aaecc479cd4854703374912
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L331
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L332
 - template: "{% for i in array.items %}{{ i }}{% break %}{% endfor %}"
   environment:
     array:
@@ -1072,7 +1072,7 @@
       - 10
   expected: '1'
   name: ForTagTest#test_for_with_break_43ec258b0fb0044613f1d259de8d21f9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L235
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L236
 - template: "{% for i in array.items %}{% break %}{{ i }}{% endfor %}"
   environment:
     array:
@@ -1089,7 +1089,7 @@
       - 10
   expected: ''
   name: ForTagTest#test_for_with_break_52beb5dd63d004e73ab74a9060926f4a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L239
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L240
 - template: "{% for i in array.items %}{% if i == 9999 %}{% break %}{% endif %}{{
     i }}{% endfor %}"
   environment:
@@ -1102,7 +1102,7 @@
       - 5
   expected: '12345'
   name: ForTagTest#test_for_with_break_80d46c478b2b4bad61e13b10712dbc33
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L263
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L264
 - template: "{% for i in array.items %}{{ i }}{% if i > 3 %}{% break %}{% endif %}{%
     endfor %}"
   environment:
@@ -1120,7 +1120,7 @@
       - 10
   expected: '1234'
   name: ForTagTest#test_for_with_break_a36c8ce2d990d187c1a36a67ea4986d8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L243
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L244
 - template: "{% for i in array.items %}{% break %}{% endfor %}"
   environment:
     array:
@@ -1137,7 +1137,7 @@
       - 10
   expected: ''
   name: ForTagTest#test_for_with_break_a896a48386e3e40f34aa79ba79073072
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L231
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L232
 - template: |-
     {% for i in (1..2) -%}
       {% for j in (1..2) -%}
@@ -1148,7 +1148,7 @@
     after
   expected: 1-1,1-2,after
   name: ForTagTest#test_for_with_break_after_nested_loop_cfa5aaebbf31b8572f00c5308c06a57b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L276
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L277
 - template: "{% for item in array %}{% for i in item %}{% if i == 1 %}{% break %}{%
     endif %}{{ i }}{% endfor %}{% endfor %}"
   environment:
@@ -1161,7 +1161,7 @@
       - 6
   expected: '3456'
   name: ForTagTest#test_for_with_break_c242d2def452c9212d6419bd5a58823f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L257
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L258
 - template: "{% for i in array.items %}{% if i > 3 %}{% continue %}{% endif %}{{ i
     }}{% endfor %}"
   environment:
@@ -1174,7 +1174,7 @@
       - 5
   expected: '123'
   name: ForTagTest#test_for_with_continue_18c1af435a29c03eb037d988e2c45577
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L296
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L297
 - template: "{% for i in array.items %}{% if i == 9999 %}{% continue %}{% endif %}{{
     i }}{% endfor %}"
   environment:
@@ -1187,7 +1187,7 @@
       - 5
   expected: '12345'
   name: ForTagTest#test_for_with_continue_1c980ec9e9e1bc5d72d3e4bf9fe5b6cf
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L319
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L320
 - template: "{% for i in array.items %}{% continue %}{% endfor %}"
   environment:
     array:
@@ -1199,7 +1199,7 @@
       - 5
   expected: ''
   name: ForTagTest#test_for_with_continue_4d3adcf7d9a5c5bbb62ea89b7dd73720
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L284
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L285
 - template: "{% for i in array.items %}{% continue %}{{ i }}{% endfor %}"
   environment:
     array:
@@ -1211,7 +1211,7 @@
       - 5
   expected: ''
   name: ForTagTest#test_for_with_continue_5aa9e0b9635d5b78946ba9a8de714775
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L292
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L293
 - template: "{% for i in array.items %}{% if i == 3 %}{% continue %}{% else %}{{ i
     }}{% endif %}{% endfor %}"
   environment:
@@ -1224,7 +1224,7 @@
       - 5
   expected: '1245'
   name: ForTagTest#test_for_with_continue_72c46d2b658f9213743efefe127ed0dc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L300
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L301
 - template: "{% for item in array %}{% for i in item %}{% if i == 1 %}{% continue
     %}{% endif %}{{ i }}{% endfor %}{% endfor %}"
   environment:
@@ -1237,7 +1237,7 @@
       - 6
   expected: '23456'
   name: ForTagTest#test_for_with_continue_73315cb2c720d98d9416ee3fa0a2a9d8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L313
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L314
 - template: "{% for i in array.items %}{{ i }}{% continue %}{% endfor %}"
   environment:
     array:
@@ -1249,30 +1249,31 @@
       - 5
   expected: '12345'
   name: ForTagTest#test_for_with_continue_eb98a81dfb08e4b208ef7b0ca2ff5578
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L288
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L289
 - template: "{%for item in (1..foobar.value) %} {{item}} {%endfor%}"
   environment:
-    foobar: !ruby/object:ThingWithValue {}
+    foobar: !ruby/object:ThingWithValue
+      context:
   expected: " 1  2  3 "
-  name: ForTagTest#test_for_with_drop_value_range_78d9f57aa4e48eb15d60d2617411c1ed
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L62
+  name: ForTagTest#test_for_with_drop_value_range_0162c44d41703fb624280a294a8d85ba
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L62
 - template: "{%for item in (1..foobar.value) %} {{item}} {%endfor%}"
   environment:
     foobar:
       value: 3
   expected: " 1  2  3 "
   name: ForTagTest#test_for_with_hash_value_range_70cfa40558255923299037637d6fffc8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L57
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L57
 - template: "{% for item in (a..3) %} {{item}} {% endfor %}"
   environment:
     a: invalid integer
   expected: " 0  1  2  3 "
   name: ForTagTest#test_for_with_range_0658022061b71560195f668370a837db
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L48
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L48
 - template: "{%for item in (1..3) %} {{item}} {%endfor%}"
   expected: " 1  2  3 "
   name: ForTagTest#test_for_with_range_fa1a40ac6226ec3708635565f5e70c98
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L42
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L42
 - template: "{%for item in array%}{{item}}{%endfor%}"
   environment:
     array:
@@ -1283,7 +1284,7 @@
     - c
   expected: abc
   name: ForTagTest#test_for_with_variable_14387c927b27a35de0e6f7dac4965b79
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L71
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L71
 - template: "{%for item in array%}{{item}}{%endfor%}"
   environment:
     array:
@@ -1293,7 +1294,7 @@
     - d
   expected: abcd
   name: ForTagTest#test_for_with_variable_18fff5c9f4fe69727ff4e2e569093daa
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L69
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L69
 - template: "{%for item in array%}{{item}}{%endfor%}"
   environment:
     array:
@@ -1304,7 +1305,7 @@
     - c
   expected: a b c
   name: ForTagTest#test_for_with_variable_83ff1c27819fee4eba4adc79ecd06735
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L70
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L70
 - template: "{%for item in array%} {{item}} {%endfor%}"
   environment:
     array:
@@ -1313,7 +1314,7 @@
     - 3
   expected: " 1  2  3 "
   name: ForTagTest#test_for_with_variable_8fbefd83753b4085d113a819765f09b2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L66
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L66
 - template: "{% for item in array %}{{item}}{% endfor %}"
   environment:
     array:
@@ -1322,7 +1323,7 @@
     - 3
   expected: '123'
   name: ForTagTest#test_for_with_variable_933796905632f0e063256475fbd2b574
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L68
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L68
 - template: "{%for item in array%}{{item}}{%endfor%}"
   environment:
     array:
@@ -1331,17 +1332,17 @@
     - 3
   expected: '123'
   name: ForTagTest#test_for_with_variable_9d7994d690440747d27e7744397deffd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L67
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L67
 - template: "{%for item in (1..foobar) %} {{item}} {%endfor%}"
   environment:
     foobar: 3
   expected: " 1  2  3 "
   name: ForTagTest#test_for_with_variable_range_b6e029885055a5e774fe3dfc2fcba0ab
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L52
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L52
 - template: "{% for a in (1..2) %}o{% for b in empty %}{% endfor %}{% endfor %}"
   expected: oo
   name: ForTagTest#test_inner_for_over_empty_input_8cb5b29b9e065ee5ff38a32040936e13
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L366
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L367
 - template: "{% for item in items %}{{item}}{% endfor %}"
   environment:
     items: !ruby/object:ForTagTest::LoaderDrop
@@ -1353,7 +1354,7 @@
       - 5
   expected: '12345'
   name: ForTagTest#test_iterate_with_each_when_no_limit_applied_002f198eecb768a0bdcb4666105b0b97
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L409
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L410
 - template: "{% for item in items offset:2 limit:2 %}{{item}}{% endfor %}"
   environment:
     items:
@@ -1364,7 +1365,7 @@
     - 5
   expected: '34'
   name: ForTagTest#test_iterate_with_load_slice_returns_same_results_as_without_82ba3ad07c150c48f406c732c5730828
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L441
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L442
 - template: "{% for item in items offset:2 limit:2 %}{{item}}{% endfor %}"
   environment:
     items: !ruby/object:ForTagTest::LoaderDrop
@@ -1376,7 +1377,7 @@
       - 5
   expected: '34'
   name: ForTagTest#test_iterate_with_load_slice_returns_same_results_as_without_8e98646da00448ffe0b9c05a03d28498
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L440
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L441
 - template: "{% for item in items offset:2 limit:2 %}{{item}}{% endfor %}"
   environment:
     items: !ruby/object:ForTagTest::LoaderDrop
@@ -1388,7 +1389,7 @@
       - 5
   expected: '34'
   name: ForTagTest#test_iterate_with_load_slice_when_limit_and_offset_applied_03f78dc1dc5d24a15d6b89e2e39329c4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L429
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L430
 - template: "{% for item in items limit:1 %}{{item}}{% endfor %}"
   environment:
     items: !ruby/object:ForTagTest::LoaderDrop
@@ -1400,7 +1401,7 @@
       - 5
   expected: '1'
   name: ForTagTest#test_iterate_with_load_slice_when_limit_applied_709d9e7e1652c2753d9919d865e9118e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L419
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L420
 - template: "{%for i in array limit:4 offset:2 %}{{ i }}{%endfor%}"
   environment:
     array:
@@ -1416,7 +1417,7 @@
     - 0
   expected: '3456'
   name: ForTagTest#test_limiting_18d248c34738c924081d22bedc978726
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L104
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L104
 - template: "{%for i in array limit:2 %}{{ i }}{%endfor%}"
   environment:
     array:
@@ -1432,7 +1433,7 @@
     - 0
   expected: '12'
   name: ForTagTest#test_limiting_64302565711c5ff467f966e048d858dd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L102
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L102
 - template: "{%for i in array limit:4 %}{{ i }}{%endfor%}"
   environment:
     array:
@@ -1448,7 +1449,7 @@
     - 0
   expected: '1234'
   name: ForTagTest#test_limiting_c47f6571268896754c20701a34e56da1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L103
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L103
 - template: "{%for i in array limit: 4 offset: 2 %}{{ i }}{%endfor%}"
   environment:
     array:
@@ -1464,7 +1465,23 @@
     - 0
   expected: '3456'
   name: ForTagTest#test_limiting_d07ce3cba944573bdddae50bce0cd277
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L105
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L105
+- template: "{%for i in array, limit: 4, offset: 2 %}{{ i }}{%endfor%}"
+  environment:
+    array:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 0
+  expected: '3456'
+  name: ForTagTest#test_limiting_d8db85373421e2c8af60ad19c98c66e3
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L106
 - template: "{%for item in array%}{%for i in item%}{{ i }}{%endfor%}{%endfor%}"
   environment:
     array:
@@ -1476,7 +1493,7 @@
       - 6
   expected: '123456'
   name: ForTagTest#test_nested_for_df66fe9326ada3e96f76ef08a8d4edab
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L146
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L147
 - template: "{%for i in array offset:7 %}{{ i }}{%endfor%}"
   environment:
     array:
@@ -1492,7 +1509,7 @@
     - 0
   expected: '890'
   name: ForTagTest#test_offset_only_80d1eaa30b6e45b8c4dc2879ae071668
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L151
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L152
 - template: |2
           {%for i in array.items limit: 3 %}{{i}}{%endfor%}
           next
@@ -1519,7 +1536,7 @@
           next
           789
   name: ForTagTest#test_pause_resume_1df9356fc6cc7e3265ba1e516d4f6b67
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L170
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L171
 - template: |2
           {%for i in array.items limit:3 %}{{i}}{%endfor%}
           next
@@ -1546,7 +1563,7 @@
           next
           7890
   name: ForTagTest#test_pause_resume_big_limit_41f864b235a3da2505de6713e8b2e35d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L208
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L209
 - template: |-
     {%for i in array.items limit:3 %}{{i}}{%endfor%}
           next
@@ -1568,7 +1585,7 @@
       - 0
   expected: "123\n      next\n      456\n      next\n      "
   name: ForTagTest#test_pause_resume_big_offset_6190b3970c711fde8eb4e133f3148a9d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L223
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L224
 - template: |2
           {%for i in array.items limit:3 %}{{i}}{%endfor%}
           next
@@ -1595,7 +1612,7 @@
           next
           7
   name: ForTagTest#test_pause_resume_limit_e8420d87580ed00a1220b2281b10e565
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L189
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L190
 - template: "{% for       item   in   items %}{{item}}{% endfor %}"
   environment:
     items:
@@ -1606,7 +1623,7 @@
     - 5
   expected: '12345'
   name: ForTagTest#test_spacing_with_variable_naming_in_for_loop_c89337d5e4e0f664136020c586b463f8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/for_tag_test.rb#L383
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/for_tag_test.rb#L384
 - template: "{% if order.items_count == 0 %}YES{% endif %}"
   environment:
     order:
@@ -1615,7 +1632,7 @@
       name: Roy
   expected: 'YES'
   name: IfElseTagTest#test_comparison_of_expressions_starting_with_and_or_or_c49cd9c95e95b5585937ab92ef53d4fa
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L57
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L57
 - template: "{% if android.name == 'Roy' %}YES{% endif %}"
   environment:
     order:
@@ -1624,7 +1641,7 @@
       name: Roy
   expected: 'YES'
   name: IfElseTagTest#test_comparison_of_expressions_starting_with_and_or_or_d012d79f0bb6fb4bc8efd43a7a98c16e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L54
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L54
 - template: "{% if a == 'and' and b == 'or' and c == 'foo and bar' and d == 'bar or
     baz' and e == 'foo' and foo and bar %} YES {% endif %}"
   environment:
@@ -1637,281 +1654,281 @@
     bar: true
   expected: " YES "
   name: IfElseTagTest#test_comparison_of_strings_containing_and_or_or_7638e83fb846e7030f7d884e48d45017
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L49
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L49
 - template: "{% if 10 < null %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_044196ad9ac750f1757fe26a28bf75de
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L122
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L122
 - template: "{% if null >= 10 %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_05441921d70423a431f36a25c43c908f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L119
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L119
 - template: "{% if 10 >= null %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_05bc3bbac717e9c7518580e664479684
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L124
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L124
 - template: "{% if 10 > null %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_09d4415f6e9af3d4f0a1afb62f182333
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L125
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L125
 - template: "{% if 10 <= null %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_41a0729e8245ce8878063f4e4c697686
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L123
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L123
 - template: "{% if null <= 10 %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_57e087a37693aeb9bc119da7396b0821
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L118
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L118
 - template: "{% if null < 10 %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_9270644fcdc3b7dd7a77436881d0789a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L117
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L117
 - template: "{% if null > 10 %} NO {% endif %}"
   expected: ''
   name: IfElseTagTest#test_comparisons_on_null_e33d1b77a969a141356cfb6a42047254
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L120
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L120
 - template: "{% if 0 != 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}"
   expected: '1'
   name: IfElseTagTest#test_else_if_16756bec0db4f08a7c5af593e123c3e2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L130
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L130
 - template: "{% if 0 != 0 %}0{% elsif 1 != 1%}1{% else %}2{% endif %}"
   expected: '2'
   name: IfElseTagTest#test_else_if_1eabf14a4e4203e998be53a880840ae3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L131
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L131
 - template: "{% if 0 == 0 %}0{% elsif 1 == 1%}1{% else %}2{% endif %}"
   expected: '0'
   name: IfElseTagTest#test_else_if_db8b1c9be1c4db93308db131136cb4b8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L129
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L129
 - template: "{% if false %}if{% elsif true %}elsif{% endif %}"
   expected: elsif
   name: IfElseTagTest#test_else_if_e5bd7bf36a4469ae2d40382ac47bd5f7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L133
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L133
 - template: "{% if foo.bar %} NO {% endif %}"
   environment:
     foo: {}
   expected: ''
   name: IfElseTagTest#test_hash_miss_generates_false_c81ed5d85a9e28487d79fd877298b7b0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L69
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L69
 - template: " {% if false %} this text should not go into the output {% endif %} "
   expected: "  "
   name: IfElseTagTest#test_if_07118c3c5795b3ef65bb061899d80433
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L9
 - template: "{% if false %} you suck {% endif %} {% if true %} you rock {% endif %}?"
   expected: "  you rock ?"
   name: IfElseTagTest#test_if_81246fa55091011e2260cdf5ea8bf37f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L12
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L12
 - template: " {% if true %} this text should go into the output {% endif %} "
   expected: "  this text should go into the output  "
   name: IfElseTagTest#test_if_9ce8b1d56f8ec09f443ea1b918bfaef4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L10
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L10
 - template: "{% if true and true %} YES {% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_if_and_58a1ffaeb5e43c675c8e378901a03ce5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L63
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L63
 - template: "{% if false and true %} YES {% endif %}"
   expected: ''
   name: IfElseTagTest#test_if_and_ef48981750cc3305d050f4fd03b1ac6b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L65
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L64
 - template: "{% if false and true %} YES {% endif %}"
   expected: ''
   name: IfElseTagTest#test_if_and_ef48981750cc3305d050f4fd03b1ac6b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L64
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L65
 - template: "{% if var %} YES {% endif %}"
   environment:
     var: true
   expected: " YES "
   name: IfElseTagTest#test_if_boolean_5d39c25342c186558922f1b1c53c3722
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L27
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L27
 - template: "{% if false %} NO {% else %} YES {% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_if_else_484b3b088138f10035e8edde97ce19bc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L21
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L21
 - template: "{% if true %} YES {% else %} NO {% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_if_else_e3c924719ac3b3bcedca25b2cde00199
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L22
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L22
 - template: '{% if "foo" %} YES {% else %} NO {% endif %}'
   expected: " YES "
   name: IfElseTagTest#test_if_else_fef367ba0366452b6ed94a65dee17c97
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L23
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L23
 - template: "{% if foo.bar %} NO {% else %} YES {% endif %}"
   environment:
     foo: {}
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_0e9e33868bd47605a53b300912eae86f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L101
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L101
 - template: "{% if var %} NO {% endif %}"
   environment:
     var:
   expected: ''
   name: IfElseTagTest#test_if_from_variable_132c8abbfbaed60705d65b8340c8f34c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L74
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L74
 - template: "{% if var %} YES {% endif %}"
   environment:
     var: []
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_14e1a1f9335eba946179682a93310f92
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L84
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L84
 - template: "{% if foo.bar %} YES {% else %} NO {% endif %}"
   environment:
     foo:
       bar: true
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_1bab99a6da9191ce69c99c3c01f77896
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L98
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L98
 - template: "{% if foo.bar %} NO {% else %} YES {% endif %}"
   environment:
     notfoo:
       bar: true
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_3ba611c165a9481ac9c5f8cbbe71e6be
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L102
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L102
 - template: "{% if foo.bar %} NO {% else %} YES {% endif %}"
   environment:
     foo:
       notbar: true
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_415ff5fccd7bbc656540fdc3002fbe95
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L100
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L100
 - template: "{% if var %} YES {% endif %}"
   environment:
     var: {}
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_4a342788658521de7661845de7dfd2ad
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L83
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L83
 - template: "{% if var %} YES {% endif %}"
   environment:
     var: true
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_4ea4f7151554b335fc452300ce61b3bc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L81
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L81
 - template: "{% if var %} YES {% else %} NO {% endif %}"
   environment:
     var: true
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_5145cc81a1ed00572fbdd3190c4b6c88
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L94
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L94
 - template: "{% if foo.bar %} NO {% endif %}"
   environment:
     foo: true
   expected: ''
   name: IfElseTagTest#test_if_from_variable_73e4523542abbd524cefb9938de15562
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L78
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L78
 - template: "{% if foo.bar %} YES {% else %} NO {% endif %}"
   environment:
     foo:
       bar: text
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_874309bbfdeb7d2b2447b9b29506bf67
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L99
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L99
 - template: '{% if "foo" %} YES {% endif %}'
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_8b51996f283088b9f80a0c342a64ad92
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L85
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L85
 - template: "{% if foo.bar %} YES {% endif %}"
   environment:
     foo:
       bar: text
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_9333a2a8e0650df2a0ea3f18091454d6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L87
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L87
 - template: "{% if foo.bar %} NO {% endif %}"
   environment:
     foo:
       bar: false
   expected: ''
   name: IfElseTagTest#test_if_from_variable_94950bad2677d16e185920bc85b9b34d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L75
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L75
 - template: "{% if foo.bar %} YES {% endif %}"
   environment:
     foo:
       bar: []
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_9f9e31861fc8de5fee54b7ce3426ea14
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L90
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L90
 - template: "{% if foo.bar %} YES {% endif %}"
   environment:
     foo:
       bar: 1
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_a7090a2bbd5584ef0bc5084aa29ce821
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L88
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L88
 - template: "{% if foo.bar %} YES {% endif %}"
   environment:
     foo:
       bar: true
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_b0b2c40aa07e907131e03c0c927d756f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L86
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L86
 - template: "{% if foo.bar %} YES {% endif %}"
   environment:
     foo:
       bar: {}
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_bb6d38dcbdf6cb3d70c6288f081ed0f6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L89
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L89
 - template: "{% if foo.bar %} NO {% else %} YES {% endif %}"
   environment:
     foo:
       bar: false
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_bc01baa36fe6421e551095df874f8b00
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L97
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L97
 - template: "{% if foo.bar %} NO {% endif %}"
   environment:
     foo:
   expected: ''
   name: IfElseTagTest#test_if_from_variable_c87d20628e9084ca144b259bc96af3b3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L77
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L77
 - template: "{% if var %} YES {% endif %}"
   environment:
     var: 1
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_cb441dcc61fc6dc1f310149deb432a58
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L82
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L82
 - template: '{% if "foo" %} YES {% else %} NO {% endif %}'
   environment:
     var: text
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_cb56f663aa7e8305e2b8ce42b42bd96b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L95
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L95
 - template: "{% if var %} YES {% endif %}"
   environment:
     var: text
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_d231bd042f49ac4b2b760bd8a2ed7ee9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L80
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L80
 - template: "{% if var %} NO {% else %} YES {% endif %}"
   environment:
     var: false
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_d41f302b0c679480ff4c513be9b562d5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L92
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L92
 - template: "{% if var %} NO {% endif %}"
   environment:
     var: false
   expected: ''
   name: IfElseTagTest#test_if_from_variable_e0545fb30663701a0845fd4a73d2698d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L73
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L73
 - template: "{% if var %} NO {% else %} YES {% endif %}"
   environment:
     var:
   expected: " YES "
   name: IfElseTagTest#test_if_from_variable_e947da47b71a7abbf988229663265dac
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L93
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L93
 - template: "{% if foo.bar %} NO {% endif %}"
   environment:
     foo: {}
   expected: ''
   name: IfElseTagTest#test_if_from_variable_eab24ddff8c6d12cc830fb157e8e0a8f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L76
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L76
 - template: "{% if a or b %} YES {% endif %}"
   environment:
     a: true
     b: true
   expected: " YES "
   name: IfElseTagTest#test_if_or_09373dacf625d118a4ef3d820153e641
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L31
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L31
 - template: "{% if a or b or c %} YES {% endif %}"
   environment:
     a: false
@@ -1919,28 +1936,28 @@
     c: true
   expected: " YES "
   name: IfElseTagTest#test_if_or_47f70b227634d5ebb0919342bc2c0540
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L36
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L36
 - template: "{% if a or b %} YES {% endif %}"
   environment:
     a: false
     b: false
   expected: ''
   name: IfElseTagTest#test_if_or_4c7b89762a04e33e01e3cc9ea1f21bf1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L34
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L34
 - template: "{% if a or b %} YES {% endif %}"
   environment:
     a: true
     b: false
   expected: " YES "
   name: IfElseTagTest#test_if_or_53a584c3821fa0bd04e9140cc3dacb4f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L32
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L32
 - template: "{% if a or b %} YES {% endif %}"
   environment:
     a: false
     b: true
   expected: " YES "
   name: IfElseTagTest#test_if_or_c963cb7f788cdedecdf58b9244fbbfb9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L33
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L33
 - template: "{% if a or b or c %} YES {% endif %}"
   environment:
     a: false
@@ -1948,44 +1965,44 @@
     c: false
   expected: ''
   name: IfElseTagTest#test_if_or_ce5a79168c34ee66790a6cad81775b19
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L37
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L37
 - template: "{% if a == true or b == false %} YES {% endif %}"
   environment:
     a: true
     b: true
   expected: " YES "
   name: IfElseTagTest#test_if_or_with_operators_5e6d811d43fa5b94f2309f60718e5b6f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L42
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L42
 - template: "{% if a == false or b == false %} YES {% endif %}"
   environment:
     a: true
     b: true
   expected: ''
   name: IfElseTagTest#test_if_or_with_operators_68eae8de3135db313c2366ebda32befd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L43
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L43
 - template: "{% if a == true or b == true %} YES {% endif %}"
   environment:
     a: true
     b: true
   expected: " YES "
   name: IfElseTagTest#test_if_or_with_operators_8c888d688f2e14d17427828dc9754ad1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L41
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L41
 - template: "{% if 'bob' contains 'f' %}yes{% else %}no{% endif %}"
   expected: 'no'
   name: IfElseTagTest#test_if_with_custom_condition_24bedcf329a2a1bab6bd3f762fc4c8e0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L149
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L149
 - template: "{% if 'bob' contains 'o' %}yes{% endif %}"
   expected: 'yes'
   name: IfElseTagTest#test_if_with_custom_condition_8d5acae7debec609830621ac5c17f35d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L148
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L148
 - template: "{% assign v = nil %}{% if v == nil %} YES {% else %} NO {% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_literal_comparisons_2db568f31194034bf2baa1460e5610c7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L17
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L17
 - template: "{% assign v = false %}{% if v %} YES {% else %} NO {% endif %}"
   expected: " NO "
   name: IfElseTagTest#test_literal_comparisons_a998ed22db85346f14467cbf99a34fea
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L16
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L16
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: false
@@ -1993,7 +2010,7 @@
     c: false
   expected: 'false'
   name: IfElseTagTest#test_multiple_conditions_0e47609b2a170c6bc8633fee3de2460e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: false
@@ -2001,7 +2018,7 @@
     c: true
   expected: 'true'
   name: IfElseTagTest#test_multiple_conditions_0f579a0658e8513e722925f8fe4ec468
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: true
@@ -2009,7 +2026,7 @@
     c: true
   expected: 'true'
   name: IfElseTagTest#test_multiple_conditions_21f647ce8f3ba64d111a17fdf0db95e8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: true
@@ -2017,7 +2034,7 @@
     c: false
   expected: 'true'
   name: IfElseTagTest#test_multiple_conditions_3af152581c7aaf1af738e3ef635776a9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: false
@@ -2025,7 +2042,7 @@
     c: true
   expected: 'false'
   name: IfElseTagTest#test_multiple_conditions_440d95ee5cce50161d369863e0f4eb88
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: true
@@ -2033,7 +2050,7 @@
     c: true
   expected: 'true'
   name: IfElseTagTest#test_multiple_conditions_80e1c10277301806d7dbd5e53464998d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: false
@@ -2041,7 +2058,7 @@
     c: false
   expected: 'false'
   name: IfElseTagTest#test_multiple_conditions_b7bb67a2ec066c49157a9db62be69538
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if a or b and c %}true{% else %}false{% endif %}"
   environment:
     a: true
@@ -2049,53 +2066,53 @@
     c: false
   expected: 'true'
   name: IfElseTagTest#test_multiple_conditions_f31ac1a703308a9e9d70b0bc4f0f1d04
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L187
 - template: "{% if false %}{% if true %} NO {% endif %}{% endif %}"
   expected: ''
   name: IfElseTagTest#test_nested_if_07d3536abef57ce5c17ccf1adee44987
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L107
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L107
 - template: "{% if true %}{% if true %} YES {% endif %}{% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_nested_if_2415b2a0ea56a8262d65851ff7fc6ccc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L109
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L109
 - template: "{% if true %}{% if false %} NO {% endif %}{% endif %}"
   expected: ''
   name: IfElseTagTest#test_nested_if_3893633d865e5a1451fcc4c9ef4ca6aa
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L108
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L108
 - template: "{% if true %}{% if true %} YES {% else %} NO {% endif %}{% else %} NO
     {% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_nested_if_59723800397dfdd01d7eaf3fb0f9177a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L111
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L111
 - template: "{% if false %}{% if true %} NO {% else %} NONO {% endif %}{% else %}
     YES {% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_nested_if_9f9b4a55e63ae9d36932fcf92eafbdee
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L113
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L113
 - template: "{% if false %}{% if false %} NO {% endif %}{% endif %}"
   expected: ''
   name: IfElseTagTest#test_nested_if_9fbdeadd1391396f187277951f48b466
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L106
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L106
 - template: "{% if true %}{% if false %} NO {% else %} YES {% endif %}{% else %} NO
     {% endif %}"
   expected: " YES "
   name: IfElseTagTest#test_nested_if_e4149d68eb7a196ba43a3d61aa4f0637
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L112
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L112
 - template: "{% if 'gnomeslab-and-or-liquid' contains 'gnomeslab-and-or-liquid' %}yes{%
     endif %}"
   expected: 'yes'
   name: IfElseTagTest#test_operators_are_ignored_unless_isolated_3638b0a2cf4f521c31affa5c804fa350
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/if_else_tag_test.rb#L158
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/if_else_tag_test.rb#L158
 - template: "{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}"
   expected: '1'
   name: IncludeTagTest#test_break_through_include_54a4a7471f423b300a9ef7ab659010cb
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L276
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L281
 - template: "{% for i in (1..3) %}{{ i }}{% include 'break' %}{{ i }}{% endfor %}"
   expected: '1'
   name: IncludeTagTest#test_break_through_include_b5bfb47c713e5515506d3dfeef275f28
   filesystem:
     break: "{% break %}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L277
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L282
 - template: "{% include template %}"
   environment:
     template: Test321
@@ -2103,7 +2120,7 @@
   name: IncludeTagTest#test_dynamically_choosen_template_06126199324c822e105bdcb59207c08b
   filesystem:
     Test321: Test321
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L167
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L167
 - template: "{% include template %}"
   environment:
     template: Test123
@@ -2111,7 +2128,7 @@
   name: IncludeTagTest#test_dynamically_choosen_template_6184168ce2f78fc84e05cf35d0587693
   filesystem:
     Test123: Test123
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L164
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L164
 - template: "{% include template for product %}"
   environment:
     template: product
@@ -2121,7 +2138,7 @@
   name: IncludeTagTest#test_dynamically_choosen_template_a3b45c3582c25090beb5def1d60d27b4
   filesystem:
     product: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L170
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L170
 - template: "{% include 'product' for products %}"
   environment:
     products:
@@ -2131,7 +2148,7 @@
   name: IncludeTagTest#test_include_tag_for_37d4b6d8cd0e9dbaec9f184213a3a2b2
   filesystem:
     product: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L93
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L93
 - template: "{% include 'product_alias' for products as product %}"
   environment:
     products:
@@ -2141,7 +2158,7 @@
   name: IncludeTagTest#test_include_tag_for_alias_df6e1e5693c513da0dc788e6f162d284
   filesystem:
     product_alias: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L80
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L80
 - template: "{% include 'product' with products[0] %}"
   environment:
     products:
@@ -2151,7 +2168,7 @@
   name: IncludeTagTest#test_include_tag_with_a8b1cb7f8d09cdcbc3f7dfa55b2f41ae
   filesystem:
     product: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L66
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L66
 - template: "{% include 'product_alias' with products[0] as product %}"
   environment:
     products:
@@ -2161,7 +2178,7 @@
   name: IncludeTagTest#test_include_tag_with_alias_ee42dc64ce14c2af4acc522a96eb59be
   filesystem:
     product_alias: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L73
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L73
 - template: "{% include 'product' %}"
   environment:
     product:
@@ -2170,19 +2187,19 @@
   name: IncludeTagTest#test_include_tag_with_default_name_25e2d575068d21d91bf8d684a2afafb2
   filesystem:
     product: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L87
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L87
 - template: "{% include 'locale_variables' echo1: 'test123' %}"
   expected: 'Locale: test123 '
   name: IncludeTagTest#test_include_tag_with_local_variables_896b9cae4c98730f08ecc34c67540559
   filesystem:
     locale_variables: 'Locale: {{echo1}} {{echo2}}'
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L100
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L100
 - template: "{% include 'locale_variables' echo1: 'test123', echo2: 'test321' %}"
   expected: 'Locale: test123 test321'
   name: IncludeTagTest#test_include_tag_with_multiple_local_variables_7186d48abd96a4d583263afb27ad5a96
   filesystem:
     locale_variables: 'Locale: {{echo1}} {{echo2}}'
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L105
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L105
 - template: "{% include 'locale_variables' echo1: echo1, echo2: more_echos.echo2 %}"
   environment:
     echo1: test123
@@ -2192,19 +2209,19 @@
   name: IncludeTagTest#test_include_tag_with_multiple_local_variables_from_context_12f03befc081be96c6e04beb35159bf5
   filesystem:
     locale_variables: 'Locale: {{echo1}} {{echo2}}'
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L111
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L111
 - template: "{% if true %}{% include 'foo_if_true' %}{% endif %}"
   expected: foo_if_true
   name: IncludeTagTest#test_include_tag_within_if_statement_8474b706e645a769914d609a92b8b4a5
   filesystem:
     foo_if_true: foo_if_true
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L194
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L194
 - template: "{% include 'assignments' %}{{ foo }}"
   expected: bar
   name: IncludeTagTest#test_included_templates_assigns_variables_8e574a89edc610cc65e273f09c7b43d0
   filesystem:
     assignments: "{% assign foo = 'bar' %}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L118
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L118
 - template: "{% assign page = 'product' %}{% include page for foo %}"
   environment:
     foo:
@@ -2213,13 +2230,13 @@
   name: IncludeTagTest#test_including_via_variable_value_219cd33584adaf835c0a8a81653121f5
   filesystem:
     product: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L262
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L267
 - template: "{% assign page = 'pick_a_source' %}{% include page %}"
   expected: from TestFileSystem
   name: IncludeTagTest#test_including_via_variable_value_2fd3f7dc97f207671d9f4aca8af09e0b
   filesystem:
     pick_a_source: from TestFileSystem
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L253
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L258
 - template: "{% assign page = 'product' %}{% include page %}"
   environment:
     product:
@@ -2228,7 +2245,7 @@
   name: IncludeTagTest#test_including_via_variable_value_ad7415ebf2d5e4ca7fa87afc71c95ce9
   filesystem:
     product: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L258
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L263
 - template: "{% include 'nested_template' %}"
   expected: header body body_detail footer
   name: IncludeTagTest#test_nested_include_tag_574478a839e05f7e10bd65762732ff10
@@ -2239,14 +2256,14 @@
       %}"
     header: header
     footer: footer
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L131
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L131
 - template: "{% include 'body' %}"
   expected: body body_detail
   name: IncludeTagTest#test_nested_include_tag_b0245dbaa03a8f46654b1c70ae7685d8
   filesystem:
     body: body {% include 'body_detail' %}
     body_detail: body_detail
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L124
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L124
 - template: "{% include 'nested_product_template' for products %}"
   environment:
     products:
@@ -2258,7 +2275,7 @@
     nested_product_template: 'Product: {{ nested_product_template.title }} {%include
       ''details''%} '
     details: details
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L144
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L144
 - template: "{% include 'nested_product_template' with product %}"
   environment:
     product:
@@ -2269,46 +2286,51 @@
     nested_product_template: 'Product: {{ nested_product_template.title }} {%include
       ''details''%} '
     details: details
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L140
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L140
+- template: "{% include 123 %}"
+  expected: 'Liquid error (line 1): Argument error in tag ''include'' - Illegal template
+    name'
+  name: IncludeTagTest#test_render_raise_argument_error_when_template_is_not_a_string_403d47cecd937950631d8e1d59cc7382
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L253
 - template: "{% include undefined_variable %}"
   expected: 'Liquid error (line 1): Argument error in tag ''include'' - Illegal template
     name'
   name: IncludeTagTest#test_render_raise_argument_error_when_template_is_undefined_4d409c2d09f126f67a94ab048a80ae31
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L245
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L245
 - template: "{% include nil %}"
   expected: 'Liquid error (line 1): Argument error in tag ''include'' - Illegal template
     name'
   name: IncludeTagTest#test_render_raise_argument_error_when_template_is_undefined_fd16a0e80355cc8e550ad10d246f6339
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/include_tag_test.rb#L248
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L248
 - template: "{%decrement port %} {{ port }}"
   environment:
     port: 10
   expected: "-1 -1"
   name: IncrementTagTest#test_dec_756bc56cdcd597ce166ac68b315c6e5b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/increment_tag_test.rb#L18
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/increment_tag_test.rb#L18
 - template: "{{port}} {%decrement port %} {%decrement port%} {{port}}"
   expected: " -1 -2 -2"
   name: IncrementTagTest#test_dec_cada125dbfb17c5ee3d695b1663c9ce4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/increment_tag_test.rb#L19
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/increment_tag_test.rb#L19
 - template: "{%increment starboard %} {%increment starboard%} {%increment starboard%}
     {%increment port %} {%increment starboard%} {%increment port %} {%decrement port%}
     {%decrement starboard %}"
   expected: 0 1 2 0 3 1 1 3
   name: IncrementTagTest#test_dec_db529b1a2cd6d73edbabba6fd86326a9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/increment_tag_test.rb#L20
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/increment_tag_test.rb#L20
 - template: "{{port}} {%increment port %} {%increment port%} {{port}}"
   expected: " 0 1 2"
   name: IncrementTagTest#test_inc_25b5fef904a089a1fab6b208d1ad4998
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/increment_tag_test.rb#L10
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/increment_tag_test.rb#L10
 - template: "{%increment port %} {{ port }}"
   expected: 0 1
   name: IncrementTagTest#test_inc_4c6b1df205f6785316fc00479d2e1108
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/increment_tag_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/increment_tag_test.rb#L9
 - template: "{%increment port %} {%increment starboard%} {%increment port %} {%increment
     port%} {%increment starboard %}"
   expected: 0 0 1 2 1
   name: IncrementTagTest#test_inc_c55d05285100402f808bef3c2bd83551
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/increment_tag_test.rb#L11
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/increment_tag_test.rb#L11
 - template: |
     {%-
       # That kind of block comment is also allowed.
@@ -2319,15 +2341,15 @@
     -%}
   expected: ''
   name: InlineCommentTest#test_inline_comment_can_be_written_on_multiple_lines_e466189f6bd0c00c00a22cc58e60a0aa
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L36
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L36
 - template: "{%#this is an inline comment%}"
   expected: ''
   name: InlineCommentTest#test_inline_comment_does_not_require_a_space_after_the_pound_sign_23e6b5098a4bca3854f77ca43b72f619
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L16
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L16
 - template: "{%- # {% echo 'hello world' %} -%}"
   expected: " -%}"
   name: InlineCommentTest#test_inline_comment_does_not_support_nested_tags_15f2b854ff5af7dae56d24bb8672f80a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L67
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L67
 - template: |
     {%- liquid
       ######################################
@@ -2336,23 +2358,23 @@
     -%}
   expected: ''
   name: InlineCommentTest#test_inline_comment_multiple_pound_signs_a289ec05d7a2dfe6e0a705756e642c20
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L48
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L48
 - template: "{%# this is an inline comment %}"
   expected: ''
   name: InlineCommentTest#test_inline_comment_returns_nothing_0df23c8d30ca830027c52fa8650b4882
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L12
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L12
 - template: "{%-# this is an inline comment -%}"
   expected: ''
   name: InlineCommentTest#test_inline_comment_returns_nothing_6bc53095fddc8a63175aeb671403d904
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L10
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L10
 - template: "{% # this is an inline comment %}"
   expected: ''
   name: InlineCommentTest#test_inline_comment_returns_nothing_9ed41adecf78ff4eeff1e23ca8883c43
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L11
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L11
 - template: "{%- # this is an inline comment -%}"
   expected: ''
   name: InlineCommentTest#test_inline_comment_returns_nothing_b6b3051049e167a7ad547cd87f74a891
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L9
 - template: |
     {%- liquid
       # This is how you'd write a block comment in a liquid tag.
@@ -2367,14 +2389,14 @@
     -%}
   expected: Hey there, how are you doing today?
   name: InlineCommentTest#test_liquid_inline_comment_returns_nothing_c5d621699b524ef03b8f515a2827bb20
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/inline_comment_test.rb#L20
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/inline_comment_test.rb#L20
 - template: |
     {%- liquid echo "a" -%}
     b
     {%- liquid echo "c" -%}
   expected: abc
   name: LiquidTagTest#test_liquid_tag_179ce7c78464d1051fa0504e1e60c9fb
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/liquid_tag_test.rb#L41
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/liquid_tag_test.rb#L41
 - template: |
     {%- liquid
       for value in array
@@ -2391,7 +2413,7 @@
     - 3
   expected: 1 2 3
   name: LiquidTagTest#test_liquid_tag_17d5b8194f1f3a9e577230efad7262c0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/liquid_tag_test.rb#L15
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/liquid_tag_test.rb#L15
 - template: |
     {%- liquid
       echo array | join: " "
@@ -2403,7 +2425,7 @@
     - 3
   expected: 1 2 3
   name: LiquidTagTest#test_liquid_tag_a1d4ae00b6019d79db304fbf427e2872
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/liquid_tag_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/liquid_tag_test.rb#L9
 - template: |
     {%- liquid
       for value in array
@@ -2424,11 +2446,11 @@
     - 3
   expected: 4 8 12 6
   name: LiquidTagTest#test_liquid_tag_d1962108260241831d53def0f8e3470b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/liquid_tag_test.rb#L26
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/liquid_tag_test.rb#L26
 - template: "{% raw %}{% liquid echo 'test' %}{% endraw %}\n"
   expected: "{% liquid echo 'test' %}\n"
   name: LiquidTagTest#test_liquid_tag_in_raw_a8bc937e089099ed8684e50d1736fbfb
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/liquid_tag_test.rb#L112
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/liquid_tag_test.rb#L112
 - template: |
     {%- if true %}
       {%- liquid
@@ -2437,13 +2459,13 @@
     {%- endif -%}
   expected: good
   name: LiquidTagTest#test_nested_liquid_tag_8b1bdb882600044b240c7f348c064329
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/liquid_tag_test.rb#L85
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/liquid_tag_test.rb#L85
 - template: " {{best_cars}} "
   environment:
     best_cars: bmw
   expected: " bmw "
   name: OutputTest#test_variable_d3448c385a35326151cbd82c0579652f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/output_test.rb#L41
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/output_test.rb#L41
 - template: " {{car.bmw}} {{car.gm}} {{car.bmw}} "
   environment:
     car:
@@ -2451,7 +2473,7 @@
       gm: bad
   expected: " good bad good "
   name: OutputTest#test_variable_traversing_d1b45a3aa7c077d1d324c93725ba0e0d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/output_test.rb#L54
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/output_test.rb#L54
 - template: "{{ site.data.menu[include.menu][include.locale] }}"
   environment:
     site:
@@ -2464,43 +2486,43 @@
       locale: bar
   expected: it works!
   name: OutputTest#test_variable_traversing_with_two_brackets_723eec374559d5b520d7687541f77ac8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/output_test.rb#L46
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/output_test.rb#L46
 - template: "{{}}"
   expected: ''
   name: ParsingQuirksTest#test_blank_variable_markup_4f8451fb7480634f1e2eb73fbcaea7b0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L122
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L122
 - template: "{% if containsallshipments == true %} YES {% endif %}"
   environment:
     containsallshipments: true
   expected: " YES "
   name: ParsingQuirksTest#test_contains_in_id_a3b934197823140598c34d9bc664c2a4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L132
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L132
 - template: "{% for i in (1...5) %}{{ i }}{% endfor %}"
   expected: '12345'
   name: ParsingQuirksTest#test_extra_dots_in_ranges_803bf572b9fac656df6962987af830e8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L117
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L117
 - template: "{% assign 123 = 'bar' %}{{ 123 }}"
   expected: '123'
   name: ParsingQuirksTest#test_invalid_variables_work_f0d1bbe1952b6ac7eddbe80a301de738
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L111
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L111
 - template: "{% assign 123foo = 'bar' %}{{ 123foo }}"
   expected: bar
   name: ParsingQuirksTest#test_invalid_variables_work_f7c994dbca51ff571fe2e847feb35366
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L110
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L110
 - template: "{{ blank['x'] }}"
   environment:
     blank:
       x: result
   expected: result
   name: ParsingQuirksTest#test_lookup_on_var_with_literal_name_cf0b27887cdb401d4f7e94985482ef6d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L128
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L128
 - template: "{{ blank.x }}"
   environment:
     blank:
       x: result
   expected: result
   name: ParsingQuirksTest#test_lookup_on_var_with_literal_name_d934beeef3cf860fedeae8bfa3a1e3ae
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L127
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L127
 - template: "{% if a == 'foo' or (b == 'bar' and c == 'baz') or false %} YES {% endif
     %}"
   environment:
@@ -2508,93 +2530,93 @@
     c: baz
   expected: " YES "
   name: ParsingQuirksTest#test_meaningless_parens_lax_77e608954f027b4271068f9060d0a2e1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L76
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L76
 - template: '{{ ''hi there'' | split:"t"" | reverse | first}}'
   expected: here
   name: ParsingQuirksTest#test_unanchored_filter_arguments_24cf008c11d10c5b06d0370c743b4aa9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L103
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L103
 - template: "{{ 'hi there' | split$$$:' ' | first }}"
   expected: hi
   name: ParsingQuirksTest#test_unanchored_filter_arguments_625d530b8646b7958dae0d1088b9d3be
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L97
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L97
 - template: "{{ 'X' | downcase) }}"
   expected: x
   name: ParsingQuirksTest#test_unanchored_filter_arguments_8be3e52ae0f344eddc24f2284f91a6ed
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L99
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L99
 - template: '{{ ''hi there'' | split:"t"" | remove:"i" | first}}'
   expected: 'hi '
   name: ParsingQuirksTest#test_unanchored_filter_arguments_f86e9f09f62a43d5d602ac9cabf722ab
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L104
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L104
 - template: "{% if false || true %} YES {% endif %}"
   expected: ''
   name: ParsingQuirksTest#test_unexpected_characters_silently_eat_logic_lax_21c90e7b3a0a38ead32a73563c157586
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L85
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L85
 - template: "{% if true && false %} YES {% endif %}"
   expected: " YES "
   name: ParsingQuirksTest#test_unexpected_characters_silently_eat_logic_lax_f8dcab00274e3dfeeda28ae1fd98cc98
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/parsing_quirks_test.rb#L83
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/parsing_quirks_test.rb#L83
 - template: "{% raw %} Foobar {{ invalid {% endraw %}"
   expected: " Foobar {{ invalid "
   name: RawTagTest#test_open_tag_in_raw_1abe5b47525fbdf931252d569272e415
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L20
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L20
 - template: "{% raw %} Foobar {{ invalid {% endraw %}{{ 1 }}"
   expected: " Foobar {{ invalid 1"
   name: RawTagTest#test_open_tag_in_raw_6f19f7d7b080ef46833e715c540d22fe
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L25
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L25
 - template: "{% raw %} Foobar {% foo {% bar %}{% endraw %}"
   expected: " Foobar {% foo {% bar %}"
   name: RawTagTest#test_open_tag_in_raw_7cd228bc978d056810666f1199becf81
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L26
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L26
 - template: "{% raw %} Foobar invalid }} {% endraw %}"
   expected: " Foobar invalid }} "
   name: RawTagTest#test_open_tag_in_raw_c0c4a49f7d420a5c25ae2ee53b8344e1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L21
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L21
 - template: "{% raw %} Foobar {% invalid {% endraw %}"
   expected: " Foobar {% invalid "
   name: RawTagTest#test_open_tag_in_raw_c9f58ce2c198bef5aed1fd4e4c869827
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L18
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L18
 - template: "{% raw %} Foobar {% {% {% {% endraw %}"
   expected: " Foobar {% {% {% "
   name: RawTagTest#test_open_tag_in_raw_d0af5da268fb66a06d596974328a5772
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L23
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L23
 - template: "{% raw %} Foobar invalid %} {% endraw %}"
   expected: " Foobar invalid %} "
   name: RawTagTest#test_open_tag_in_raw_d32aa3b1c9c5ea0644b0c1d48fa90003
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L19
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L19
 - template: "{% raw %} Foobar {% invalid {% {% endraw {% endraw %}"
   expected: " Foobar {% invalid {% {% endraw "
   name: RawTagTest#test_open_tag_in_raw_e2a6fdfeb00c4865d8d25615c2a0b1f7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L22
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L22
 - template: "{% raw %} test {% raw %} {% {% endraw %}endraw %}"
   expected: " test {% raw %} {% endraw %}"
   name: RawTagTest#test_open_tag_in_raw_f0a181e860b9bede79b37872f124aae3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L24
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L24
 - template: "{% raw %}{{ test }}{% endraw %}"
   expected: "{{ test }}"
   name: RawTagTest#test_output_in_raw_c39682e5f90309714ce22dd5440add6d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L14
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L14
 - template: "{% raw %}{% comment %} test {% endcomment %}{% endraw %}"
   expected: "{% comment %} test {% endcomment %}"
   name: RawTagTest#test_tag_in_raw_fece745d8ccca35efde8c1a1bafab254
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/raw_tag_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/raw_tag_test.rb#L9
 - template: '{% for i in (1..3) %}{{ i }}{% render "break" %}{{ i }}{% endfor %}'
   expected: '112233'
   name: RenderTagTest#test_break_through_render_5a9b7713674d93f7adc3221446042fd9
   filesystem:
     break: "{% break %}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L106
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L106
 - template: "{% for i in (1..3) %}{{ i }}{% break %}{{ i }}{% endfor %}"
   expected: '1'
   name: RenderTagTest#test_break_through_render_8631e112df0679ec3d4425f7df1c58f7
   filesystem:
     break: "{% break %}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L105
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L105
 - template: '{% decrement %}{% decrement %}{% render "decr" %}'
   expected: "-1-2-1"
   name: RenderTagTest#test_decrement_is_isolated_between_renders_44534aba1ec247957428ba7fa30229e6
   filesystem:
     decr: "{% decrement %}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L115
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L115
 - template: '{% render "nested_render_with_sibling_include" %}'
   expected: 'Liquid error (test_include line 1): include usage is not allowed in this
     contextLiquid error (nested_render_with_sibling_include line 1): include usage
@@ -2605,7 +2627,7 @@
     nested_render_with_sibling_include: '{% render "test_include" %}{% include "foo"
       %}'
     test_include: '{% include "foo" %}'
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L132
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L132
 - template: '{% render "test_include" %}'
   expected: 'Liquid error (test_include line 1): include usage is not allowed in this
     context'
@@ -2613,51 +2635,51 @@
   filesystem:
     foo: bar
     test_include: '{% include "foo" %}'
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L120
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L120
 - template: '{% increment %}{% increment %}{% render "incr" %}'
   expected: '010'
   name: RenderTagTest#test_increment_is_isolated_between_renders_fb1e8f313d4ca6dbb94954e90abed070
   filesystem:
     incr: "{% increment %}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L110
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L110
 - template: "{% render 'one' %}"
   expected: one two
   name: RenderTagTest#test_nested_render_tag_9fee84598dd5fac60ac56c4b31b40480
   filesystem:
     one: one {% render 'two' %}
     two: two
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L50
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L50
 - template: '{% render "snippet", price: 123 %}'
   expected: '123'
   name: RenderTagTest#test_render_accepts_literals_as_arguments_d84f9afcb59c5685cd8603841cd2cd4e
   filesystem:
     snippet: "{{ price }}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L25
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L25
 - template: '{% render "snippet", one: 1, two: 2 %}'
   expected: 1 2
   name: RenderTagTest#test_render_accepts_multiple_named_arguments_ffe876aa3d6968bf9fcb596bb0b20d1a
   filesystem:
     snippet: "{{ one }} {{ two }}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L30
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L30
 - template: '{% assign outer_variable = "should not be visible" %}{% render "snippet"
     %}'
   expected: ''
   name: RenderTagTest#test_render_does_not_inherit_parent_scope_variables_3fd58cb2b6ff4d43517d0113bbb198da
   filesystem:
     snippet: "{{ outer_variable }}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L35
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L35
 - template: "{% assign snippet = 'should not be visible' %}{% render 'snippet' %}"
   expected: ''
   name: RenderTagTest#test_render_does_not_inherit_variable_with_same_name_as_snippet_6f7e389a39f39f321e0df61a93a029d3
   filesystem:
     snippet: "{{ snippet }}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L40
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L40
 - template: "{% render 'snippet' %}{{ inner }}"
   expected: ''
   name: RenderTagTest#test_render_does_not_mutate_parent_scope_a47b31955e1768fb6b3c0cdb80d027ee
   filesystem:
     snippet: "{% assign inner = 1 %}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L45
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L45
 - template: '{% render "product", inner_product: outer_product %}'
   environment:
     outer_product:
@@ -2666,7 +2688,7 @@
   name: RenderTagTest#test_render_passes_named_arguments_into_inner_scope_4bebeeca586ef8960880bf81bd710368
   filesystem:
     product: "{{ inner_product.title }}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L19
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L19
 - template: "{% render 'product_alias' for products as product %}"
   environment:
     products:
@@ -2677,7 +2699,7 @@
   filesystem:
     product: 'Product: {{ product.title }} '
     product_alias: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L166
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L166
 - template: "{% render 'product' for products %}"
   environment:
     products:
@@ -2688,15 +2710,16 @@
   filesystem:
     product: 'Product: {{ product.title }} '
     product_alias: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L176
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L176
 - template: "{% render 'loop' for loop as value %}"
   environment:
-    loop: !ruby/object:TestEnumerable {}
+    loop: !ruby/object:TestEnumerable
+      context:
   expected: '123'
-  name: RenderTagTest#test_render_tag_for_drop_88f92ad9322662c59e72432e521b2e13
+  name: RenderTagTest#test_render_tag_for_drop_587f4879c9123537ddb1ca10ff269454
   filesystem:
     loop: "{{ value.foo }}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L195
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L195
 - template: "{% render 'product' for products %}"
   environment:
     products:
@@ -2707,13 +2730,13 @@
   filesystem:
     product: 'Product: {{ product.title }} {% if forloop.first %}first{% endif %}
       {% if forloop.last %}last{% endif %} index:{{ forloop.index }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L186
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L186
 - template: '{% render "pick_a_source" %}'
   expected: from register file system
   name: RenderTagTest#test_render_tag_looks_for_file_system_in_registers_first_2db1027edc56d805c4c77676af1d55e3
   filesystem:
     pick_a_source: from register file system
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L14
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L14
 - template: "{% render 'product' with products[0] %}"
   environment:
     products:
@@ -2724,7 +2747,7 @@
   filesystem:
     product: 'Product: {{ product.title }} '
     product_alias: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L146
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L146
 - template: "{% render 'product_alias' with products[0] as product %}"
   environment:
     products:
@@ -2735,274 +2758,279 @@
   filesystem:
     product: 'Product: {{ product.title }} '
     product_alias: 'Product: {{ product.title }} '
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L156
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L156
 - template: "{% render 'loop' with loop as value %}"
   environment:
-    loop: !ruby/object:TestEnumerable {}
+    loop: !ruby/object:TestEnumerable
+      context:
   expected: TestEnumerable
-  name: RenderTagTest#test_render_tag_with_drop_cca9f1b3603d95e6ac5a80cf4e1b9d1f
+  name: RenderTagTest#test_render_tag_with_drop_16e751507470a3feec825e62d35c36e7
   filesystem:
     loop: "{{ value }}"
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L203
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L203
 - template: '{% if true %}{% render "snippet" %}{% endif %}'
   expected: my message
   name: RenderTagTest#test_render_tag_within_if_statement_752a1c6a223f802967e8cfec851d08a2
   filesystem:
     snippet: my message
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L99
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L99
 - template: '{% render "source" %}'
   expected: rendered content
   name: RenderTagTest#test_render_with_no_arguments_fc4143902fbdaf1423578e4500cfd5be
   filesystem:
     source: rendered content
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/render_tag_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L9
 - template: "{{ 0 | abs }}"
   expected: '0'
   name: StandardFiltersTest#test_abs_116fd48a45937bfa6905521a02c5ba12
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L652
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L652
 - template: "{{ 17 | abs }}"
   expected: '17'
   name: StandardFiltersTest#test_abs_118a85f7f020fc6a0f0fec2614d916e5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L648
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L648
 - template: "{{ '-17' | abs }}"
   expected: '17'
   name: StandardFiltersTest#test_abs_158b143beda0349da094844ab5d6f23b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L651
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L651
 - template: "{{ '0' | abs }}"
   expected: '0'
   name: StandardFiltersTest#test_abs_20ffbd4dc3ebbcebc0a8c6609d7956b6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L653
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L653
 - template: "{{ -17 | abs }}"
   expected: '17'
   name: StandardFiltersTest#test_abs_5391ad41bde9e9db487bdeb6995d668f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L649
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L649
 - template: "{{ '17.42' | abs }}"
   expected: '17.42'
   name: StandardFiltersTest#test_abs_7885dde8fcddbe0d92533e017723b8ee
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L656
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L656
 - template: "{{ -17.42 | abs }}"
   expected: '17.42'
   name: StandardFiltersTest#test_abs_975f23e4cea779f8325e1eca0441b1ec
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L655
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L655
 - template: "{{ '-17.42' | abs }}"
   expected: '17.42'
   name: StandardFiltersTest#test_abs_984c13fc94fabf45eeebf62509c0c8a5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L657
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L657
 - template: "{{ 17.42 | abs }}"
   expected: '17.42'
   name: StandardFiltersTest#test_abs_cdef995153d7ac572cbb8c77bd94599d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L654
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L654
 - template: "{{ '17' | abs }}"
   expected: '17'
   name: StandardFiltersTest#test_abs_e5e75ff67900ac969a3cbb2646fbe3b3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L650
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L650
 - template: "{{ a | append: b}}"
   environment:
     a: bc
     b: d
   expected: bcd
   name: StandardFiltersTest#test_append_4109adeaba48c12f6497c2ca799a3498
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L751
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L751
 - template: "{{ a | append: 'd'}}"
   environment:
     a: bc
     b: d
   expected: bcd
   name: StandardFiltersTest#test_append_792913fb8817e420fa3793a3f90bb491
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L750
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L750
 - template: "{{ width | at_least:5 }}"
   environment:
     width: !ruby/object:NumberLikeThing
       amount: 6
   expected: '6'
   name: StandardFiltersTest#test_at_least_0fda1f4c4439307312a8fd327e58b685
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L743
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L743
 - template: "{{ width | at_least:5 }}"
   environment:
     width: !ruby/object:NumberLikeThing
       amount: 4
   expected: '5'
   name: StandardFiltersTest#test_at_least_35ba83c7106df9d8804fba05fea300f2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L744
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L744
 - template: "{{ 4.5 | at_least:5 }}"
   expected: '5'
   name: StandardFiltersTest#test_at_least_3c7e252084de0f160007038be560e809
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L742
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L742
 - template: "{{ 5 | at_least:6 }}"
   expected: '6'
   name: StandardFiltersTest#test_at_least_b8de53972cced747d3668b2b48dce4c5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L740
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L740
 - template: "{{ 5 | at_least: width }}"
   environment:
     width: !ruby/object:NumberLikeThing
       amount: 6
   expected: '6'
   name: StandardFiltersTest#test_at_least_c5d1a69d1ba36b4d6819804b7aefd7b5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L745
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L745
 - template: "{{ 5 | at_least:4 }}"
   expected: '5'
   name: StandardFiltersTest#test_at_least_da30866445bd80fd29aadc76e5d1e681
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L738
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L738
 - template: "{{ 5 | at_least:5 }}"
   expected: '5'
   name: StandardFiltersTest#test_at_least_dadadb609e8e99199f9666e89e80261c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L739
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L739
 - template: "{{ 5 | at_most:5 }}"
   expected: '5'
   name: StandardFiltersTest#test_at_most_17f636454614733cf442abcb19893bd1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L728
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L728
 - template: "{{ width | at_most:5 }}"
   environment:
     width: !ruby/object:NumberLikeThing
       amount: 6
   expected: '5'
   name: StandardFiltersTest#test_at_most_2120c5ce35e3bcc52622a0b1d5eaa40e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L732
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L732
 - template: "{{ 5 | at_most:4 }}"
   expected: '4'
   name: StandardFiltersTest#test_at_most_6f4edd63cc1bcc5958d9de229d052b3f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L727
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L727
 - template: "{{ 5 | at_most:6 }}"
   expected: '5'
   name: StandardFiltersTest#test_at_most_723858101ce2dca9ad2af27eabc969b1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L729
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L729
 - template: "{{ 5 | at_most: width }}"
   environment:
     width: !ruby/object:NumberLikeThing
       amount: 4
   expected: '4'
   name: StandardFiltersTest#test_at_most_8e9c315df355db1b246d12cae37c6a6a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L734
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L734
 - template: "{{ 4.5 | at_most:5 }}"
   expected: '4.5'
   name: StandardFiltersTest#test_at_most_a02cc6af152a4491c733e4584b255dba
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L731
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L731
 - template: "{{ width | at_most:5 }}"
   environment:
     width: !ruby/object:NumberLikeThing
       amount: 4
   expected: '4'
   name: StandardFiltersTest#test_at_most_c923d973ed6fdadf0204f51d746437ba
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L733
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L733
 - template: "{{ 'a' | to_number }}"
   expected: a
   name: StandardFiltersTest#test_cannot_access_private_methods_1d18faefb34c127c2237fe2cef56a32c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L795
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L795
 - template: "{{ '4.3' | ceil }}"
   expected: '5'
   name: StandardFiltersTest#test_ceil_2a6315b8670f13361ef7157ac0e6588e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L708
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L708
 - template: "{{ input | ceil }}"
   environment:
     input: 4.6
   expected: '5'
   name: StandardFiltersTest#test_ceil_2b5e9d30e91c4476a96eed91c6840e61
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L707
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L707
 - template: "{{ price | ceil }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 4.6
   expected: '5'
   name: StandardFiltersTest#test_ceil_4b157a7fd75b4286548fdd4e5be9f947
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L713
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L713
 - template: "{{ '' | date: '%D' }}"
   expected: ''
   name: StandardFiltersTest#test_date_raises_nothing_6f4de0aaa6bce2bf611597224603b82b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L799
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L799
 - template: "{{ 'abc' | date: '%D' }}"
   expected: abc
   name: StandardFiltersTest#test_date_raises_nothing_feccd4c2fcb75f94cda874b5e9196f09
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L800
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L800
 - template: "{{ drop | default: 'bar' }}"
   environment:
     drop: !ruby/object:BooleanDrop
+      context:
       value: true
   expected: Yay
-  name: StandardFiltersTest#test_default_c3d084cc6333dcc1be81dabc3831ff1f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L779
+  name: StandardFiltersTest#test_default_0d6bb3846d0a4d18e12182c30b07ee83
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L779
 - template: "{{ false | default: 'bar' }}"
   expected: bar
   name: StandardFiltersTest#test_default_d713feccbc53c74468bf72d6a76595a9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L777
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L777
 - template: "{{ drop | default: 'bar' }}"
   environment:
     drop: !ruby/object:BooleanDrop
+      context:
       value: false
   expected: bar
-  name: StandardFiltersTest#test_default_ed9bbd975780512e8620ffd2c1296026
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L778
+  name: StandardFiltersTest#test_default_f3e16bdd214f9a9cdb259a1046091403
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L778
 - template: "{{ false | default: 'bar', allow_false: true }}"
   expected: 'false'
   name: StandardFiltersTest#test_default_handle_false_177cfbb3f8680afe3b41309f25f671cf
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L789
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L789
 - template: "{{ drop | default: 'bar', allow_false: true }}"
   environment:
     drop: !ruby/object:BooleanDrop
-      value: true
-  expected: Yay
-  name: StandardFiltersTest#test_default_handle_false_5d69cfd34b05748c3bae2ad95e4eec34
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L791
-- template: "{{ drop | default: 'bar', allow_false: true }}"
-  environment:
-    drop: !ruby/object:BooleanDrop
+      context:
       value: false
   expected: Nay
-  name: StandardFiltersTest#test_default_handle_false_5e712bb4eabe9456086e98908b7d7870
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L790
+  name: StandardFiltersTest#test_default_handle_false_6367485e83c12978501834b0f67d61bb
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L790
+- template: "{{ drop | default: 'bar', allow_false: true }}"
+  environment:
+    drop: !ruby/object:BooleanDrop
+      context:
+      value: true
+  expected: Yay
+  name: StandardFiltersTest#test_default_handle_false_af3b6d774d1c445ee0f7c30a9116462e
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L791
 - template: "{{ 2.0 | divided_by:4 }}"
   expected: '0.5'
   name: StandardFiltersTest#test_divided_by_593b7b6f3d8a03e04c256db0c4c06758
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L677
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L677
 - template: "{{ 14 | divided_by:3 }}"
   expected: '4'
   name: StandardFiltersTest#test_divided_by_6ec56ac5c6d43b1becb51cf077b2b41c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L672
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L672
 - template: "{{ 15 | divided_by:3 }}"
   expected: '5'
   name: StandardFiltersTest#test_divided_by_a50aa7df9c4f5cb6fcc176dc46479a8a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L674
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L674
 - template: "{{ price | divided_by:2 }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 10
   expected: '5'
   name: StandardFiltersTest#test_divided_by_f079e85e4ed2102d251fba7847d033d8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L682
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L682
 - template: "{{ 12 | divided_by:3 }}"
   expected: '4'
   name: StandardFiltersTest#test_divided_by_fdc759d1509af62b6bfae85502453810
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L671
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L671
 - template: "{{ foo | last }}"
   environment:
     foo:
     - !ruby/object:ThingWithToLiquid {}
   expected: foobar
   name: StandardFiltersTest#test_first_and_last_call_to_liquid_4dcd6134693b973938c2c627fcb57fc6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L531
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L531
 - template: "{{ foo | first }}"
   environment:
     foo:
     - !ruby/object:ThingWithToLiquid {}
   expected: foobar
   name: StandardFiltersTest#test_first_and_last_call_to_liquid_7013f4c30edde6d9383626798061b7f1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L530
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L530
 - template: "{{ input | floor }}"
   environment:
     input: 4.6
   expected: '4'
   name: StandardFiltersTest#test_floor_1ed3d3723dea998fe95583e3a7419251
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L717
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L717
 - template: "{{ '4.3' | floor }}"
   expected: '4'
   name: StandardFiltersTest#test_floor_8025b85ddd41116aba93e67afa744eec
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L718
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L718
 - template: "{{ price | floor }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 5.4
   expected: '5'
   name: StandardFiltersTest#test_floor_a05307853b1f0a98e609bec6f7dcff82
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L723
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L723
 - template: "{% assign key = 'foo' %}{{ thing | map: key | map: 'bar' }}"
   environment:
     thing:
@@ -3010,19 +3038,19 @@
         bar: 42
   expected: '42'
   name: StandardFiltersTest#test_legacy_map_on_hashes_with_dynamic_key_9e9be1c8143a9a5769a8118ddb773452
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L468
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L468
 - template: "{{ source | lstrip }}"
   environment:
     source: " \tab c  \n \t"
   expected: "ab c  \n \t"
   name: StandardFiltersTest#test_lstrip_0690b5d605dfa4ff4fa763dfc3f71c5f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L615
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L615
 - template: "{{ source | lstrip }}"
   environment:
     source: " ab c  "
   expected: 'ab c  '
   name: StandardFiltersTest#test_lstrip_0c496c746b86f6fee37c171c91023a58
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L614
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L614
 - template: "{{ ary | map:'foo' | map:'bar' }}"
   environment:
     ary:
@@ -3034,11 +3062,11 @@
         bar: c
   expected: abc
   name: StandardFiltersTest#test_map_62ca03b8adb9713c8a8fd56442685f5a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L436
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L436
 - template: "{:test=>1234}"
   expected: "{:test=>1234}"
   name: StandardFiltersTest#test_map_calls_context=_6396270ae7ffd57d22bc5f2dbba9ec7b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L457
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L457
 - template: '{{ foo | map: "whatever" }}'
   environment:
     foo:
@@ -3046,15 +3074,15 @@
       foo: 0
   expected: 'woot: 1'
   name: StandardFiltersTest#test_map_calls_to_liquid_67b664577bd3d9245a45ec7aa4247215
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L447
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L447
 - template: '{{ "foo" | map: "__id__" }}'
   expected: ''
   name: StandardFiltersTest#test_map_doesnt_call_arbitrary_stuff_43ed3e660a13e755aa2b613acb9448d3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L441
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L441
 - template: '{{ "foo" | map: "inspect" }}'
   expected: ''
   name: StandardFiltersTest#test_map_doesnt_call_arbitrary_stuff_594cec5332595ff990270a8bf2cf12dc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L442
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L442
 - template: '{{ thing | map: "foo" | map: "bar" }}'
   environment:
     thing:
@@ -3063,36 +3091,36 @@
       - bar: 17
   expected: '4217'
   name: StandardFiltersTest#test_map_on_hashes_70049ad51995ce3768b2f9a384918557
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L461
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L461
 - template: "{{ '4.3' | minus:'2' }}"
   expected: '2.3'
   name: StandardFiltersTest#test_minus_6380107d6b0c96f273c1949c1ff05b88
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L642
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L642
 - template: "{{ price | minus:'2' }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 7
   expected: '5'
   name: StandardFiltersTest#test_minus_7e54f7f401b56b43457ba10223af8177
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L644
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L644
 - template: "{{ input | minus:operand }}"
   environment:
     input: 5
     operand: 1
   expected: '4'
   name: StandardFiltersTest#test_minus_d7a30a6d820bfdb82d31b05f74594a47
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L641
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L641
 - template: "{{ 3 | modulo:2 }}"
   expected: '1'
   name: StandardFiltersTest#test_modulo_0f875f2a9873cef564632a7ec6bb6c58
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L686
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L686
 - template: "{{ price | modulo:2 }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 3
   expected: '1'
   name: StandardFiltersTest#test_modulo_9d72c8bd4c80ce492667400c42f88c9c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L691
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L691
 - template: "{{ source | newline_to_br }}"
   environment:
     source: |-
@@ -3104,7 +3132,7 @@
     b<br />
     c
   name: StandardFiltersTest#test_newlines_to_br_20527e4e1d4b6c5448062945e8d15dcf
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L629
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L629
 - template: "{{ source | newline_to_br }}"
   environment:
     source: "a\r\nb\nc"
@@ -3113,124 +3141,125 @@
     b<br />
     c
   name: StandardFiltersTest#test_newlines_to_br_b48d4b0547b7e8e4e54400457a55d81b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L630
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L630
 - template: "{{ 'foo|bar' | remove: '|' }}"
   expected: foobar
   name: StandardFiltersTest#test_pipes_in_string_arguments_d5e5a2ed7a2ff333a39a1d43a7fa0337
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L605
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L605
 - template: "{{ '1' | plus:'1.0' }}"
   expected: '2.0'
   name: StandardFiltersTest#test_plus_4bb63dd84f1b702fd9983963aaa2e7ce
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L635
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L635
 - template: "{{ 1 | plus:1 }}"
   expected: '2'
   name: StandardFiltersTest#test_plus_6c4762c3915ffc47835546c71a014594
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L634
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L634
 - template: "{{ price | plus:'2' }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 3
   expected: '5'
   name: StandardFiltersTest#test_plus_9099671b1c00b0207c245e19c3028ed7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L637
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L637
 - template: "{{ a | prepend: 'a'}}"
   environment:
     a: bc
     b: a
   expected: abc
   name: StandardFiltersTest#test_prepend_741d03f3c390be88c4eed40ea88f2259
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L766
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L766
 - template: "{{ a | prepend: b}}"
   environment:
     a: bc
     b: a
   expected: abc
   name: StandardFiltersTest#test_prepend_98b72fdb2ec90d164ca88f74510a8dcf
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L767
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L767
 - template: "{{ '1 1 1 1' | remove: 1 }}"
   expected: "   "
   name: StandardFiltersTest#test_remove_a661d46129cb7b62ead3e1cd5db006dc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L595
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L595
 - template: "{{ '1 1 1 1' | remove_first: 1 }}"
   expected: " 1 1 1"
   name: StandardFiltersTest#test_remove_ad37e1b854431f8821df3c34b1f31008
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L598
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L598
 - template: "{{ '1 1 1 1' | remove_last: 1 }}"
   expected: '1 1 1 '
   name: StandardFiltersTest#test_remove_e9b7e5b21ef9515bbe6016e8028138ba
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L601
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L601
 - template: "{{ '1 1 1 1' | replace: '1', 2 }}"
   expected: 2 2 2 2
   name: StandardFiltersTest#test_replace_38ec36f94f4036811ffdf74ed87df408
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L580
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L580
 - template: "{{ '1 1 1 1' | replace_last: '1', 2 }}"
   expected: 1 1 1 2
   name: StandardFiltersTest#test_replace_8cf0e0fd1f21ea9b5eacc7798b1cdb6c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L590
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L590
 - template: "{{ '1 1 1 1' | replace_first: '1', 2 }}"
   expected: 2 1 1 1
   name: StandardFiltersTest#test_replace_f5bd5ed520154c1c31c90a47d9db4f6a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L585
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L585
 - template: "{{ '4.3' | round }}"
   expected: '4'
   name: StandardFiltersTest#test_round_a89d7964e17822f6edfa188d965f98a2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L696
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L696
 - template: "{{ input | round: 2 }}"
   environment:
     input: 4.5612
   expected: '4.56'
   name: StandardFiltersTest#test_round_b2b81e326e519193d09e38143090157b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L697
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L697
 - template: "{{ price | round }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 4.6
   expected: '5'
   name: StandardFiltersTest#test_round_b6db09c92c54e6b884bf702be653b37a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L702
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L702
 - template: "{{ price | round }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 4.3
   expected: '4'
   name: StandardFiltersTest#test_round_bfb9d5ec0da02e6dd0ea9504a9da6362
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L703
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L703
 - template: "{{ input | round }}"
   environment:
     input: 4.6
   expected: '5'
   name: StandardFiltersTest#test_round_e982d9f116fa84558ddc57df3f0e7bae
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L695
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L695
 - template: "{{ source | rstrip }}"
   environment:
     source: " \tab c  \n \t"
   expected: " \tab c"
   name: StandardFiltersTest#test_rstrip_d9a26a12ee6f055e28dc4ad2143e2336
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L620
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L620
 - template: "{{ source | rstrip }}"
   environment:
     source: " ab c  "
   expected: " ab c"
   name: StandardFiltersTest#test_rstrip_da246a00fadff83ad024dd0e16a60d4c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L619
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L619
 - template: '{{ foo | sort: "bar" | map: "foo" }}'
   environment:
-    foo: !ruby/object:TestEnumerable {}
+    foo: !ruby/object:TestEnumerable
+      context:
   expected: '213'
-  name: StandardFiltersTest#test_sort_works_on_enumerables_69f0f892d30245e90f83e73034cd8ac9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L526
+  name: StandardFiltersTest#test_sort_works_on_enumerables_9867a0e170a5a39212a15bd573c75733
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L526
 - template: "{{ source | strip }}"
   environment:
     source: " ab c  "
   expected: ab c
   name: StandardFiltersTest#test_strip_28ec8d9af544a08be9f8535421edf98a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L609
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L609
 - template: "{{ source | strip }}"
   environment:
     source: " \tab c  \n \t"
   expected: ab c
   name: StandardFiltersTest#test_strip_4fe0d1e0973009cd44e2b2e2859f2e7f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L610
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L610
 - template: "{{ source | strip_newlines }}"
   environment:
     source: |-
@@ -3239,59 +3268,59 @@
       c
   expected: abc
   name: StandardFiltersTest#test_strip_newlines_3ee5075971a2e3125f1d19c5a5a88dd6
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L624
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L624
 - template: "{{ source | strip_newlines }}"
   environment:
     source: "a\r\nb\nc"
   expected: abc
   name: StandardFiltersTest#test_strip_newlines_9860fe9f66483bae9741ab5f02df11d1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L625
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L625
 - template: "{{ price | times:2 }}"
   environment:
     price: !ruby/object:NumberLikeThing
       amount: 2
   expected: '4'
   name: StandardFiltersTest#test_times_1038ca2b971a55313b1c8f3a250f0829
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L667
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L667
 - template: "{{ 3 | times:4 }}"
   expected: '12'
   name: StandardFiltersTest#test_times_843b6a29e6cbcd9c1b837a743f1981f7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L661
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L661
 - template: "{{ 0.0725 | times:100 }}"
   expected: '7.25'
   name: StandardFiltersTest#test_times_8ca0ad6ec847fdf3a1506a5e228ef3b7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L664
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L664
 - template: "{{ 'foo' | times:4 }}"
   expected: '0'
   name: StandardFiltersTest#test_times_a5f2e2e3c90de6e0ec5a309cd27dcf7f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L662
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L662
 - template: "{{ '2.1' | times:3 | replace: '.','-' | plus:0}}"
   expected: '6'
   name: StandardFiltersTest#test_times_c7dcd6db9909b533a26ff9394e914c30
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L663
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L663
 - template: '{{ "-0.0725" | times: -100 }}'
   expected: '7.25'
   name: StandardFiltersTest#test_times_cecd1d8f38e0d81e73ac7ac11eb596bd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L666
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L666
 - template: '{{ "-0.0725" | times:100 }}'
   expected: "-7.25"
   name: StandardFiltersTest#test_times_d1288329fa3940dad857fb96882da3bb
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L665
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L665
 - template: "{{ foo | truncate: 5 }}"
   environment:
     foo: !ruby/object:TestThing
       foo: 0
   expected: wo...
   name: StandardFiltersTest#test_truncate_calls_to_liquid_134362341bb7641d5702e5d16208bd86
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/standard_filter_test.rb#L535
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/standard_filter_test.rb#L535
 - template: '{% assign a = "variable"%}{{a}}'
   expected: variable
   name: StandardTagTest#test_assign_545a289cc6b5eb98726fa76c7a67891f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L221
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L223
 - template: '{% assign a = ""%}{{a}}'
   expected: ''
   name: StandardTagTest#test_assign_an_empty_string_aba507beb47764aa57dbf520e671f181
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L230
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L232
 - template: "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle
     = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{%
     else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}"
@@ -3300,7 +3329,7 @@
       handle: z
   expected: womenswear
   name: StandardTagTest#test_assign_from_case_0e4229f7a5b747242976ae01cbaf2df2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L182
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L184
 - template: "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle
     = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{%
     else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}"
@@ -3309,7 +3338,7 @@
       handle: menswear-t-shirts
   expected: menswear
   name: StandardTagTest#test_assign_from_case_6085dc77c7f050431c93f25f3fb5c669
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L179
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L181
 - template: "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle
     = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{%
     else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}"
@@ -3318,7 +3347,7 @@
       handle: menswear-jackets
   expected: menswear
   name: StandardTagTest#test_assign_from_case_74c7cf8e4703cb4f343f99d4d3ec39b8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L178
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L180
 - template: "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle
     = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{%
     else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}"
@@ -3327,7 +3356,7 @@
       handle: x
   expected: womenswear
   name: StandardTagTest#test_assign_from_case_8b0f33f572c52f27f45d89d02740e4f3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L180
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L182
 - template: "{% case collection.handle %}{% when 'menswear-jackets' %}{% assign ptitle
     = 'menswear' %}{% when 'menswear-t-shirts' %}{% assign ptitle = 'menswear' %}{%
     else %}{% assign ptitle = 'womenswear' %}{% endcase %}{{ ptitle }}"
@@ -3336,17 +3365,17 @@
       handle: "y"
   expected: womenswear
   name: StandardTagTest#test_assign_from_case_cb9de8bfe47656091421b74f1cec2df3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L181
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L183
 - template: '{%for i in (1..2) %}{% assign a = "variable"%}{% endfor %}{{a}}'
   expected: variable
   name: StandardTagTest#test_assign_is_global_69c713cd6f831bf59fb4c9464f305211
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L234
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L236
 - template: var2:{{var2}} {%assign var2 = var%} var2:{{var2}}
   environment:
     var: content
   expected: 'var2:  var2:content'
   name: StandardTagTest#test_assign_unassigned_fbe195f89ae4458eb31f91d33c4e901c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L226
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L228
 - template: '{%assign var2 = var["a:b c"].paged %}var2: {{var2}}'
   environment:
     var:
@@ -3354,67 +3383,67 @@
         paged: '1'
   expected: 'var2: 1'
   name: StandardTagTest#test_assign_with_colon_and_spaces_3db5f5922e7fd34923c8124c289d54ca
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L60
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L62
 - template: "{{ var2 }}{% capture var2 %}{{ var }} foo {% endcapture %}{{ var2 }}{{
     var2 }}"
   environment:
     var: content
   expected: 'content foo content foo '
   name: StandardTagTest#test_capture_7257f7b95eb5671e79f1cd77c809c27f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L65
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L67
 - template: "{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase
     %}"
   environment:
     condition: 1
   expected: " its 1 "
   name: StandardTagTest#test_case_06b82f7c79605c8a02bd61f65b86f340
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L85
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L87
 - template: '{% case condition %}{% when "string here" %} hit {% endcase %}'
   environment:
     condition: bad string here
   expected: ''
   name: StandardTagTest#test_case_0f8dafcbfea2be839773aa2e01dbfd3d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L100
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L102
 - template: '{% case condition %}{% when "string here" %} hit {% endcase %}'
   environment:
     condition: string here
   expected: " hit "
   name: StandardTagTest#test_case_5bd36440f705a8957a71f979f96aed5f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L95
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L97
 - template: "{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase
     %}"
   environment:
     condition: 3
   expected: ''
   name: StandardTagTest#test_case_8e497e0342c03883de7de421f2ed1e43
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L90
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L92
 - template: "{% case condition %}{% when 1 %} its 1 {% when 2 %} its 2 {% endcase
     %}"
   environment:
     condition: 2
   expected: " its 2 "
   name: StandardTagTest#test_case_dd04ad4ce1fa8bf5bbdd8ac449af2367
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L80
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L82
 - template: "{% case false %}{% when true %}true{% when false %}false{% else %}else{%
     endcase %}"
   expected: 'false'
   name: StandardTagTest#test_case_on_length_with_else_3827256023eafa8243e5c5e183f1f556
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L162
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L164
 - template: "{% case NULL %}{% when true %}true{% when false %}false{% else %}else{%
     endcase %}"
   expected: else
   name: StandardTagTest#test_case_on_length_with_else_53da534b44b385add08c186870352d80
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L170
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L172
 - template: "{% case true %}{% when true %}true{% when false %}false{% else %}else{%
     endcase %}"
   expected: 'true'
   name: StandardTagTest#test_case_on_length_with_else_9ff1152f0fe6636aa66697a8ed890bb3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L166
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L168
 - template: "{% case a.empty? %}{% when true %}true{% when false %}false{% else %}else{%
     endcase %}"
   expected: else
   name: StandardTagTest#test_case_on_length_with_else_a3282055120fd0a883f8cdf538d62d8e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L158
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L160
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}"
   environment:
     a:
@@ -3423,13 +3452,13 @@
     - 1
   expected: ''
   name: StandardTagTest#test_case_on_size_250950dc469d542cc1b272149522862b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L126
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L128
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}"
   environment:
     a: []
   expected: ''
   name: StandardTagTest#test_case_on_size_3d9dbd6a673e0c04a3d58ae8cf481e54
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L123
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L125
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}"
   environment:
     a:
@@ -3440,14 +3469,14 @@
     - 1
   expected: ''
   name: StandardTagTest#test_case_on_size_54cdee9becde3ce5644b48cc696f8ecd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L128
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L130
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}"
   environment:
     a:
     - 1
   expected: '1'
   name: StandardTagTest#test_case_on_size_5703998f80c53be11653a978d5456f3a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L124
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L126
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}"
   environment:
     a:
@@ -3455,7 +3484,7 @@
     - 1
   expected: '2'
   name: StandardTagTest#test_case_on_size_8f4bfba46e5709f8c652e38dd5dfa272
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L125
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L127
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% endcase %}"
   environment:
     a:
@@ -3465,7 +3494,7 @@
     - 1
   expected: ''
   name: StandardTagTest#test_case_on_size_9f21ee8f90a6739f92a494d8322889a8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L127
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L129
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}"
   environment:
     a:
@@ -3474,20 +3503,20 @@
     - 1
   expected: else
   name: StandardTagTest#test_case_on_size_with_else_37868e2aaad469b73d8591c62755db97
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L144
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L146
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}"
   environment:
     a: []
   expected: else
   name: StandardTagTest#test_case_on_size_with_else_49641028c355738ea6713df66474ff92
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L132
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L134
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}"
   environment:
     a:
     - 1
   expected: '1'
   name: StandardTagTest#test_case_on_size_with_else_c6d02816cdb713ffedf83b71c355e649
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L136
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L138
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}"
   environment:
     a:
@@ -3497,7 +3526,7 @@
     - 1
   expected: else
   name: StandardTagTest#test_case_on_size_with_else_cb2c06ec45bfa1a0171cbd432df36370
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L148
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L150
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}"
   environment:
     a:
@@ -3505,7 +3534,7 @@
     - 1
   expected: '2'
   name: StandardTagTest#test_case_on_size_with_else_e4acda64d2f7d053cce5edf2eaf2334b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L140
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L142
 - template: "{% case a.size %}{% when 1 %}1{% when 2 %}2{% else %}else{% endcase %}"
   environment:
     a:
@@ -3516,273 +3545,281 @@
     - 1
   expected: else
   name: StandardTagTest#test_case_on_size_with_else_f8a5eb40a3fbeef77c886fb354295ddd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L152
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L154
 - template: '{% case condition %}{% when 1, "string", null %} its 1 or 2 or 3 {% when
     4 %} its 4 {% endcase %}'
   environment:
     condition: 1
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_comma_2a3e0285c501e45a79aad7aa11b3498f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L209
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L211
 - template: '{% case condition %}{% when 1, "string", null %} its 1 or 2 or 3 {% when
     4 %} its 4 {% endcase %}'
   environment:
     condition: something else
   expected: ''
   name: StandardTagTest#test_case_when_comma_2f3257c6241e656131e3215b913d4927
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L212
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L214
 - template: "{% case condition %}{% when 1, 2, 3 %} its 1 or 2 or 3 {% when 4 %} its
     4 {% endcase %}"
   environment:
     condition: 3
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_comma_4d38dcedade4693c9a4e4f0d847bfd64
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L204
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L206
 - template: "{% case condition %}{% when 1, 2, 3 %} its 1 or 2 or 3 {% when 4 %} its
     4 {% endcase %}"
   environment:
     condition: 1
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_comma_553e32145f2cbf8645835bfd94225a84
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L202
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L204
 - template: '{% case condition %}{% when 1, "string", null %} its 1 or 2 or 3 {% when
     4 %} its 4 {% endcase %}'
   environment:
     condition:
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_comma_5f56e1f49ab87d59c3b12ad6debb5573
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L211
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L213
 - template: '{% case condition %}{% when 1, 2 %} {% assign r = "result" %} {% endcase
     %}{{ r }}'
   environment:
     condition: 2
   expected: result
   name: StandardTagTest#test_case_when_comma_and_blank_body_5627dc19fe849ffc73cf04e6973a4bb3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L217
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L219
 - template: '{% case condition %}{% when 1, "string", null %} its 1 or 2 or 3 {% when
     4 %} its 4 {% endcase %}'
   environment:
     condition: string
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_comma_c3c0e6d6d6c0424fddd55dfd8ee78562
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L210
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L212
 - template: "{% case condition %}{% when 1, 2, 3 %} its 1 or 2 or 3 {% when 4 %} its
     4 {% endcase %}"
   environment:
     condition: 4
   expected: " its 4 "
   name: StandardTagTest#test_case_when_comma_e0ff6c5f2e613be0b42419521a25ecb2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L205
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L207
 - template: "{% case condition %}{% when 1, 2, 3 %} its 1 or 2 or 3 {% when 4 %} its
     4 {% endcase %}"
   environment:
     condition: 5
   expected: ''
   name: StandardTagTest#test_case_when_comma_eb2058a2720eadfe74448760b6d468b3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L206
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L208
 - template: "{% case condition %}{% when 1, 2, 3 %} its 1 or 2 or 3 {% when 4 %} its
     4 {% endcase %}"
   environment:
     condition: 2
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_comma_f89e98f67092d21f807f8fea93466a52
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L203
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L205
 - template: '{% case condition %}{% when 1 or "string" or null %} its 1 or 2 or 3
     {% when 4 %} its 4 {% endcase %}'
   environment:
     condition: string
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_or_1d7b1686fa03098ad5671308611e741e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L195
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L197
 - template: "{% case condition %}{% when 1 or 2 or 3 %} its 1 or 2 or 3 {% when 4
     %} its 4 {% endcase %}"
   environment:
     condition: 1
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_or_2a68e80529cd755871d3b638d7d32454
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L187
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L189
 - template: "{% case condition %}{% when 1 or 2 or 3 %} its 1 or 2 or 3 {% when 4
     %} its 4 {% endcase %}"
   environment:
     condition: 3
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_or_2b2319ae8cdba1f346fd9eaa7f94ffc9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L189
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L191
 - template: '{% case condition %}{% when 1 or "string" or null %} its 1 or 2 or 3
     {% when 4 %} its 4 {% endcase %}'
   environment:
     condition: 1
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_or_3a364586ee802231436154799d599174
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L194
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L196
 - template: '{% case condition %}{% when 1 or "string" or null %} its 1 or 2 or 3
     {% when 4 %} its 4 {% endcase %}'
   environment:
     condition: something else
   expected: ''
   name: StandardTagTest#test_case_when_or_5064350d810c2780a1ce6e4117f3876f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L197
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L199
 - template: "{% case condition %}{% when 1 or 2 or 3 %} its 1 or 2 or 3 {% when 4
     %} its 4 {% endcase %}"
   environment:
     condition: 2
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_or_8f7dffe340359784397f7c44a3875459
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L188
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L190
 - template: '{% case condition %}{% when 1 or "string" or null %} its 1 or 2 or 3
     {% when 4 %} its 4 {% endcase %}'
   environment:
     condition:
   expected: " its 1 or 2 or 3 "
   name: StandardTagTest#test_case_when_or_92c9b86d89216562b4566646f24f3ff9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L196
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L198
 - template: "{% case condition %}{% when 1 or 2 or 3 %} its 1 or 2 or 3 {% when 4
     %} its 4 {% endcase %}"
   environment:
     condition: 4
   expected: " its 4 "
   name: StandardTagTest#test_case_when_or_b540f65e7927cdfd8791ade22c938935
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L190
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L192
 - template: "{% case condition %}{% when 1 or 2 or 3 %} its 1 or 2 or 3 {% when 4
     %} its 4 {% endcase %}"
   environment:
     condition: 5
   expected: ''
   name: StandardTagTest#test_case_when_or_f068cc0c855c489b230029b512d00c0f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L191
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L193
 - template: "{% case condition %} {% when 5 %} hit {% else %} else {% endcase %}"
   environment:
     condition: 6
   expected: " else "
   name: StandardTagTest#test_case_with_else_21bf64284e4b6fa72fa90e07a3dfb80e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L117
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L119
 - template: "{% case condition %}{% when 5 %} hit {% else %} else {% endcase %}"
   environment:
     condition: 5
   expected: " hit "
   name: StandardTagTest#test_case_with_else_4a10ddca29add6359520c130c084fcf1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L107
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L109
 - template: "{% case condition %}{% when 5 %} hit {% else %} else {% endcase %}"
   environment:
     condition: 6
   expected: " else "
   name: StandardTagTest#test_case_with_else_d4d29896cf5e6d8359cb4bda952ed83e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L112
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L114
 - template: '{%cycle "", "two"%} {%cycle "", "two"%}'
   expected: " two"
   name: StandardTagTest#test_cycle_0f19e1e11f28d57fdcdb80a9251ed6e2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L250
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L252
 - template: '{%cycle "one", "two"%}'
   expected: one
   name: StandardTagTest#test_cycle_2e820e6c8dbec41882a3c60aae342774
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L248
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L250
 - template: '{%cycle "text-align: left", "text-align: right" %} {%cycle "text-align:
     left", "text-align: right"%}'
   expected: 'text-align: left text-align: right'
   name: StandardTagTest#test_cycle_5a4fac03d1f5fad068e92b86efed39d4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L254
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L256
 - template: '{%cycle "one", "two"%} {%cycle "one", "two"%} {%cycle "one", "two"%}'
   expected: one two one
   name: StandardTagTest#test_cycle_9b0d02107f57b985fe723375a6c78e76
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L252
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L254
 - template: '{%cycle "one", "two"%} {%cycle "one", "two"%}'
   expected: one two
   name: StandardTagTest#test_cycle_bb99f4d4ef9eb19e9bfa276767396f49
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L249
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L251
 - template: "{% comment %}{% endcomment %}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_09b4659cec555709a409627bc123adaa
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L29
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L29
 - template: |-
     foo{%comment%}
                                          {%endcomment%}bar
   expected: foobar
   name: StandardTagTest#test_has_a_block_which_does_nothing_0ff7271d37229da4bce9cf481bae77fd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L49
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L51
 - template: "{% comment %}{% raw %} {{%%%%}}  }} { {% endcomment %} {% comment {%
     endraw %} {% endcomment %}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_2c32a19f04205c763fc77d8a123b905b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L38
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L38
 - template: "{% comment %}{%endcomment%}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_30707ba82d076543277752d0e8ad12bc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L28
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L28
+- template: '{% comment %}{% " %}{% endcomment %}'
+  expected: ''
+  name: StandardTagTest#test_has_a_block_which_does_nothing_32fe31036ef41a6f7b4479f044736068
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L39
 - template: foo {%comment%} comment {%endcomment%} bar
   expected: foo  bar
   name: StandardTagTest#test_has_a_block_which_does_nothing_3aa207d13ebbf7f4a71484eef199630a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L47
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L49
 - template: foo {%comment%} {%endcomment%} bar
   expected: foo  bar
   name: StandardTagTest#test_has_a_block_which_does_nothing_3d1a02d8ac94a1f44a08ad6d54a6e2cb
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L45
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L47
 - template: "{% comment %}comment{% endcomment %}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_4db1be1cd5d027f65b395ca5d37ee0de
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L31
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L31
 - template: foo {%comment%}comment{%endcomment%} bar
   expected: foo  bar
   name: StandardTagTest#test_has_a_block_which_does_nothing_52d1ec736f3ac7c72fabf5b60f8210e5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L46
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L48
 - template: "{%comment%}{% endcomment %}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_5c6d3ef4d95de2ace6cd43a2d52f0d88
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L27
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L27
 - template: foo{% comment %}comment{% endcomment %}bar
   expected: foobar
   name: StandardTagTest#test_has_a_block_which_does_nothing_6450f995eec5504845007d5f2568d44e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L41
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L43
 - template: foo{%comment%}comment{%endcomment%}bar
   expected: foobar
   name: StandardTagTest#test_has_a_block_which_does_nothing_6c0b953bbd0f72439a84c5a82d6f61e4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L40
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L42
 - template: "{% comment %} 1 {% comment %} 2 {% endcomment %} 3 {% endcomment %}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_821e8371e5b9b0a87f2fd2b72e149e7b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L32
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L32
 - template: foo{%comment%} comment {%endcomment%}bar
   expected: foobar
   name: StandardTagTest#test_has_a_block_which_does_nothing_84c48127a1639ef13925c9d579153b98
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L42
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L44
 - template: "{% comment %}{% endwhatever %}{% endcomment %}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_9527c375564ab78cd42a894bd0dd545c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L37
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L37
 - template: "{%comment%}{%blabla%}{%endcomment%}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_9f80f9dc4050eab45e41808e20ee9d97
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L34
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L34
 - template: foo{% comment %} comment {% endcomment %}bar
   expected: foobar
   name: StandardTagTest#test_has_a_block_which_does_nothing_b18743f7bd1dcc563b2483557b1cc369
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L43
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L45
 - template: "{% comment %}{% blabla %}{% endcomment %}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_c267d8b6855bb74feb5ac5fcffc38ca1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L35
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L35
 - template: "{%comment%}{%endcomment%}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_c2d2e6e4a3bedc67a78a209cfb367f7c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L26
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L26
 - template: "{%comment%}comment{%endcomment%}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_d9fca87edab4b6006875a34baa7e3266
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L30
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L30
+- template: "{% comment %}{%%}{% endcomment %}"
+  expected: ''
+  name: StandardTagTest#test_has_a_block_which_does_nothing_de45146fbffa502aa393dcf58ad09f78
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L40
 - template: "{%comment%}{% endif %}{%endcomment%}"
   expected: ''
   name: StandardTagTest#test_has_a_block_which_does_nothing_e4820ea61903b17df3f5bd57ff103092
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L36
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L36
 - template: the comment block should be removed {%comment%} be gone.. {%endcomment%}
     .. right?
   expected: the comment block should be removed  .. right?
   name: StandardTagTest#test_has_a_block_which_does_nothing_ec7a53b5b5671b30be6fc5b1cccd6330
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L23
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L23
 - template: a-b:{{a-b}} {%assign a-b = 2 %}a-b:{{a-b}}
   environment:
     a-b: '1'
   expected: a-b:1 a-b:2
   name: StandardTagTest#test_hyphenated_assign_73be643b05054d2f039521a16ea3599d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L55
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L57
 - template: "{%for item in array%}{%ifchanged%}{{item}}{% endifchanged %}{%endfor%}"
   environment:
     array:
@@ -3794,7 +3831,7 @@
     - 3
   expected: '123'
   name: StandardTagTest#test_ifchanged_a713e0c9e03680c1e7f99c827804be3e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L293
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L295
 - template: "{%for item in array%}{%ifchanged%}{{item}}{% endifchanged %}{%endfor%}"
   environment:
     array:
@@ -3804,23 +3841,23 @@
     - 1
   expected: '1'
   name: StandardTagTest#test_ifchanged_f05da9010d379df8243e079594e6e16a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L296
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L298
 - template: "{% if true == empty %}?{% endif %}"
   expected: ''
   name: StandardTagTest#test_illegal_symbols_243bcd5be93a7ce32ada192f6ac9da76
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L285
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L287
 - template: "{% if empty == true %}?{% endif %}"
   expected: ''
   name: StandardTagTest#test_illegal_symbols_243ef59eb05494b70cbeb614d1445379
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L287
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L289
 - template: "{% if null == true %}?{% endif %}"
   expected: ''
   name: StandardTagTest#test_illegal_symbols_36ae99e70d9a5f315162df28b4aefed8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L288
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L290
 - template: "{% if true == null %}?{% endif %}"
   expected: ''
   name: StandardTagTest#test_illegal_symbols_db1f7e096b5d5ef0db02916905e1221f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L286
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L288
 - template: |-
     0{%
     for i in (1..3)
@@ -3831,18 +3868,18 @@
     %}
   expected: 0 1 2 3
   name: StandardTagTest#test_multiline_tag_981124e9e58a5201254bb0436940b0d1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L300
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L302
 - template: "{%cycle 1,2%} {%cycle 1,2%} {%cycle 1,2%} {%cycle 1,2,3%} {%cycle 1,2,3%}
     {%cycle 1,2,3%} {%cycle 1,2,3%}"
   expected: 1 2 1 1 2 3 1
   name: StandardTagTest#test_multiple_cycles_9d3484141824981fc9b078d7f125a8f8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L259
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L261
 - template: '{%cycle 1: "one", "two" %} {%cycle 2: "one", "two" %} {%cycle 1: "one",
     "two" %} {%cycle 2: "one", "two" %} {%cycle 1: "one", "two" %} {%cycle 2: "one",
     "two" %}'
   expected: one one two two one one
   name: StandardTagTest#test_multiple_named_cycles_513093028d49e60ab85553649e58439d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L264
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L266
 - template: '{%cycle var1: "one", "two" %} {%cycle var2: "one", "two" %} {%cycle var1:
     "one", "two" %} {%cycle var2: "one", "two" %} {%cycle var1: "one", "two" %} {%cycle
     var2: "one", "two" %}'
@@ -3851,23 +3888,23 @@
     var2: 2
   expected: one one two two one one
   name: StandardTagTest#test_multiple_named_cycles_with_names_from_context_1b3cb2705227cd637e80f8dc7488197e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L270
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L272
 - template: blah
   expected: blah
   name: StandardTagTest#test_no_transform_258074ab987e3cdbb2d932e29239f8f0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L12
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L12
 - template: ''
   expected: ''
   name: StandardTagTest#test_no_transform_5e2a1070aa66598e52ed106ac56d55c3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L15
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L15
 - template: this text should come out of the template without change...
   expected: this text should come out of the template without change...
   name: StandardTagTest#test_no_transform_9cfb1d12df83898e5c65084d7a302d98
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L9
 - template: "<blah>"
   expected: "<blah>"
   name: StandardTagTest#test_no_transform_c5364bfc65960ff7add90f1e997f7bec
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L13
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L13
 - template: |-
     this shouldnt see any transformation either but has multiple lines
                   as you can clearly see here ...
@@ -3875,11 +3912,11 @@
     this shouldnt see any transformation either but has multiple lines
                   as you can clearly see here ...
   name: StandardTagTest#test_no_transform_e51e9e91e0fa6521b43e6069da0e019d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L19
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L19
 - template: "|,.:"
   expected: "|,.:"
   name: StandardTagTest#test_no_transform_f21c1864db333f412e03a3cbcce10348
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L14
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L14
 - template: array has {{ array.size }} elements
   environment:
     array:
@@ -3889,7 +3926,7 @@
     - 4
   expected: array has 4 elements
   name: StandardTagTest#test_size_of_array_161d16fd2d03719a69a8c17159a002ca
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L276
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L278
 - template: hash has {{ hash.size }} elements
   environment:
     hash:
@@ -3899,13 +3936,13 @@
       :d: 4
   expected: hash has 4 elements
   name: StandardTagTest#test_size_of_hash_b8034e9e1a0f6932cddb82b95e17741d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/standard_tag_test.rb#L281
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/standard_tag_test.rb#L283
 - template: " {% if array == empty %} true {% else %} false {% endif %} "
   environment:
     array: []
   expected: "  true  "
   name: StatementsTest#test_is_collection_empty_b8fc6678f53ca3d6abebb170997d786d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L90
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L90
 - template: " {% if array == empty %} true {% else %} false {% endif %} "
   environment:
     array:
@@ -3914,99 +3951,99 @@
     - 3
   expected: "  false  "
   name: StatementsTest#test_is_not_collection_empty_f0656a69173e41dcf582e3cc434179d1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L95
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L95
 - template: " {% if var == nil %} true {% else %} false {% endif %} "
   environment:
     var:
   expected: "  true  "
   name: StatementsTest#test_nil_2f8dbe020000aa60edad580eaa198214
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L100
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L100
 - template: " {% if var == null %} true {% else %} false {% endif %} "
   environment:
     var:
   expected: "  true  "
   name: StatementsTest#test_nil_cd44f143525c8a319e2320a99adc3136
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L103
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L103
 - template: " {% if var != null %} true {% else %} false {% endif %} "
   environment:
     var: 1
   expected: "  true  "
   name: StatementsTest#test_not_nil_7d1ea5b108d60f4d100bf0a6dba2f466
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L111
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L111
 - template: " {% if var != nil %} true {% else %} false {% endif %} "
   environment:
     var: 1
   expected: "  true  "
   name: StatementsTest#test_not_nil_814aae898b2bf498abb1e0ec9c52e178
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L108
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L108
 - template: " {% if 1 > 0 %} true {% else %} false {% endif %} "
   expected: "  true  "
   name: StatementsTest#test_one_lq_zero_7686a0444acf1213b705567e61e79ea0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L25
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L25
 - template: " {% if 'test' == 'test' %} true {% else %} false {% endif %} "
   expected: "  true  "
   name: StatementsTest#test_strings_a7818be968fca8b404c7da7a429ac68c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L53
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L53
 - template: " {% if 'test' != 'test' %} true {% else %} false {% endif %} "
   expected: "  false  "
   name: StatementsTest#test_strings_not_equal_5e17369e3c1141840b034a283e8913de
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L58
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L58
 - template: " {% if true == true %} true {% else %} false {% endif %} "
   expected: "  true  "
   name: StatementsTest#test_true_eql_true_720dfd7a0b69f80b174618fb62785bee
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L10
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L10
 - template: " {% if 0 > 0 %} true {% else %} false {% endif %} "
   expected: "  false  "
   name: StatementsTest#test_true_lq_true_35fd1f7b73a59eef3ced39d6de024859
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L20
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L20
 - template: " {% if true != true %} true {% else %} false {% endif %} "
   expected: "  false  "
   name: StatementsTest#test_true_not_eql_true_8831be8fddba49e2a3b5675f131567e5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L15
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L15
 - template: " {% if var == 'hello there!' %} true {% else %} false {% endif %} "
   environment:
     var: hello there!
   expected: "  true  "
   name: StatementsTest#test_var_and_long_string_are_equal_4bbe64cd194df1871155781145297270
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L73
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L73
 - template: " {% if 'hello there!' == var %} true {% else %} false {% endif %} "
   environment:
     var: hello there!
   expected: "  true  "
   name: StatementsTest#test_var_and_long_string_are_equal_backwards_7039a939ab0fcb14cc1a7a4c11ec0253
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L78
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L78
 - template: ' {% if "hello there!" == var %} true {% else %} false {% endif %} '
   environment:
     var: hello there!
   expected: "  true  "
   name: StatementsTest#test_var_strings_are_not_equal_bb43963c99a6d391b6b01941673253bc
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L68
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L68
 - template: ' {% if var == "hello there!" %} true {% else %} false {% endif %} '
   environment:
     var: hello there!
   expected: "  true  "
   name: StatementsTest#test_var_strings_equal_c8f56f3bc37f076095465018321a8d13
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L63
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L63
 - template: " {% if 0 < 1 %} true {% else %} false {% endif %} "
   expected: "  true  "
   name: StatementsTest#test_zero_lq_one_4479719270665e6d7431a22f6fa180ff
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L30
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L30
 - template: " {% if 0 <= 0 %} true {% else %} false {% endif %} "
   expected: "  true  "
   name: StatementsTest#test_zero_lq_or_equal_one_ed4079a8ae1e666eb401172d35234849
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L35
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L35
 - template: " {% if 0 <= null %} true {% else %} false {% endif %} "
   expected: "  false  "
   name: StatementsTest#test_zero_lq_or_equal_one_involving_nil_3df7538028b63bbb8382e62263ea02c9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L43
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L43
 - template: " {% if null <= 0 %} true {% else %} false {% endif %} "
   expected: "  false  "
   name: StatementsTest#test_zero_lq_or_equal_one_involving_nil_681e7d1371669dd7de6d2585c811b3c7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L40
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L40
 - template: " {% if 0 >= 0 %} true {% else %} false {% endif %} "
   expected: "  true  "
   name: StatementsTest#test_zero_lqq_or_equal_one_3d173372c1e0c59673b5e0140736148a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/statements_test.rb#L48
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/statements_test.rb#L48
 - template: "{% tablerow char in characters cols:3 %}I WILL NOT BE OUTPUT{% endtablerow
     %}"
   environment:
@@ -4015,7 +4052,23 @@
     <tr class="row1">
     </tr>
   name: TableRowTest#test_blank_string_not_iterable_1d1ecea66bcada51b52c2702ef8d0b07
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L64
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L64
+- template: "{% tablerow i in (1..2) cols:var %}{{ tablerowloop.col_last }}{% endtablerow
+    %}"
+  environment:
+    var:
+  expected: |
+    <tr class="row1">
+    <td class="col1">false</td><td class="col2">false</td></tr>
+  name: TableRowTest#test_cols_nil_constant_same_as_evaluated_nil_expression_ae4f6373678530317f697021172907e4
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L78
+- template: "{% tablerow i in (1..2) cols:nil %}{{ tablerowloop.col_last }}{% endtablerow
+    %}"
+  expected: |
+    <tr class="row1">
+    <td class="col1">false</td><td class="col2">false</td></tr>
+  name: TableRowTest#test_cols_nil_constant_same_as_evaluated_nil_expression_e978c710ec07fbbd7c338d10a196cc97
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L75
 - template: "{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}"
   environment:
     numbers: !ruby/object:TableRowTest::ArrayDrop
@@ -4031,7 +4084,7 @@
     <td class="col1"> 1 </td><td class="col2"> 2 </td><td class="col3"> 3 </td></tr>
     <tr class="row2"><td class="col1"> 4 </td><td class="col2"> 5 </td><td class="col3"> 6 </td></tr>
   name: TableRowTest#test_enumerable_drop_9adc8c47cbc396ffcc4fcf7d3fa19f60
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L52
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L52
 - template: "{% tablerow n in numbers cols:3 offset:1 limit:6%} {{n}} {% endtablerow
     %}"
   environment:
@@ -4049,7 +4102,7 @@
     <td class="col1"> 1 </td><td class="col2"> 2 </td><td class="col3"> 3 </td></tr>
     <tr class="row2"><td class="col1"> 4 </td><td class="col2"> 5 </td><td class="col3"> 6 </td></tr>
   name: TableRowTest#test_offset_and_limit_f159993ac22ee35e8530b978b591cb5f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L58
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L58
 - template: "{% tablerow n in collections['frontpage'] cols:3%} {{n}} {% endtablerow
     %}"
   environment:
@@ -4066,7 +4119,7 @@
     <td class="col1"> 1 </td><td class="col2"> 2 </td><td class="col3"> 3 </td></tr>
     <tr class="row2"><td class="col1"> 4 </td><td class="col2"> 5 </td><td class="col3"> 6 </td></tr>
   name: TableRowTest#test_quoted_fragment_15532c97ad7e04c7db5169e0d61d1df2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L46
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L46
 - template: "{% tablerow n in collections.frontpage cols:3%} {{n}} {% endtablerow
     %}"
   environment:
@@ -4083,7 +4136,7 @@
     <td class="col1"> 1 </td><td class="col2"> 2 </td><td class="col3"> 3 </td></tr>
     <tr class="row2"><td class="col1"> 4 </td><td class="col2"> 5 </td><td class="col3"> 6 </td></tr>
   name: TableRowTest#test_quoted_fragment_bc90343efbfbc19cd7d99f642acdea94
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L43
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L43
 - template: "{% tablerow n in numbers cols:2%}{{tablerowloop.col}}{% endtablerow %}"
   environment:
     numbers:
@@ -4099,7 +4152,7 @@
     <tr class="row2"><td class="col1">1</td><td class="col2">2</td></tr>
     <tr class="row3"><td class="col1">1</td><td class="col2">2</td></tr>
   name: TableRowTest#test_table_col_counter_d5564f2f5c3621fdf675aa3b1dc568a5
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L37
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L37
 - template: "{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}"
   environment:
     numbers: []
@@ -4107,7 +4160,7 @@
     <tr class="row1">
     </tr>
   name: TableRowTest#test_table_row_6b232ddc1c7233f1578db3d0ccc04303
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L25
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L25
 - template: "{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}"
   environment:
     numbers:
@@ -4122,7 +4175,7 @@
     <td class="col1"> 1 </td><td class="col2"> 2 </td><td class="col3"> 3 </td></tr>
     <tr class="row2"><td class="col1"> 4 </td><td class="col2"> 5 </td><td class="col3"> 6 </td></tr>
   name: TableRowTest#test_table_row_adc6a2c919464ed8e82eb0f027605c98
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L21
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L21
 - template: "{% tablerow n in numbers cols:5%} {{n}} {% endtablerow %}"
   environment:
     numbers:
@@ -4137,7 +4190,7 @@
     <td class="col1"> 1 </td><td class="col2"> 2 </td><td class="col3"> 3 </td><td class="col4"> 4 </td><td class="col5"> 5 </td></tr>
     <tr class="row2"><td class="col1"> 6 </td></tr>
   name: TableRowTest#test_table_row_with_different_cols_827649a729ca4569d67b899a88ec623f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L31
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L31
 - template: |-
     {% tablerow i in (1...2) %}
     col: {{ tablerowloop.col }}
@@ -4183,21 +4236,21 @@
     row: 1
     </td></tr>
   name: TableRowTest#test_tablerow_loop_drop_attributes_8617a1ec4445691c6755b40509b9a754
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/table_row_test.rb#L118
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/table_row_test.rb#L132
 - template: "{% assign nums = (x..y) %}{% for num in nums %}{{ num }}{% endfor %}"
   environment:
     x: 1
     "y": 5
   expected: '12345'
   name: TemplateTest#test_using_range_literal_works_as_expected_9dc1734871d2f07b2ff8f32f1d534f79
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/template_test.rb#L322
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/template_test.rb#L322
 - template: "{% assign foo = (x..y) %}{{ foo }}"
   environment:
     x: 1
     "y": 5
   expected: 1..5
   name: TemplateTest#test_using_range_literal_works_as_expected_bc778ecef047e238460cb3e8dc4168f7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/template_test.rb#L319
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/template_test.rb#L319
 - template: |2
           <div>
             {%- if true -%}
@@ -4210,7 +4263,7 @@
           </div>
   expected: "      <div><p>John</p></div>\n"
   name: TrimModeTest#test_complex_trim_f9f2fb49ddd658e3522d432c85c907ce
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L498
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L498
 - template: |2
           <div>
             <p>
@@ -4236,19 +4289,19 @@
               30</i>
           </div>
   name: TrimModeTest#test_complex_trim_output_afce137bb071fdf209ffba7d45cc0835
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L480
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L480
 - template: "<p>{{- 'John' -}}</p>"
   expected: "<p>John</p>"
   name: TrimModeTest#test_no_trim_output_0a982aedde7c77ed1334066705d4e00d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L115
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L115
 - template: "<p>{%- if true -%}yes{%- endif -%}</p>"
   expected: "<p>yes</p>"
   name: TrimModeTest#test_no_trim_tags_499752be7a9ee002ab22329ba78b023e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L122
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L122
 - template: "<p>{%- if false -%}no{%- endif -%}</p>"
   expected: "<p></p>"
   name: TrimModeTest#test_no_trim_tags_e1c452da199dcc2d7a32dafa7ca6f5db
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L126
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L126
 - template: |2
           <div>
             <p>
@@ -4264,7 +4317,7 @@
             </p>
           </div>
   name: TrimModeTest#test_post_and_pre_trim_tags_6dfefae90de0547e7f6830ff344404b1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L330
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L330
 - template: |2
           <div>
             <p>
@@ -4275,7 +4328,7 @@
           </div>
   expected: "      <div>\n        <p>\n          \n        </p>\n      </div>\n"
   name: TrimModeTest#test_post_and_pre_trim_tags_7072350f0c292dd8c99458b49616bd5c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L349
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L349
 - template: |2
           <div>
             <p>
@@ -4288,7 +4341,7 @@
               John</p>
           </div>
   name: TrimModeTest#test_post_trim_output_c7bb68a2937f564e4598e46bb925703a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L237
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L237
 - template: |2
           <div>
             <p>
@@ -4303,7 +4356,7 @@
               </p>
           </div>
   name: TrimModeTest#test_post_trim_tags_e20c8b9a4a82fdd69cc84bff290f5b11
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L274
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L274
 - template: |2
           <div>
             <p>
@@ -4319,7 +4372,7 @@
               </p>
           </div>
   name: TrimModeTest#test_post_trim_tags_ebc0edd805af4c350d2b58ff6e4a6203
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L257
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L257
 - template: |2
           <div>
             <p>
@@ -4333,7 +4386,7 @@
             <p></p>
           </div>
   name: TrimModeTest#test_pre_and_post_trim_tags_37b59ef899c8dd93bd47ff1d02732243
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L310
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L310
 - template: |2
           <div>
             <p>
@@ -4349,23 +4402,23 @@
               </p>
           </div>
   name: TrimModeTest#test_pre_and_post_trim_tags_d389e94987c89f59140dc6b01fc0f079
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L294
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L294
 - template: "{{ 'B' }} \n{%- if true %}C{% endif %}"
   expected: BC
   name: TrimModeTest#test_pre_trim_blank_preceding_text_6708eeb05b3947c539249ab8364ce67d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L535
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L535
 - template: |2-
 
     {%- if true %}{% endif %}
   expected: ''
   name: TrimModeTest#test_pre_trim_blank_preceding_text_ae4d761c777c642b86a842b9649bafd9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L534
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L534
 - template: |2-
 
     {%- raw %}{% endraw %}
   expected: ''
   name: TrimModeTest#test_pre_trim_blank_preceding_text_c4ff5f6a87805a62a7e7668b9ef387f9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L533
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L533
 - template: |2
           <div>
             <p>
@@ -4378,7 +4431,7 @@
             </p>
           </div>
   name: TrimModeTest#test_pre_trim_output_226cfa2ec5e3510a77ff54dc56084c1c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L183
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L183
 - template: |2
           <div>
             <p>
@@ -4393,7 +4446,7 @@
             </p>
           </div>
   name: TrimModeTest#test_pre_trim_tags_3c963c7ada8cc6176be00367e08757c4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L220
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L220
 - template: |2
           <div>
             <p>
@@ -4409,7 +4462,7 @@
             </p>
           </div>
   name: TrimModeTest#test_pre_trim_tags_6b853c7b89e0e3820e26a62a2f4b6534
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L203
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L203
 - template: |2
           <div>
             {% raw %}
@@ -4423,43 +4476,43 @@
   expected: "      <div>\n        \n          {%- if true -%}\n            <p>\n              {{-
     'John' -}}\n            </p>\n          {%- endif -%}\n        \n      </div>\n"
   name: TrimModeTest#test_raw_output_beabe834832c8e2cc10b709c3e10134f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L529
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L529
 - template: '{{ "a" -}}{{ "b" }} c'
   expected: ab c
   name: TrimModeTest#test_right_trim_followed_by_tag_4ff64fc4d65042ef88278366179d0551
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L502
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L502
 - template: "<p> {% if true -%} yes {%- endif %} </p>"
   expected: "<p> yes </p>"
   name: TrimModeTest#test_single_line_inner_tag_09f3cb95ceb01efda728ed6e7ee6b561
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L142
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L142
 - template: "<p> {% if false -%} no {%- endif %} </p>"
   expected: "<p>  </p>"
   name: TrimModeTest#test_single_line_inner_tag_831d01f20e69fe3dd7b932ce45624e45
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L146
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L146
 - template: "<p> {%- if true %} yes {% endif -%} </p>"
   expected: "<p> yes </p>"
   name: TrimModeTest#test_single_line_outer_tag_3b6d32149a95f42ef49fe0ac6325b41a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L132
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L132
 - template: "<p> {%- if false %} no {% endif -%} </p>"
   expected: "<p></p>"
   name: TrimModeTest#test_single_line_outer_tag_ff6b204b0d4e872e0a65572ee713eac3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L136
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L136
 - template: "<p> {% if true -%} yes {% endif -%} </p>"
   expected: "<p> yes </p>"
   name: TrimModeTest#test_single_line_post_tag_37cf7675c86ec26f7a8211e63314ee95
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L152
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L152
 - template: "<p> {% if false -%} no {% endif -%} </p>"
   expected: "<p> </p>"
   name: TrimModeTest#test_single_line_post_tag_51b28bc8d9e8a061bc8022bba682f860
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L156
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L156
 - template: "<p> {%- if true %} yes {%- endif %} </p>"
   expected: "<p> yes </p>"
   name: TrimModeTest#test_single_line_pre_tag_1a00541d246334f0ea03c064800da0e2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L162
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L162
 - template: "<p> {%- if false %} no {%- endif %} </p>"
   expected: "<p> </p>"
   name: TrimModeTest#test_single_line_pre_tag_487ca945beeba29c7b3ef45812797a75
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L166
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L166
 - template: |2
           <div>
             <p>
@@ -4473,7 +4526,7 @@
             </p>
           </div>
   name: TrimModeTest#test_standard_output_a75cc8bedb7430ce8dd29dcd4e084cbf
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L24
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L24
 - template: |2
           <div>
             <p>
@@ -4484,7 +4537,7 @@
           </div>
   expected: "      <div>\n        <p>\n          \n        </p>\n      </div>\n"
   name: TrimModeTest#test_standard_tags_605506b0dac759a89302c74d013a173c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L108
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L108
 - template: |2
           <div>
             <p>
@@ -4496,7 +4549,7 @@
   expected: "      <div>\n        <p>\n          \n          yes\n          \n        </p>\n
     \     </div>\n"
   name: TrimModeTest#test_standard_tags_d38b1d27108bd61534af4a8befb83891
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L90
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L90
 - template: |2
           <div>
             <p>
@@ -4514,11 +4567,11 @@
             <p>yes</p>
           </div>
   name: TrimModeTest#test_tag_output_with_multiple_blank_lines_2c7741b73b290ace91e99e3eeaaeb6f7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L66
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L66
 - template: foo {{-}} bar
   expected: foobar
   name: TrimModeTest#test_trim_blank_629ea885c6b1884149be75a65cb0a389
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L556
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L556
 - template: |2
           <div>
             <p>
@@ -4530,7 +4583,7 @@
             <p>John</p>
           </div>
   name: TrimModeTest#test_trim_output_15e1ddbdfea8418589f53d237b06875d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L365
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L365
 - template: |2
           <div>
             <p>
@@ -4544,7 +4597,7 @@
             <p></p>
           </div>
   name: TrimModeTest#test_trim_tags_c999f6cd62e81b367297cf3a33bdd946
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L399
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L399
 - template: |2
           <div>
             <p>
@@ -4558,7 +4611,7 @@
             <p>yes</p>
           </div>
   name: TrimModeTest#test_trim_tags_f6047e43ac978d88215ace33018d05d1
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L383
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L383
 - template: |2
           <div>
             <p>
@@ -4574,7 +4627,7 @@
             <p>John</p>
           </div>
   name: TrimModeTest#test_variable_output_with_multiple_blank_lines_c26f5b2ace98ba7383bd937dc37ade2b
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L44
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L44
 - template: |2
           <div>
             <p>
@@ -4587,7 +4640,7 @@
             <p>John,30</p>
           </div>
   name: TrimModeTest#test_whitespace_trim_output_0e34512b5df28ec39b4caeb280dd385a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L416
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L416
 - template: |2
           <div>
             <p>
@@ -4601,7 +4654,7 @@
             <p></p>
           </div>
   name: TrimModeTest#test_whitespace_trim_tags_a045246d76d290c9f57f3111abb37f1e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L450
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L450
 - template: |2
           <div>
             <p>
@@ -4615,34 +4668,34 @@
             <p>yes</p>
           </div>
   name: TrimModeTest#test_whitespace_trim_tags_a49cc35907ec0708c1e956a21b9d3384
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/trim_mode_test.rb#L434
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/trim_mode_test.rb#L434
 - template: "{% unless true %} you suck {% endunless %} {% unless false %} you rock
     {% endunless %}?"
   expected: "  you rock ?"
   name: UnlessElseTagTest#test_unless_09113739a0811c695b984bb77b438557
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L12
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L12
 - template: " {% unless true %} this text should not go into the output {% endunless
     %} "
   expected: "  "
   name: UnlessElseTagTest#test_unless_960490fad3cce08552cda7e74a6cc8c4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L9
 - template: " {% unless false %} this text should go into the output {% endunless
     %} "
   expected: "  this text should go into the output  "
   name: UnlessElseTagTest#test_unless_ecb29e039ff7f0840e17bed40fab09d7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L10
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L10
 - template: '{% unless "foo" %} NO {% else %} YES {% endunless %}'
   expected: " YES "
   name: UnlessElseTagTest#test_unless_else_49dd8188bf97748d89e83f254d45a0a9
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L18
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L18
 - template: "{% unless false %} YES {% else %} NO {% endunless %}"
   expected: " YES "
   name: UnlessElseTagTest#test_unless_else_bf7c111de323d3f6f1699f94a596f329
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L17
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L17
 - template: "{% unless true %} NO {% else %} YES {% endunless %}"
   expected: " YES "
   name: UnlessElseTagTest#test_unless_else_f3292ae8acec7f7a801c3c4f20498281
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L16
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L16
 - template: "{% for i in choices %}{% unless i %} {{ forloop.index }} {% else %} TRUE
     {% endunless %}{% endfor %}"
   environment:
@@ -4652,7 +4705,7 @@
     - false
   expected: " TRUE  2  3 "
   name: UnlessElseTagTest#test_unless_else_in_loop_6a7017178e4c8eb0b676a7eeca79c17e
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L26
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L26
 - template: "{% for i in choices %}{% unless i %}{{ forloop.index }}{% endunless %}{%
     endfor %}"
   environment:
@@ -4662,21 +4715,22 @@
     - false
   expected: '23'
   name: UnlessElseTagTest#test_unless_in_loop_9b664bcf7858435a0d3425c0404c65f8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/tags/unless_else_tag_test.rb#L22
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/unless_else_tag_test.rb#L22
 - template: "{% case foo %}{% when 1 %}One{% endcase %}"
   environment:
     foo: !ruby/object:IntegerDrop
+      context:
       value: 1
   expected: One
-  name: VariableTest#test_case_tag_calls_to_liquid_value_be63eb946318785f639ea7aa5eb38882
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L41
+  name: VariableTest#test_case_tag_calls_to_liquid_value_eed4ccc3013e7bdaad13bf5b9f59e020
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L46
 - template: "{{ [key] }}"
   environment:
     key: foo
     foo: bar
   expected: bar
   name: VariableTest#test_dynamic_find_var_39d93a38f5bde38548689f4800e2277a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L127
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L132
 - template: "{{ a[ [ 'b' ] ] }}"
   environment:
     b: c
@@ -4684,91 +4738,130 @@
       c: result
   expected: result
   name: VariableTest#test_expression_with_whitespace_in_square_brackets_139910af12112ad0300f626da363d426
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L51
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L56
 - template: "{{ a[ 'b' ] }}"
   environment:
     a:
       b: result
   expected: result
   name: VariableTest#test_expression_with_whitespace_in_square_brackets_c721ddbf0bd04b45c4784cab6a658074
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L50
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L55
 - template: "{{ foo }}"
   environment:
     foo: false
   expected: 'false'
   name: VariableTest#test_false_renders_as_false_36133c7fa3bf048c934c1350cb9ff9ca
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L72
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L77
 - template: "{{ false }}"
   expected: 'false'
   name: VariableTest#test_false_renders_as_false_bcaf4a7ded32fa44bff93e98c2e58da7
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L73
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L78
 - template: "{{ test . test }}"
   environment:
     test:
       test: worked
   expected: worked
   name: VariableTest#test_hash_scoping_1373d3f9d8132f2c46b1c124f3ef7385
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L68
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L73
 - template: "{{ test.test }}"
   environment:
     test:
       test: worked
   expected: worked
   name: VariableTest#test_hash_scoping_b02468a4bc2a2fd0f66699082a9f5b2f
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L67
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L72
+- template: "{% if foo == eqv %}one{% endif %}"
+  environment:
+    foo: !ruby/object:IntegerDrop
+      context:
+      value: 1
+    eqv: !ruby/object:IntegerDrop
+      context:
+      value: 1
+  expected: one
+  name: VariableTest#test_if_tag_calls_to_liquid_value_06a899315e0d5ca329b2c03d0bca8055
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L27
+- template: "{% if a contains x %}one{% endif %}"
+  environment:
+    a:
+    - 1
+    x: !ruby/object:IntegerDrop
+      context:
+      value: 1
+  expected: one
+  name: VariableTest#test_if_tag_calls_to_liquid_value_2680b21f5b0c21182baa1de6e6a0f765
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L37
+- template: "{% if foo %}true{% endif %}"
+  environment:
+    foo: !ruby/object:BooleanDrop
+      context:
+      value: false
+  expected: ''
+  name: VariableTest#test_if_tag_calls_to_liquid_value_b5cd80a6c13b72771320566199fe4791
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L34
 - template: "{% if 0 < foo %}one{% endif %}"
   environment:
     foo: !ruby/object:IntegerDrop
+      context:
       value: 1
   expected: one
-  name: VariableTest#test_if_tag_calls_to_liquid_value_080253e8ada73e94603b2423db76a53a
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L27
-- template: "{% if foo == true %}true{% endif %}"
-  environment:
-    foo: !ruby/object:BooleanDrop
-      value: true
-  expected: 'true'
-  name: VariableTest#test_if_tag_calls_to_liquid_value_18c901df3e7bdae995c2d9641e4599f0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L29
+  name: VariableTest#test_if_tag_calls_to_liquid_value_c41c82d1b6be6e1be7fc952383ea4263
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L28
 - template: "{% if foo > 0 %}one{% endif %}"
   environment:
     foo: !ruby/object:IntegerDrop
+      context:
       value: 1
   expected: one
-  name: VariableTest#test_if_tag_calls_to_liquid_value_4d7497237e96cc216ae1c717c9b505a0
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L28
+  name: VariableTest#test_if_tag_calls_to_liquid_value_c7bedde7a87d2fff55db54c4932b51ed
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L29
+- template: "{% if b > a %}one{% endif %}"
+  environment:
+    b: !ruby/object:IntegerDrop
+      context:
+      value: 1
+    a: !ruby/object:IntegerDrop
+      context:
+      value: 0
+  expected: one
+  name: VariableTest#test_if_tag_calls_to_liquid_value_dfd7065ea36b42de2c306db14012b13a
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L30
+- template: "{% if foo %}true{% endif %}"
+  environment:
+    foo: !ruby/object:BooleanDrop
+      context:
+      value: true
+  expected: 'true'
+  name: VariableTest#test_if_tag_calls_to_liquid_value_f447761670b5c2d773923022adaa4b01
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L32
 - template: "{% if foo == true %}True{% endif %}"
   environment:
     foo: !ruby/object:BooleanDrop
+      context:
       value: false
   expected: ''
-  name: VariableTest#test_if_tag_calls_to_liquid_value_6c0cd1e642671ea7b6e283f811084132
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L33
+  name: VariableTest#test_if_tag_calls_to_liquid_value_f47059573449f8e6c2b37e69eaa8c827
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L35
+- template: "{% if foo == true %}true{% endif %}"
+  environment:
+    foo: !ruby/object:BooleanDrop
+      context:
+      value: true
+  expected: 'true'
+  name: VariableTest#test_if_tag_calls_to_liquid_value_f6b078efaabe9547fcf7bd0a97ee985b
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L31
 - template: "{% if foo == 1 %}one{% endif %}"
   environment:
     foo: !ruby/object:IntegerDrop
+      context:
       value: 1
   expected: one
-  name: VariableTest#test_if_tag_calls_to_liquid_value_91f99b1f712ed3004ec98b8a74a0713d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L26
-- template: "{% if foo %}true{% endif %}"
-  environment:
-    foo: !ruby/object:BooleanDrop
-      value: true
-  expected: 'true'
-  name: VariableTest#test_if_tag_calls_to_liquid_value_98a64f1924fcb653baa7db90dddea813
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L30
-- template: "{% if foo %}true{% endif %}"
-  environment:
-    foo: !ruby/object:BooleanDrop
-      value: false
-  expected: ''
-  name: VariableTest#test_if_tag_calls_to_liquid_value_bcb0e32adf5fe25a30f410769a02becd
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L32
+  name: VariableTest#test_if_tag_calls_to_liquid_value_fa12030e044d7921c5253d4632b87fd6
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L26
 - template: "{{ test }}"
   expected: ''
   name: VariableTest#test_ignore_unknown_ad89396513c52de6f5bf719e9a77c5ba
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L55
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L60
 - template: |-
     {{
     test
@@ -4777,111 +4870,125 @@
     test: worked
   expected: worked
   name: VariableTest#test_multiline_variable_682d8225441fb1e89699fdca1a9b62ef
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L119
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L124
 - template: "{{ nil }}"
   expected: ''
   name: VariableTest#test_nil_renders_as_empty_string_91cb0ea6dcb848a3ea50e7e129ea9b93
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L77
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L82
 - template: "{{ nil | append: 'cat' }}"
   expected: cat
   name: VariableTest#test_nil_renders_as_empty_string_e1b302a8bc456da410cf46756d94e1d4
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L78
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L83
 - template: "{{ [key] }}"
   environment:
     key: foo
     foo: bar
   expected: bar
   name: VariableTest#test_raw_value_variable_75643419e29cb2473b9dba4198911063
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L131
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L136
 - template: "{{ foo }}"
   environment:
     foo: :bar
   expected: bar
   name: VariableTest#test_render_symbol_138b625bf133e501bd8807c2b82b5a85
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L123
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L128
 - template: "{{test}}"
   environment:
     test: worked wonderfully
   expected: worked wonderfully
   name: VariableTest#test_simple_variable_0c34e0770c95f617ac47d672f9a9dd82
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L10
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L10
 - template: "{{test}}"
   environment:
     test: worked
   expected: worked
   name: VariableTest#test_simple_variable_8b77a0d902090fa4080327c77c48692c
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L9
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L9
 - template: "  {{ test }}  "
   environment:
     test: worked
   expected: "  worked  "
   name: VariableTest#test_simple_with_whitespaces_1daf90514a8fcf030b5cd19422d7c0ff
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L45
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L50
 - template: "  {{ test }}  "
   environment:
     test: worked wonderfully
   expected: "  worked wonderfully  "
   name: VariableTest#test_simple_with_whitespaces_4174b213f493994ea357914ea53e3ecf
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L46
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L51
 - template: "{% unless foo %}true{% endunless %}"
   environment:
     foo: !ruby/object:BooleanDrop
+      context:
       value: true
   expected: ''
-  name: VariableTest#test_unless_tag_calls_to_liquid_value_61de3f334f50223bc935d394ad607060
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L37
+  name: VariableTest#test_unless_tag_calls_to_liquid_value_789e7e9193662eba0c0c09e2088d3114
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L41
+- template: "{% unless foo %}true{% endunless %}"
+  environment:
+    foo: !ruby/object:BooleanDrop
+      context:
+      value: false
+  expected: 'true'
+  name: VariableTest#test_unless_tag_calls_to_liquid_value_a35b43d886e80109e7ad3906f5bcbecb
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L42
 - template: "{% assign foo = blank %}{{ foo }}"
   expected: ''
   name: VariableTest#test_using_blank_as_variable_name_0b1f6bd052e1da923605a6d29426866d
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L59
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L64
 - template: "{% assign foo = empty %}{{ foo }}"
   expected: ''
   name: VariableTest#test_using_empty_as_variable_name_b3c58ada434456d9b1a61d08b5750c32
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L63
-- template: "{{ foo }}"
-  environment:
-    foo: !ruby/object:IntegerDrop
-      value: 1
-  expected: '1'
-  name: VariableTest#test_variable_lookup_calls_to_liquid_value_8161b4b1655885acf0c1808f34e66f01
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L18
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L68
 - template: "{{ foo | upcase }}"
   environment:
     foo: !ruby/object:BooleanDrop
+      context:
       value: true
   expected: YAY
-  name: VariableTest#test_variable_lookup_calls_to_liquid_value_84310e3e9e13c4afecc0dfabf31152e3
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L22
+  name: VariableTest#test_variable_lookup_calls_to_liquid_value_2e348a3c21ad6ab509215cf216cef4c0
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L22
 - template: "{{ list[foo] }}"
   environment:
     foo: !ruby/object:IntegerDrop
+      context:
+      value: 1
+    list:
+      1: one
+  expected: one
+  name: VariableTest#test_variable_lookup_calls_to_liquid_value_6a9f495714d0684f13cb178c64aafbd0
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L20
+- template: "{{ list[foo] }}"
+  environment:
+    foo: !ruby/object:IntegerDrop
+      context:
       value: 1
     list:
     - 1
     - 2
     - 3
   expected: '2'
-  name: VariableTest#test_variable_lookup_calls_to_liquid_value_a241a0645195403891ab6ee598da1729
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L19
-- template: "{{ list[foo] }}"
+  name: VariableTest#test_variable_lookup_calls_to_liquid_value_9e53d638d5c66c91ceeff37353729550
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L19
+- template: "{{ foo }}"
   environment:
     foo: !ruby/object:IntegerDrop
+      context:
       value: 1
-    list:
-      1: one
-  expected: one
-  name: VariableTest#test_variable_lookup_calls_to_liquid_value_abd135d79c72750fdfcac65966b07684
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L20
+  expected: '1'
+  name: VariableTest#test_variable_lookup_calls_to_liquid_value_a2548b438b4c843ccfb7f858a1a8ac88
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L18
 - template: "{{ foo }}"
   environment:
     foo: !ruby/object:BooleanDrop
+      context:
       value: true
   expected: Yay
-  name: VariableTest#test_variable_lookup_calls_to_liquid_value_e2600a781fc12ce4be745ae0b110d6d2
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L21
+  name: VariableTest#test_variable_lookup_calls_to_liquid_value_a6c7ec95bec4b3f6b2bcea193e69a07c
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L21
 - template: "{{ foo }}"
   environment:
     foo: !ruby/object:ThingWithToLiquid {}
   expected: foobar
   name: VariableTest#test_variable_render_calls_to_liquid_1bdf410c9dc5f0350c74f7e2700f07b8
-  url: https://github.com/Shopify/liquid/blob/a39422feac532c245ceb9d6a15b8ac91d3d73431/test/integration/variable_test.rb#L14
+  url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/variable_test.rb#L14


### PR DESCRIPTION
Regenerate specs to include https://github.com/Shopify/liquid-spec/pull/47 & https://github.com/Shopify/liquid/pull/1674 to provide improved test coverage for https://github.com/Shopify/liquid-wasm/pull/664