### PR TITLE
add template names to context and templates for testing liquid error messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem 'liquid', git: "https://github.com/Shopify/liquid"
+  gem 'liquid', git: "https://github.com/Shopify/liquid", ref: "3ff4170cb0571648a4a46d45ad8de3875cfed75b"
   gem 'rake'
 end
 

--- a/lib/liquid/spec/adapter/liquid_ruby.rb
+++ b/lib/liquid/spec/adapter/liquid_ruby.rb
@@ -5,13 +5,23 @@ module Liquid
         def render(spec)
           static_registers = {
             file_system: MemoryFileSystem.new(spec.filesystem),
+            template_factory: StubTemplateFactory.new,
           }
           context = Liquid::Context.build(
             static_environments: spec.environment,
-            registers: Liquid::Registers.new(static_registers)
+            registers: Liquid::Registers.new(static_registers),
           )
           template = Liquid::Template.parse(spec.template, error_mode: spec.error_mode, line_numbers: true)
+          context.template_name = "templates/index"
           template.render(context)
+        end
+      end
+
+      class StubTemplateFactory
+        def for(template_name)
+          template = Liquid::Template.new
+          template.name = "snippets/" + template_name
+          template
         end
       end
 

--- a/specs/liquid_ruby/specs.yml
+++ b/specs/liquid_ruby/specs.yml
@@ -2288,17 +2288,17 @@
     details: details
   url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L140
 - template: "{% include 123 %}"
-  expected: 'Liquid error (line 1): Argument error in tag ''include'' - Illegal template
+  expected: 'Liquid error (templates/index line 1): Argument error in tag ''include'' - Illegal template
     name'
   name: IncludeTagTest#test_render_raise_argument_error_when_template_is_not_a_string_403d47cecd937950631d8e1d59cc7382
   url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L253
 - template: "{% include undefined_variable %}"
-  expected: 'Liquid error (line 1): Argument error in tag ''include'' - Illegal template
+  expected: 'Liquid error (templates/index line 1): Argument error in tag ''include'' - Illegal template
     name'
   name: IncludeTagTest#test_render_raise_argument_error_when_template_is_undefined_4d409c2d09f126f67a94ab048a80ae31
   url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L245
 - template: "{% include nil %}"
-  expected: 'Liquid error (line 1): Argument error in tag ''include'' - Illegal template
+  expected: 'Liquid error (templates/index line 1): Argument error in tag ''include'' - Illegal template
     name'
   name: IncludeTagTest#test_render_raise_argument_error_when_template_is_undefined_fd16a0e80355cc8e550ad10d246f6339
   url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/include_tag_test.rb#L248
@@ -2618,8 +2618,8 @@
     decr: "{% decrement %}"
   url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L115
 - template: '{% render "nested_render_with_sibling_include" %}'
-  expected: 'Liquid error (test_include line 1): include usage is not allowed in this
-    contextLiquid error (nested_render_with_sibling_include line 1): include usage
+  expected: 'Liquid error (snippets/test_include line 1): include usage is not allowed in this
+    contextLiquid error (snippets/nested_render_with_sibling_include line 1): include usage
     is not allowed in this context'
   name: RenderTagTest#test_includes_will_not_render_inside_nested_sibling_tags_7252ebefc8aeddf28f05d56a12bfbb15
   filesystem:
@@ -2629,7 +2629,7 @@
     test_include: '{% include "foo" %}'
   url: https://github.com/Shopify/liquid/blob/e804f36681015c2fc9605e1b3049a832310be62f/test/integration/tags/render_tag_test.rb#L132
 - template: '{% render "test_include" %}'
-  expected: 'Liquid error (test_include line 1): include usage is not allowed in this
+  expected: 'Liquid error (snippets/test_include line 1): include usage is not allowed in this
     context'
   name: RenderTagTest#test_includes_will_not_render_inside_render_tag_6adab3b1d0532bc84aa45d1fbeb048f4
   filesystem:


### PR DESCRIPTION
main issue: https://github.com/Shopify/liquid-wasm/issues/715

Since LiquidWASM always renders with error line numbers with template path, `Spec::Adapter:: LiquidRuby` has been updated to default the context's template name to  `templates/index`, and set partial render template's name to `snippets/{template_name}`