### PR TITLE
Use case insensitive filesystem lookups to match Shopify's implementation

### DIFF
--- a/lib/liquid/spec/adapter/liquid_ruby.rb
+++ b/lib/liquid/spec/adapter/liquid_ruby.rb
@@ -28,12 +28,18 @@ module Liquid
       MemoryFileSystem = Struct.new(:data) do
         def read_template_file(template_path)
           name = template_path.to_s
-          data.fetch(name) do
-            # Report the same error as in storefront-renderer
-            # (https://github.com/Shopify/storefront-renderer/blob/9014ee25828c6c5f5e8fec278dd0cd6fd04d803b/app/models/theme.rb#L416)
-            full_name = "snippets/#{name.end_with?('.liquid') ? name : "#{name}.liquid"}"
-            raise Liquid::FileSystemError, "Could not find asset #{full_name}"
+
+          body = data[name]
+          return body if body
+
+          data.each do |key, body|
+            return body if key.casecmp?(name)
           end
+
+          # Report the same error as in storefront-renderer
+          # (https://github.com/Shopify/storefront-renderer/blob/9014ee25828c6c5f5e8fec278dd0cd6fd04d803b/app/models/theme.rb#L416)
+          full_name = "snippets/#{name.end_with?('.liquid') ? name : "#{name}.liquid"}"
+          raise Liquid::FileSystemError, "Could not find asset #{full_name}"
         end
       end
     end


### PR DESCRIPTION
## Problem

Shopify's liquid filesystem implementation does case insensitive lookups, but liquid-spec's MemoryFileSystem was doing case sensitive Hash#fetch lookups.

## Solution

On a Hash#fetch miss, fallback to iterating over the key to find a matching one with String#casecmp?