### PR TITLE
Invert feature gating: `required_features` → `missing_features`

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,3 +20,5 @@ jobs:
       run: bundle exec rake test
     - name: Run liquid-spec
       run: bundle exec rake run
+    - name: Check feature tag coverage
+      run: bundle exec rake coverage_check

--- a/README.md
+++ b/README.md
@@ -90,10 +90,9 @@ LiquidSpec.setup do
   require "my_liquid"
 end
 
-# Declare which features you support
+# Declare what your adapter can't handle (default: run everything)
 LiquidSpec.configure do |config|
-  config.features = [:core]  # enables liquid_ruby suite
-  # Add :shopify_tags, :shopify_objects, :shopify_filters for Shopify themes
+  config.missing_features = [:shopify_tags, :shopify_filters]
 end
 
 # Parse template source into a template object
@@ -146,15 +145,15 @@ Each spec includes a detailed `hint` explaining how the feature should be implem
 
 ### Feature-Based Suite Selection
 
-Suites run based on feature declarations:
+Suites run by default. Declare what your adapter can't handle to skip specific specs:
 
 ```ruby
 LiquidSpec.configure do |config|
-  # Just core Liquid (liquid_ruby + shopify_production_recordings)
-  config.features = [:core]
-  
-  # Full Shopify theme support (adds shopify_theme_dawn)
-  config.features = [:core, :shopify_tags, :shopify_objects, :shopify_filters]
+  # Run everything (default — empty denylist)
+  config.missing_features = []
+
+  # Skip Shopify-specific specs (for adapters without Shopify extensions)
+  config.missing_features = [:shopify_tags, :shopify_objects, :shopify_filters]
 end
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,60 @@ task :matrix do
   system("bundle", "exec", "ruby", "bin/liquid-spec", "matrix", "--all") || abort
 end
 
+desc "Verify every spec feature tag is covered by at least one reference adapter"
+task :coverage_check do
+  require "yaml"
+  require "set"
+
+  base = File.expand_path(__dir__)
+
+  # Collect all feature tags used across spec YAML files
+  spec_tags = Set.new
+  Dir.glob(File.join(base, "specs/**/*.yml")).each do |f|
+    begin
+      data = YAML.safe_load(File.read(f), permitted_classes: [Symbol, Range], aliases: true)
+      next unless data
+
+      meta = data.is_a?(Hash) ? (data["_metadata"] || {}) : {}
+      (meta["features"] || []).each { |t| spec_tags << t.to_sym }
+
+      specs = data.is_a?(Hash) ? (data["specs"] || []) : (data.is_a?(Array) ? data : [])
+      specs.each do |spec|
+        (spec["features"] || []).each { |t| spec_tags << t.to_sym } if spec.is_a?(Hash)
+      end
+    rescue
+    end
+  end
+
+  # Extract missing_features from each reference adapter via static analysis.
+  # We parse the config.missing_features = [...] line rather than loading the
+  # adapter (which would require all adapter dependencies to be installed).
+  adapter_files = Dir.glob(File.join(base, "examples/*.rb"))
+  adapter_missing = {}
+  adapter_files.each do |path|
+    source = File.read(path)
+    if (m = source.match(/config\.missing_features\s*=\s*\[(.*?)\]/m))
+      symbols = m[1].scan(/:(\w+)/).flatten.map(&:to_sym)
+      adapter_missing[File.basename(path)] = symbols.to_set
+    end
+  end
+
+  if adapter_missing.empty?
+    abort "Coverage check FAILED — no reference adapters found in examples/"
+  end
+
+  # Check: every tag must be NOT-missing in at least one adapter
+  orphans = spec_tags.reject do |tag|
+    adapter_missing.any? { |_, missing| !missing.include?(tag) }
+  end
+
+  if orphans.any?
+    abort "Coverage check FAILED — no reference adapter covers these tags:\n  #{orphans.sort.join(', ')}\n\nAdd an example adapter that does not include these in missing_features."
+  else
+    puts "Coverage check passed: all #{spec_tags.size} feature tags covered across #{adapter_missing.size} reference adapters."
+  end
+end
+
 # Spec generation tasks (only needed for development)
 import("tasks/liquid_ruby.rake")
 import("tasks/standard_filters.rake")

--- a/examples/json_rpc_ruby_liquid.rb
+++ b/examples/json_rpc_ruby_liquid.rb
@@ -45,7 +45,7 @@ end
 LiquidSpec.configure do |config|
   # JSON-RPC adapters support core features including runtime_drops
   # because they implement bidirectional callbacks
-  config.features = [:core, :strict_parsing]
+  config.missing_features = [:ruby_types, :ruby_drops, :binary_data, :lax_parsing, :activesupport, :template_factory, :shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_c.rb
+++ b/examples/liquid_c.rb
@@ -36,7 +36,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :lax_parsing]
+  config.missing_features = [:runtime_drops, :ruby_types, :ruby_drops, :binary_data, :activesupport, :template_factory, :shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_c_strict.rb
+++ b/examples/liquid_c_strict.rb
@@ -24,7 +24,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :strict_parsing]
+  config.missing_features = [:runtime_drops, :ruby_types, :ruby_drops, :binary_data, :lax_parsing, :activesupport, :template_factory, :shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_ruby.rb
+++ b/examples/liquid_ruby.rb
@@ -19,7 +19,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :strict_parsing, :strict2_parsing, :ruby_types]
+  config.missing_features = [:shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access, :activesupport, :lax_parsing]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_ruby_activesupport.rb
+++ b/examples/liquid_ruby_activesupport.rb
@@ -24,7 +24,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :activesupport, :strict_parsing]
+  config.missing_features = [:shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access, :lax_parsing]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_ruby_lax.rb
+++ b/examples/liquid_ruby_lax.rb
@@ -19,7 +19,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :lax_parsing]
+  config.missing_features = [:shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access, :activesupport]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_ruby_lax_activesupport.rb
+++ b/examples/liquid_ruby_lax_activesupport.rb
@@ -24,7 +24,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :lax_parsing, :activesupport]
+  config.missing_features = [:shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_ruby_shopify.rb
+++ b/examples/liquid_ruby_shopify.rb
@@ -183,7 +183,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :strict_parsing, :ruby_types, :shopify_filters]
+  config.missing_features = [:lax_parsing]
   config.suites = [:benchmarks]
   config.filter = "shopify_"
 end

--- a/examples/liquid_ruby_yjit.rb
+++ b/examples/liquid_ruby_yjit.rb
@@ -21,7 +21,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :strict_parsing, :strict2_parsing, :ruby_types]
+  config.missing_features = [:shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access, :activesupport, :lax_parsing]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/examples/liquid_ruby_zjit.rb
+++ b/examples/liquid_ruby_zjit.rb
@@ -21,7 +21,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.features = [:core, :strict_parsing, :strict2_parsing, :ruby_types]
+  config.missing_features = [:shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access, :activesupport, :lax_parsing]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/lib/liquid/spec/adapter_runner.rb
+++ b/lib/liquid/spec/adapter_runner.rb
@@ -10,11 +10,11 @@ module Liquid
       TEST_TIME = Time.utc(2024, 1, 1, 0, 1, 58).freeze
       TEST_TZ = "America/New_York"
 
-      attr_reader :name, :features, :ctx
+      attr_reader :name, :missing_features, :ctx
 
       def initialize(name: nil)
         @name = name
-        @features = Set.new([:core])
+        @missing_features = Set.new
         @setup_block = nil
         @compile_block = nil
         @render_block = nil
@@ -43,8 +43,8 @@ module Liquid
         @render_block = ::LiquidSpec.instance_variable_get(:@render_block)
 
         config = ::LiquidSpec.instance_variable_get(:@config)
-        if config&.respond_to?(:features)
-          set_features(config.features)
+        if config&.respond_to?(:missing_features)
+          set_missing_features(config.missing_features)
         end
 
         # Validate block signatures
@@ -145,15 +145,14 @@ module Liquid
         @render_block = block
       end
 
-      # Set features
-      def set_features(features)
-        @features = Set.new(features.map(&:to_sym))
-        @features << :core unless @features.include?(:core)
+      # Set missing features
+      def set_missing_features(missing_features)
+        @missing_features = Set.new(missing_features.map(&:to_sym))
       end
 
       # Check if adapter can run a spec
       def can_run?(spec)
-        spec.runnable_with?(@features)
+        !spec.skipped_by?(@missing_features)
       end
 
       # Run a batch of specs
@@ -189,7 +188,7 @@ module Liquid
           return SpecResult.new(
             spec: spec,
             status: :skipped,
-            reason: "Missing features: #{(spec.required_features - @features.to_a).join(", ")}",
+            reason: "Adapter does not support: #{(spec.features & @missing_features.to_a).join(", ")}",
           )
         end
 

--- a/lib/liquid/spec/cli/adapter_dsl.rb
+++ b/lib/liquid/spec/cli/adapter_dsl.rb
@@ -13,7 +13,7 @@ require "timeout"
 #
 #   LiquidSpec.configure do |config|
 #     config.suite = :liquid_ruby
-#     config.features = [:core, :lax_parsing]
+#     config.missing_features = [:shopify_tags]
 #   end
 #
 #   LiquidSpec.compile do |ctx, source, parse_options|
@@ -67,19 +67,9 @@ module LiquidSpec
     shopify_error_handling: "Shopify-specific error handling and recovery behavior",
   }.freeze
 
-  # Feature expansions - declaring a feature automatically includes these
-  # :core is the "full implementation" feature that includes runtime drop support
-  # JSON-RPC adapters that can't support runtime drops should not declare :core
-  FEATURE_EXPANSIONS = {
-    core: [:runtime_drops, :inline_errors],
-  }.freeze
-
-  # Default features when no config is set (matches Configuration defaults after expansion)
-  DEFAULT_FEATURES = [:core, :runtime_drops, :inline_errors].freeze
-
   class Configuration
     attr_accessor :suite, :filter, :verbose, :strict_only
-    attr_reader :features, :known_failures, :suites
+    attr_reader :missing_features, :known_failures, :suites
 
     def initialize
       @suite = :all
@@ -87,9 +77,8 @@ module LiquidSpec
       @filter = nil
       @verbose = false
       @strict_only = false
-      @features = [:core]
+      @missing_features = []
       @known_failures = []
-      expand_features!
     end
 
     # Set multiple suites to run (overrides suite)
@@ -97,27 +86,16 @@ module LiquidSpec
       @suites = Array(list).map(&:to_sym)
     end
 
-    def features=(list)
-      @features = Array(list).map(&:to_sym)
-      expand_features!
+    def missing_features=(list)
+      @missing_features = Array(list).map(&:to_sym)
     end
 
     def known_failures=(list)
       @known_failures = Array(list).map(&:to_s)
     end
 
-    def feature?(name)
-      @features.include?(name.to_sym)
-    end
-
-    private
-
-    def expand_features!
-      FEATURE_EXPANSIONS.each do |feature, includes|
-        if @features.include?(feature)
-          @features |= includes
-        end
-      end
+    def missing_feature?(name)
+      @missing_features.include?(name.to_sym)
     end
   end
 
@@ -140,8 +118,8 @@ module LiquidSpec
       @config
     end
 
-    def features
-      @config&.instance_variable_get(:@features) || DEFAULT_FEATURES
+    def missing_features
+      @config&.instance_variable_get(:@missing_features) || []
     end
 
     # Declare Ruby flags this adapter needs (e.g. "--yjit").

--- a/lib/liquid/spec/cli/features.rb
+++ b/lib/liquid/spec/cli/features.rb
@@ -117,10 +117,10 @@ module Liquid
           puts "liquid-spec Features"
           puts "=" * 60
           puts
-          puts "Features control which specs are run. Declare them in your adapter:"
+          puts "Features are tags on specs. Declare what your adapter can't run:"
           puts
           puts "  LiquidSpec.configure do |config|"
-          puts "    config.features = [:core, :strict_parsing]"
+          puts "    config.missing_features = [:shopify_tags, :shopify_filters]"
           puts "  end"
           puts
           puts "-" * 60
@@ -147,8 +147,8 @@ module Liquid
             puts "    #{feature}: #{count}"
           end
           puts
-          puts "Recommended starter config:"
-          puts "  config.features = [:core, :strict_parsing]"
+          puts "Adapter with no limitations (runs all specs):"
+          puts "  config.missing_features = []"
           puts
         end
 
@@ -167,9 +167,9 @@ module Liquid
               specs.each do |spec|
                 next unless spec.is_a?(Hash)
 
-                # Get required features from spec or metadata
-                features = spec["required_features"] ||
-                           (metadata && metadata["required_features"]) ||
+                # Get features from spec or metadata
+                features = spec["features"] ||
+                           (metadata && metadata["features"]) ||
                            []
 
                 features = [features] unless features.is_a?(Array)

--- a/lib/liquid/spec/cli/runner.rb
+++ b/lib/liquid/spec/cli/runner.rb
@@ -226,13 +226,13 @@ module Liquid
 
             Liquid::Spec::Suite.all.each do |suite|
               default_marker = suite.default? ? " (default)" : ""
-              runnable = suite.runnable_with?(config.features)
-              status = runnable ? "" : " [missing features: #{suite.missing_features(config.features).join(", ")}]"
+              skipped = suite.skipped_by?(config.missing_features)
+              status = skipped ? " [adapter opts out of: #{(suite.features & config.missing_features.to_a).join(", ")}]" : ""
 
               puts "  #{suite.id}#{default_marker}#{status}"
               puts "    #{suite.description}" if suite.description && config.verbose
-              if config.verbose && suite.required_features.any?
-                puts "    Required features: #{suite.required_features.join(", ")}"
+              if config.verbose && suite.features.any?
+                puts "    Required features: #{suite.features.join(", ")}"
               end
             end
           end
@@ -285,31 +285,31 @@ module Liquid
             require "liquid/spec"
             require "liquid/spec/deps/liquid_ruby"
 
-            features = config.features
-            puts "Features: #{features.join(", ")}"
+            missing_features = config.missing_features
+            puts "Missing features: #{missing_features.join(", ")}"
 
             # Count available specs from all sources
             has_prioritized = options[:add_specs] && !options[:add_specs].empty?
             prioritized_specs = has_prioritized ? load_additional_specs(options[:add_specs]) : []
             prioritized_specs = filter_specs(prioritized_specs, config.filter) if config.filter && prioritized_specs.any?
-            prioritized_specs = filter_by_features(prioritized_specs, features) if prioritized_specs.any?
+            prioritized_specs = filter_by_missing(prioritized_specs, missing_features) if prioritized_specs.any?
 
             # Auto-discover local specs from ./specs/*.yml
             local_specs = discover_local_specs
             local_specs = filter_specs(local_specs, config.filter) if config.filter && local_specs.any?
-            local_specs = filter_by_features(local_specs, features) if local_specs.any?
+            local_specs = filter_by_missing(local_specs, missing_features) if local_specs.any?
             if local_specs.any?
               puts "Auto-including: #{local_specs.size} specs from ./specs/*.yml"
             end
 
             # Group specs by suite
-            suites_to_run = determine_suites(config, features)
+            suites_to_run = determine_suites(config, missing_features)
 
             # Check if there's anything to run
             suite_specs_exist = suites_to_run.any? do |suite|
               suite_specs = Liquid::Spec::SpecLoader.load_suite(suite)
               suite_specs = filter_specs(suite_specs, config.filter) if config.filter
-              suite_specs = filter_by_features(suite_specs, features)
+              suite_specs = filter_by_missing(suite_specs, missing_features)
               suite_specs.any?
             end
 
@@ -375,7 +375,7 @@ module Liquid
               end
 
               suite_specs = filter_specs(suite_specs, config.filter) if config.filter
-              suite_specs = filter_by_features(suite_specs, features)
+              suite_specs = filter_by_missing(suite_specs, missing_features)
               suite_specs = sort_by_complexity(suite_specs)
 
               next if suite_specs.empty?
@@ -453,7 +453,7 @@ module Liquid
             log_file.close
 
             # Show skipped suites
-            show_skipped_suites(config, features)
+            show_skipped_suites(config, missing_features)
 
             # Print unexpected failures
             print_failures(all_failures, max_failures)
@@ -508,12 +508,12 @@ module Liquid
               return
             end
 
-            features = config.features
+            missing_features = config.missing_features
             puts "Compare mode: checking adapter against reference liquid-ruby"
-            puts "Features: #{features.join(", ")}"
+            puts "Missing features: #{missing_features.join(", ")}"
             puts ""
 
-            suites_to_run = determine_suites(config, features)
+            suites_to_run = determine_suites(config, missing_features)
 
             total_same = 0
             total_different = 0
@@ -524,7 +524,7 @@ module Liquid
             suites_to_run.each do |suite|
               suite_specs = Liquid::Spec::SpecLoader.load_suite(suite)
               suite_specs = filter_specs(suite_specs, config.filter) if config.filter
-              suite_specs = filter_by_features(suite_specs, features)
+              suite_specs = filter_by_missing(suite_specs, missing_features)
               suite_specs = sort_by_complexity(suite_specs)
 
               next if suite_specs.empty?
@@ -585,7 +585,7 @@ module Liquid
           private
 
           def run_benchmark_suites(suites, config, options)
-            features = config.features
+            missing_features = config.missing_features
             profile_dir = nil
             run_id = ENV["LIQUID_SPEC_RUN_ID"] || Time.now.strftime("%Y%m%d_%H%M%S")
             jsonl_mode = options[:jsonl] || ENV["LIQUID_SPEC_BENCHMARK_JSONL"] == "1"
@@ -614,7 +614,7 @@ module Liquid
             suites.each do |suite|
               suite_specs = Liquid::Spec::SpecLoader.load_suite(suite)
               suite_specs = filter_specs(suite_specs, config.filter) if config.filter
-              suite_specs = filter_by_features(suite_specs, features)
+              suite_specs = filter_by_missing(suite_specs, missing_features)
               next if suite_specs.empty?
 
               duration_per_spec = suite.default_iteration_seconds
@@ -1129,27 +1129,27 @@ module Liquid
             end
           end
 
-          def determine_suites(config, features)
+          def determine_suites(config, missing_features)
             # Adapter can request specific suites via config.suites = [:benchmarks, ...]
             if config.suites&.any?
               config.suites.filter_map { |id| Liquid::Spec::Suite.find(id) }
-                .select { |s| s.runnable_with?(features) }
+                .reject { |s| s.skipped_by?(missing_features) }
             elsif config.suite != :all
               specific_suite = Liquid::Spec::Suite.find(config.suite)
               specific_suite ? [specific_suite] : []
             else
               Liquid::Spec::Suite.defaults
-                .select { |s| s.runnable_with?(features) }
+                .reject { |s| s.skipped_by?(missing_features) }
                 .sort_by { |s| s.id == :basics ? "" : s.id.to_s }
             end
           end
 
-          def run_additional_specs(options, config, features, known_failures, all_failures, all_known_failures, all_known_fixed)
+          def run_additional_specs(options, config, missing_features, known_failures, all_failures, all_known_failures, all_known_fixed)
             return [0, 0, 0, 0, 0] if options[:add_specs].nil? || options[:add_specs].empty?
 
             additional_specs = load_additional_specs(options[:add_specs])
             additional_specs = filter_specs(additional_specs, config.filter) if config.filter
-            additional_specs = filter_by_features(additional_specs, features)
+            additional_specs = filter_by_missing(additional_specs, missing_features)
             additional_specs = sort_by_complexity(additional_specs)
 
             return [0, 0, 0, 0, 0] if additional_specs.empty?
@@ -1210,12 +1210,12 @@ module Liquid
             [passed, failed, errors, known_failed, known_fixed]
           end
 
-          def show_skipped_suites(config, features)
-            skipped = Liquid::Spec::Suite.defaults.select { |s| !s.runnable_with?(features) }
+          def show_skipped_suites(config, missing_features)
+            skipped = Liquid::Spec::Suite.defaults.select { |s| s.skipped_by?(missing_features) }
             skipped.each do |suite|
-              missing = suite.missing_features(features)
+              opted_out = suite.features & missing_features.to_a
               suite_name_padded = "#{suite.name} ".ljust(40, ".")
-              puts "#{suite_name_padded} skipped (needs #{missing.join(", ")})"
+              puts "#{suite_name_padded} skipped (adapter opts out of: #{opted_out.join(", ")})"
             end
           end
 
@@ -1626,12 +1626,12 @@ module Liquid
             require "liquid/spec"
 
             suite_id = config.suite
-            features = config.features
+            missing_features = config.missing_features
 
             case suite_id
             when :all
               Liquid::Spec::Suite.defaults
-                .select { |s| s.runnable_with?(features) }
+                .reject { |s| s.skipped_by?(missing_features) }
                 .flat_map { |s| Liquid::Spec::SpecLoader.load_suite(s) }
             else
               suite = Liquid::Spec::Suite.find(suite_id)
@@ -1642,10 +1642,10 @@ module Liquid
                 exit(1)
               end
 
-              unless suite.runnable_with?(features)
-                missing = suite.missing_features(features)
-                $stderr.puts "Suite '#{suite_id}' requires features not supported by this adapter:"
-                $stderr.puts "  Missing: #{missing.join(", ")}"
+              if suite.skipped_by?(missing_features)
+                opted_out = suite.features & missing_features.to_a
+                $stderr.puts "Suite '#{suite_id}' requires features opted out of by this adapter:"
+                $stderr.puts "  Opted out: #{opted_out.join(", ")}"
                 exit(1)
               end
 
@@ -1671,9 +1671,9 @@ module Liquid
             specs
           end
 
-          def filter_by_features(specs, features)
-            feature_set = Set.new(features.map(&:to_sym))
-            specs.select { |s| s.runnable_with?(feature_set) }
+          def filter_by_missing(specs, missing_features)
+            missing_set = Set.new(missing_features.map(&:to_sym))
+            specs.reject { |s| s.skipped_by?(missing_set) }
           end
 
           def parse_filter_pattern(pattern)

--- a/lib/liquid/spec/deps/liquid_ruby.rb
+++ b/lib/liquid/spec/deps/liquid_ruby.rb
@@ -77,25 +77,33 @@ class ToSDrop < Liquid::Drop
   #   {"instantiate:ToSDrop" => {"to_s" => "hello"}}
   #   # to_s returns "hello"
   #
-  # Also accepts "foo" param for legacy TestThing compatibility:
+  # Legacy TestThing format: foo is a counter, incremented on each to_s call.
+  # This lets specs verify that to_s was actually called by the filter.
   #   {"instantiate:ToSDrop" => {"foo" => 3}}
-  #   # to_s returns "woot: 3"
+  #   # first to_s call: counter becomes 4, returns "woot: 4"
 
   def initialize(params = {})
     params = { "to_s" => params } unless params.is_a?(Hash)
 
-    @to_s_value = if params.key?("to_s") || params.key?(:to_s)
-      params["to_s"] || params[:to_s] || ""
+    if params.key?("to_s") || params.key?(:to_s)
+      @to_s_value = params["to_s"] || params[:to_s] || ""
+      @counter = nil
     elsif params.key?("foo") || params.key?(:foo)
-      # Legacy TestThing format
-      "woot: #{params["foo"] || params[:foo]}"
+      @counter = params["foo"] || params[:foo]
+      @to_s_value = nil
     else
-      ""
+      @to_s_value = ""
+      @counter = nil
     end
   end
 
   def to_s
-    @to_s_value.to_s
+    if @counter
+      @counter += 1
+      "woot: #{@counter}"
+    else
+      @to_s_value.to_s
+    end
   end
 
   def to_liquid

--- a/lib/liquid/spec/deps/liquid_ruby.rb
+++ b/lib/liquid/spec/deps/liquid_ruby.rb
@@ -77,36 +77,38 @@ class ToSDrop < Liquid::Drop
   #   {"instantiate:ToSDrop" => {"to_s" => "hello"}}
   #   # to_s returns "hello"
   #
-  # Legacy TestThing format: foo is a counter, incremented on each to_s call.
-  # This lets specs verify that to_s was actually called by the filter.
+  # Legacy TestThing format: foo is a starting counter; to_liquid increments it.
+  # This lets specs verify that to_liquid was called by the filter pipeline.
   #   {"instantiate:ToSDrop" => {"foo" => 3}}
-  #   # first to_s call: counter becomes 4, returns "woot: 4"
+  #   # after one to_liquid call, to_s returns "woot: 4"
+  #   # after two to_liquid calls, to_s returns "woot: 5"
 
   def initialize(params = {})
     params = { "to_s" => params } unless params.is_a?(Hash)
 
     if params.key?("to_s") || params.key?(:to_s)
       @to_s_value = params["to_s"] || params[:to_s] || ""
-      @counter = nil
+      @initial_foo = nil
     elsif params.key?("foo") || params.key?(:foo)
-      @counter = params["foo"] || params[:foo]
+      @initial_foo = params["foo"] || params[:foo]
+      @call_count = 0
       @to_s_value = nil
     else
       @to_s_value = ""
-      @counter = nil
+      @initial_foo = nil
     end
   end
 
   def to_s
-    if @counter
-      @counter += 1
-      "woot: #{@counter}"
+    if @initial_foo
+      "woot: #{@initial_foo + @call_count}"
     else
       @to_s_value.to_s
     end
   end
 
   def to_liquid
+    @call_count += 1 if @initial_foo
     self
   end
 end

--- a/lib/liquid/spec/deps/liquid_ruby.rb
+++ b/lib/liquid/spec/deps/liquid_ruby.rb
@@ -111,6 +111,10 @@ class ToSDrop < Liquid::Drop
     @call_count += 1 if @initial_foo
     self
   end
+
+  def [](_key)
+    to_s
+  end
 end
 
 class TestDrop < Liquid::Drop

--- a/lib/liquid/spec/lazy_spec.rb
+++ b/lib/liquid/spec/lazy_spec.rb
@@ -28,7 +28,7 @@ module Liquid
       VALID_ERROR_KEYS = ["parse_error", "render_error", "output"].freeze
 
       attr_reader :name, :template, :template_name, :expected, :expected_pattern, :errors, :hint, :doc, :complexity
-      attr_reader :error_mode, :render_errors, :required_features
+      attr_reader :error_mode, :render_errors, :features
       attr_reader :source_file, :line_number
       attr_reader :raw_environment, :raw_filesystem, :raw_template_factory, :raw_resource_limits
 
@@ -44,7 +44,7 @@ module Liquid
         complexity: 1000,
         error_mode: nil,
         render_errors: false,
-        required_features: [],
+        features: [],
         source_file: nil,
         line_number: nil,
         raw_environment: {},
@@ -65,7 +65,7 @@ module Liquid
         @complexity = complexity
         @error_mode = error_mode || source_required_options[:error_mode]
         @render_errors = render_errors
-        @required_features = Array(required_features).map(&:to_sym)
+        @features = Array(features).map(&:to_sym)
         @source_file = source_file
         @line_number = line_number
         @raw_environment = raw_environment || {}
@@ -76,12 +76,12 @@ module Liquid
         @source_required_options = source_required_options || {}
 
         # Add parsing mode requirement based on error_mode
-        if @error_mode == :lax && !@required_features.include?(:lax_parsing)
-          @required_features << :lax_parsing
-        elsif @error_mode == :strict && !@required_features.include?(:strict_parsing)
-          @required_features << :strict_parsing
-        elsif @error_mode == :strict2 && !@required_features.include?(:strict2_parsing)
-          @required_features << :strict2_parsing
+        if @error_mode == :lax && !@features.include?(:lax_parsing)
+          @features << :lax_parsing
+        elsif @error_mode == :strict && !@features.include?(:strict_parsing)
+          @features << :strict_parsing
+        elsif @error_mode == :strict2 && !@features.include?(:strict2_parsing)
+          @features << :strict2_parsing
         end
       end
 
@@ -96,21 +96,10 @@ module Liquid
         end
       end
 
-      # Check if this spec requires a specific feature
-      def requires_feature?(feature)
-        required_features.include?(feature.to_sym)
-      end
-
-      # Check if spec can run with given features
-      def runnable_with?(features)
-        feature_set = features.is_a?(Set) ? features : Set.new(features.map(&:to_sym))
-        required_features.all? { |f| feature_set.include?(f) }
-      end
-
-      # List of missing features
-      def missing_features(features)
-        features_set = features.map(&:to_sym).to_set
-        required_features.reject { |f| features_set.include?(f) }
+      # Returns true if the adapter's missing_features prevent this spec from running
+      def skipped_by?(missing_features)
+        missing_set = missing_features.is_a?(Set) ? missing_features : Set.new(missing_features.map(&:to_sym))
+        features.any? { |f| missing_set.include?(f) }
       end
 
       # Check if this spec expects a parse error

--- a/lib/liquid/spec/spec_loader.rb
+++ b/lib/liquid/spec/spec_loader.rb
@@ -53,10 +53,10 @@ module Liquid
     module SpecLoader
       # Valid keys at each level - unknown keys raise errors
       VALID_FILE_KEYS = %w[_metadata specs].freeze
-      VALID_METADATA_KEYS = %w[hint doc required_options render_errors minimum_complexity complexity required_features data_files].freeze
+      VALID_METADATA_KEYS = %w[hint doc required_options render_errors minimum_complexity complexity features data_files].freeze
       VALID_SPEC_KEYS = %w[
         name template expected expected_pattern environment filesystem complexity hint doc
-        error_mode render_errors required_features errors template_name resource_limits
+        error_mode render_errors features errors template_name resource_limits
       ].freeze
 
       class << self
@@ -195,7 +195,7 @@ module Liquid
           source_doc = metadata["doc"]
           source_required_options = (metadata["required_options"] || {}).transform_keys(&:to_sym)
           minimum_complexity = suite&.minimum_complexity || metadata["minimum_complexity"] || metadata["complexity"] || 1000
-          source_required_features = (metadata["required_features"] || []).map(&:to_s)
+          source_features = (metadata["features"] || []).map(&:to_s)
 
           # Suite defaults
           suite_defaults = suite&.defaults || {}
@@ -253,7 +253,7 @@ module Liquid
               complexity: spec_data["complexity"] || minimum_complexity,
               error_mode: spec_error_mode,
               render_errors: spec_render_errors || false,
-              required_features: (source_required_features + (spec_data["required_features"] || [])).uniq,
+              features: (source_features + (spec_data["features"] || [])).uniq,
               source_file: path,
               line_number: spec_line_number,
               raw_environment: raw_env,
@@ -314,7 +314,7 @@ module Liquid
             complexity: minimum_complexity,
             error_mode: nil,
             render_errors: false,
-            required_features: suite&.required_features || [],
+            features: suite&.features || [],
             source_file: template_file,
             line_number: nil,
             raw_environment: raw_environment,

--- a/lib/liquid/spec/suite.rb
+++ b/lib/liquid/spec/suite.rb
@@ -8,7 +8,7 @@ module Liquid
     class Suite
       SUITE_FILE = "suite.yml"
 
-      attr_reader :path, :name, :description, :hint, :required_features, :defaults, :minimum_complexity,
+      attr_reader :path, :name, :description, :hint, :features, :defaults, :minimum_complexity,
         :default_iteration_seconds
 
       def initialize(path)
@@ -17,7 +17,7 @@ module Liquid
         @name = @config["name"] || File.basename(path)
         @description = @config["description"]
         @hint = @config["hint"]
-        @required_features = (@config["required_features"] || []).map(&:to_sym)
+        @features = (@config["features"] || []).map(&:to_sym)
         @defaults = (@config["defaults"] || {}).transform_keys(&:to_sym)
         @minimum_complexity = @config["minimum_complexity"]
         @timings = @config["timings"] || false
@@ -34,18 +34,12 @@ module Liquid
         @config.fetch("default", true)
       end
 
-      # Check if this suite can run with the given features
-      def runnable_with?(features)
-        return true if required_features.empty?
+      # Check if this suite should be skipped given a set of missing features
+      def skipped_by?(missing_features)
+        return false if features.empty?
 
-        features_set = features.map(&:to_sym).to_set
-        required_features.all? { |f| features_set.include?(f) }
-      end
-
-      # List of missing features
-      def missing_features(features)
-        features_set = features.map(&:to_sym).to_set
-        required_features.reject { |f| features_set.include?(f) }
+        missing_set = missing_features.is_a?(Set) ? missing_features : Set.new(missing_features.map(&:to_sym))
+        features.any? { |f| missing_set.include?(f) }
       end
 
       # Suite identifier (directory name)

--- a/specs/basics/dynamic-partials.yml
+++ b/specs/basics/dynamic-partials.yml
@@ -504,7 +504,7 @@ specs:
     output:
       - Illegal template name
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   complexity: 550
   hint: |
     Same as dynamic_include_nil_name but with inline error rendering.
@@ -527,7 +527,7 @@ specs:
     output:
       - Could not find
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   complexity: 550
   hint: |
     Same as dynamic_include_empty_string_name but with inline error rendering.
@@ -548,7 +548,7 @@ specs:
     output:
       - Could not find
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   complexity: 550
   hint: |
     Same as dynamic_include_missing_partial but with inline error rendering.

--- a/specs/basics/dynamic_partials.yml
+++ b/specs/basics/dynamic_partials.yml
@@ -49,7 +49,7 @@ specs:
   environment:
     tpl: "missing"
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - Could not find
@@ -71,7 +71,7 @@ specs:
   environment:
     tpl: 123
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - Illegal template name

--- a/specs/basics/filter-edge-cases.yml
+++ b/specs/basics/filter-edge-cases.yml
@@ -182,7 +182,7 @@
   template: "{{ items | sort | join: ',' }}"
   environment: { items: [1, "a", true] }
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - "cannot sort"

--- a/specs/basics/inline-errors.yml
+++ b/specs/basics/inline-errors.yml
@@ -6,7 +6,7 @@ _metadata:
     This feature is useful for debugging and graceful degradation.
     Set render_errors: true to enable this behavior.
   minimum_complexity: 300
-  required_features:
+  features:
     - inline_errors
 
 specs:
@@ -19,7 +19,7 @@ specs:
   complexity: 300
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When render_errors is true, division by zero renders as an inline
     error message instead of raising an exception. The output should
@@ -37,7 +37,7 @@ specs:
   complexity: 400
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     Inline errors should include the line number where the error occurred.
     This helps template authors debug issues. The error on line 2 should
@@ -57,7 +57,7 @@ specs:
   complexity: 450
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When an error occurs in a partial, the inline error should include
     the partial name to help identify where the error came from.
@@ -70,7 +70,7 @@ specs:
   complexity: 350
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When multiple errors occur in a template, each should be rendered
     inline. Both division by zero errors should appear in the output.
@@ -84,7 +84,7 @@ specs:
   complexity: 350
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When an error occurs inside a loop, each iteration produces its own
     inline error. The loop continues despite errors when render_errors
@@ -101,7 +101,7 @@ specs:
   complexity: 320
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     Inline errors should be inserted into the output without discarding
     the surrounding content. The words "before" and "after" should both
@@ -116,7 +116,7 @@ specs:
   complexity: 310
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     Modulo by zero produces an inline error similar to division by zero.
     The error message typically says "divided by 0" since modulo is
@@ -131,7 +131,7 @@ specs:
   complexity: 330
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When a filter receives an invalid argument type, the error is
     rendered inline. The slice filter expects an integer but receives
@@ -150,7 +150,7 @@ specs:
   complexity: 470
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When an error occurs in a nested partial, the error message should
     identify the innermost partial where the error occurred. This helps
@@ -167,7 +167,7 @@ specs:
   complexity: 340
   error_mode: lax
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When render_errors is true, successful expressions still render
     correctly and errors are interpolated inline. The upcase filters

--- a/specs/basics/partials.yml
+++ b/specs/basics/partials.yml
@@ -511,7 +511,7 @@ specs:
     output:
     - include usage is not allowed in this context
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   complexity: 220
   hint: |
     Same as render_prohibits_include but with inline error rendering.
@@ -539,7 +539,7 @@ specs:
     output:
     - include usage is not allowed in this context
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   complexity: 220
   hint: |
     Same as render_prohibits_include_nested but with inline error rendering.
@@ -676,7 +676,7 @@ specs:
   filesystem:
     recursive: "{% render 'recursive' %}"
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
     - nesting too deep
@@ -699,7 +699,7 @@ specs:
   filesystem:
     recursive: "{% include 'recursive' %}"
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
     - nesting too deep
@@ -724,7 +724,7 @@ specs:
     a: "{% render 'b' %}"
     b: "{% render 'a' %}"
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
     - nesting too deep

--- a/specs/basics/recursion.yml
+++ b/specs/basics/recursion.yml
@@ -2,7 +2,7 @@
 _metadata:
   doc: implementers/scopes.md
   complexity: 400
-  required_features:
+  features:
     - inline_errors
   hint: |
     Liquid has a stack limit of 100 recursive partial calls. When this
@@ -17,7 +17,7 @@ specs:
     done
   environment: {depth: 1}
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - start
@@ -41,7 +41,7 @@ specs:
     done
   environment: {depth: 1}
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - start
@@ -64,7 +64,7 @@ specs:
     done
   environment: {depth: 1}
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - start

--- a/specs/basics/resource-limits.yml
+++ b/specs/basics/resource-limits.yml
@@ -4,8 +4,7 @@ _metadata:
     Cumulative scores survive reset() across partial renders,
     preventing unbounded work via many small partials.
   complexity: 300
-  required_features:
-    - core
+  features:
 
 specs:
 - name: cumulative_render_score_across_partials

--- a/specs/basics/suite.yml
+++ b/specs/basics/suite.yml
@@ -10,7 +10,7 @@ hint: |
   Every Liquid implementation should pass these tests. They are ordered from simplest to most complex.
   If you're building a new Liquid implementation, start here and work through each failure.
 
-required_features: []
+features: []
 
 defaults:
   render_errors: false

--- a/specs/benchmarks/suite.yml
+++ b/specs/benchmarks/suite.yml
@@ -11,8 +11,7 @@ hint: |
   These specs are designed for performance measurement.
   Run with: liquid-spec my_adapter.rb -s benchmarks --bench
 
-required_features:
-  - core
+features:
 
 defaults:
   render_errors: false

--- a/specs/benchmarks/theme_layout.yml
+++ b/specs/benchmarks/theme_layout.yml
@@ -2,7 +2,7 @@
 _metadata:
   hint: Real Shopify Dream theme benchmark — requires shopify_filters feature
   doc: implementers/shopify-theme-filters.md
-  required_features:
+  features:
     - shopify_filters
   data_files:
     - _data/theme_database.yml

--- a/specs/benchmarks/theme_product.yml
+++ b/specs/benchmarks/theme_product.yml
@@ -2,7 +2,7 @@
 _metadata:
   hint: Real Shopify Dream theme benchmark — requires shopify_filters feature
   doc: implementers/shopify-theme-filters.md
-  required_features:
+  features:
     - shopify_filters
   data_files:
     - _data/theme_database.yml

--- a/specs/liquid_ruby/dynamic_drops.yml
+++ b/specs/liquid_ruby/dynamic_drops.yml
@@ -12,7 +12,7 @@ specs:
 # LoaderDrop - tracks each_called and load_slice_called state
 - name: ForTagTest#test_iterate_with_each_when_no_limit_applied_4b504dbf
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% for item in items %}{{item}}{% endfor %}"
   environment:
     items:
@@ -24,7 +24,7 @@ specs:
 
 - name: ForTagTest#test_iterate_with_load_slice_returns_same_results_as_without_e99b5d3d
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% for item in items offset:2 limit:2 %}{{item}}{% endfor %}"
   environment:
     items:
@@ -36,7 +36,7 @@ specs:
 
 - name: ForTagTest#test_iterate_with_load_slice_when_limit_and_offset_applied_e99b5d3d
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% for item in items offset:2 limit:2 %}{{item}}{% endfor %}"
   environment:
     items:
@@ -48,7 +48,7 @@ specs:
 
 - name: ForTagTest#test_iterate_with_load_slice_when_limit_applied_fd17a528
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% for item in items limit:1 %}{{item}}{% endfor %}"
   environment:
     items:
@@ -61,13 +61,13 @@ specs:
 # ErrorDrop - raises exceptions on method access (tests error handling)
 - name: IncludeTagTest#test_render_tag_renders_error_with_template_name_c34cdb86
   complexity: 310
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% include 'foo' with errors %}"
   environment:
     errors:
       instantiate:ErrorDrop: {}
   render_errors: true
-  required_features: [runtime_drops, inline_errors]
+  features: [runtime_drops, inline_errors]
   errors:
     output:
       - "standard error"
@@ -77,7 +77,7 @@ specs:
 
 - name: IncludeTagTest#test_render_tag_renders_error_with_template_name_from_template_factory_c92c1757
   complexity: 320
-  required_features: [runtime_drops, inline_errors, template_factory]
+  features: [runtime_drops, inline_errors, template_factory]
   template: "{% include 'foo' with errors %}"
   environment:
     errors:
@@ -95,7 +95,7 @@ specs:
 
 - name: RenderTagTest#test_render_tag_renders_error_with_template_name_79f1a430
   complexity: 310
-  required_features: [runtime_drops, inline_errors]
+  features: [runtime_drops, inline_errors]
   template: "{% render 'foo' with errors %}"
   environment:
     errors:
@@ -110,7 +110,7 @@ specs:
 
 - name: RenderTagTest#test_render_tag_renders_error_with_template_name_from_template_factory_8dab9308
   complexity: 320
-  required_features: [runtime_drops, inline_errors, template_factory]
+  features: [runtime_drops, inline_errors, template_factory]
   template: "{% render 'foo' with errors %}"
   environment:
     errors:
@@ -129,7 +129,7 @@ specs:
 # CountingDrop - tracks access count (state changes during rendering)
 - name: StandardFiltersTest#test_map_calls_to_liquid_ac8bb77d
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: '{{ foo | map: "whatever" }}'
   environment:
     foo:
@@ -141,7 +141,7 @@ specs:
 # TestEnumerable - yields items dynamically at runtime
 - name: RenderTagTest#test_render_tag_for_drop_cf2ab489
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% render 'loop' for loop as value %}"
   environment:
     loop:
@@ -154,7 +154,7 @@ specs:
 
 - name: RenderTagTest#test_render_tag_with_drop_e577945d
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% render 'loop' with loop as value %}"
   environment:
     loop:
@@ -167,7 +167,7 @@ specs:
 
 - name: StandardFiltersTest#test_sort_works_on_enumerables_83b00155
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: '{{ foo | sort: "bar" | map: "foo" }}'
   environment:
     foo:
@@ -179,7 +179,7 @@ specs:
 # SettingsDrop - dynamic property access via liquid_method_missing
 - name: VariableTest#test_double_nested_variable_lookup_b9f99226
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: '{{ list[list[settings.zero]]["foo"] }}'
   environment:
     list:
@@ -196,7 +196,7 @@ specs:
 
 - name: VariableTest#test_dynamic_find_var_with_drop_4ca2f954
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: '{{ [list[settings.zero]["foo"]] }}'
   environment:
     list:
@@ -212,7 +212,7 @@ specs:
 
 - name: VariableTest#test_dynamic_find_var_with_drop_d1fd92c9
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{{ [list[settings.zero]] }}"
   environment:
     list:
@@ -229,7 +229,7 @@ specs:
 # ArrayDrop - Enumerable drop with lazy iteration
 - name: TableRowTest#test_enumerable_drop_549595e3
   complexity: 300
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   template: "{% tablerow n in numbers cols:3%} {{n}} {% endtablerow %}"
   environment:
     numbers:

--- a/specs/liquid_ruby/manual.yml
+++ b/specs/liquid_ruby/manual.yml
@@ -19,7 +19,7 @@
   name: Rendering include tag with variables and file does not exist
   filesystem: {}
   render_errors: true
-  required_features: [inline_errors, shopify_error_format]
+  features: [inline_errors, shopify_error_format]
   errors:
     output:
       - "Could not find asset locale_variables"
@@ -29,7 +29,7 @@
   name: Rendering include tag with file does not exist does not repeat .liquid extension
   filesystem: {}
   render_errors: true
-  required_features: [inline_errors, shopify_error_format]
+  features: [inline_errors, shopify_error_format]
   errors:
     output:
       - "Could not find asset foo.liquid"
@@ -40,7 +40,7 @@
   filesystem:
     foo: "{% include 'bar' %}"
   render_errors: true
-  required_features: [inline_errors, shopify_error_format]
+  features: [inline_errors, shopify_error_format]
   errors:
     output:
       - "Could not find asset bar"
@@ -79,7 +79,7 @@
       - invalid integer
       - after,end
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     Tests inline error rendering in a partial. The error occurs on line 2
     of the partial (truncate filter with float argument). Output should
@@ -154,7 +154,7 @@
   environment:
     end: 2.5
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - "invalid integer"
@@ -178,7 +178,7 @@
 - name: Tablerow throws invalid integer error when limit isn't a number
   template: "{% tablerow a in '' limit: true %}{{ a }}{% endtablerow %}"
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - "invalid integer"

--- a/specs/liquid_ruby/materialized_drops.yml
+++ b/specs/liquid_ruby/materialized_drops.yml
@@ -8,7 +8,7 @@ _metadata:
     Drops like BooleanDrop, IntegerDrop, and ThingWithToLiquid test Ruby-specific
     to_liquid, to_liquid_value, and to_s behaviors.
   minimum_complexity: 500
-  required_features:
+  features:
   - ruby_drops
 specs:
 - name: VariableTest#test_case_tag_calls_to_liquid_value_b1c40961
@@ -158,7 +158,7 @@ specs:
   render_errors: false
   expected: ''
 - name: VariableTest#test_variable_lookup_calls_to_liquid_value_069de095
-  required_features: [ruby_types]
+  features: [ruby_types]
   complexity: 500
   template: "{{ list[foo] }}"
   environment:
@@ -390,7 +390,7 @@ specs:
   expected: Yay
 - name: StandardFiltersTest#test_first_calls_to_liquid_6fc6e7a2
   complexity: 500
-  required_features: [ruby_drops]
+  features: [ruby_drops]
   template: "{{ foo | first }}"
   environment:
     foo:
@@ -400,7 +400,7 @@ specs:
   url: https://github.com/Shopify/liquid/blob/584d703aa7552a31d90d09ee6a05416957b7696d/test/integration/standard_filter_test.rb#L584
 - name: StandardFiltersTest#test_last_calls_to_liquid_a5d8c9b7
   complexity: 500
-  required_features: [ruby_drops]
+  features: [ruby_drops]
   template: "{{ foo | last }}"
   environment:
     foo:
@@ -410,7 +410,7 @@ specs:
   url: https://github.com/Shopify/liquid/blob/584d703aa7552a31d90d09ee6a05416957b7696d/test/integration/standard_filter_test.rb#L585
 - name: VariableTest#test_variable_render_calls_to_liquid_0a0a68b2
   complexity: 500
-  required_features: [ruby_drops]
+  features: [ruby_drops]
   template: "{{ foo }}"
   environment:
     foo:
@@ -429,7 +429,7 @@ specs:
   url: https://github.com/Shopify/liquid/blob/584d703aa7552a31d90d09ee6a05416957b7696d/test/integration/tags/for_tag_test.rb#L62
 - name: ConditionTest#test_range_equals_range_in_if_d89d2c49
   complexity: 500
-  required_features: [ruby_types]
+  features: [ruby_types]
   hint: "Range objects can't be represented in JSON. Ruby-specific test."
   template: "{% if (1..5) == expect %}pass{% endif %}"
   environment:
@@ -441,7 +441,7 @@ specs:
   expected: pass
 - name: ConditionTest#test_range_equals_range_d8f93c5a
   complexity: 500
-  required_features: [ruby_types]
+  features: [ruby_types]
   hint: "Range objects can't be represented in JSON. Ruby-specific test."
   template: "{% if expect == (1..2) %}pass{% else %}got {{ (1..2) }}{% endif %}"
   environment:
@@ -452,7 +452,7 @@ specs:
   render_errors: false
   expected: pass
 - name: StandardFiltersTest#test_truncate_calls_to_s_on_drops_b7d4c8e9
-  required_features: [ruby_drops]
+  features: [ruby_drops]
   complexity: 500
   template: "{{ foo | truncate: 5 }}"
   environment:
@@ -463,7 +463,7 @@ specs:
   expected: wo...
   url: https://github.com/Shopify/liquid/blob/584d703aa7552a31d90d09ee6a05416957b7696d/test/integration/standard_filter_test.rb#L295
 - name: HashRenderingTest#test_rendering_hash_with_custom_to_s_method_uses_custom_to_s_c2ef71b8
-  required_features: [ruby_drops]
+  features: [ruby_drops]
   complexity: 500
   template: "{{ my_hash }}"
   environment:
@@ -473,7 +473,7 @@ specs:
   expected: kewl
   url: https://github.com/Shopify/liquid/blob/584d703aa7552a31d90d09ee6a05416957b7696d/test/integration/hash_rendering_test.rb#L91
 - name: HashRenderingTest#test_rendering_hash_without_custom_to_s_method_8b5d7a2c
-  required_features: [ruby_types]
+  features: [ruby_types]
   complexity: 500
   template: "{{ my_hash }}"
   environment:

--- a/specs/liquid_ruby/specs.yml
+++ b/specs/liquid_ruby/specs.yml
@@ -1152,7 +1152,7 @@
   render_errors: false
   expected: 'true'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/context_test.rb#L154
-  required_features:
+  features:
   - ruby_types
 - name: ContextTest#test_length_query_8ee139be
   template: "{% if numbers.size == 4 %}true{% endif %}"
@@ -1165,7 +1165,7 @@
   render_errors: false
   expected: 'true'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/context_test.rb#L148
-  required_features:
+  features:
   - ruby_types
 - name: ContextTest#test_length_query_ae9cb49d
   template: "{% if numbers.size == 4 %}true{% endif %}"
@@ -1193,7 +1193,7 @@
   render_errors: false
   expected: pass
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/context_test.rb#L371
-  required_features:
+  features:
   - ruby_drops
 - name: ContextTest#test_ranges_b0baaf87
   template: "{{ (1..test) }}"
@@ -1673,7 +1673,7 @@
   render_errors: false
   expected: pass
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/expression_test.rb#L188
-  required_features:
+  features:
   - ruby_drops
 - name: ExpressionTest#test_range_beec6d45
   template: "{{ ( 3 .. 4 ) }}"
@@ -2302,7 +2302,7 @@
   render_errors: false
   expected: " 1  2  3 "
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/for_tag_test.rb#L62
-  required_features:
+  features:
   - ruby_drops
 - name: ForTagTest#test_for_with_hash_value_range_35a8ec0f
   template: "{%for item in (1..foobar.value) %} {{item}} {%endfor%}"
@@ -2415,7 +2415,7 @@
   render_errors: false
   expected: '12345'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/for_tag_test.rb#L424
-  required_features:
+  features:
   - ruby_drops
 - name: ForTagTest#test_iterate_with_load_slice_returns_same_results_as_without_00bb236f
   template: "{% for item in items offset:2 limit:2 %}{{item}}{% endfor %}"
@@ -2443,7 +2443,7 @@
   render_errors: false
   expected: '34'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/for_tag_test.rb#L455
-  required_features:
+  features:
   - ruby_drops
 - name: ForTagTest#test_iterate_with_load_slice_when_limit_and_offset_applied_e99b5d3d
   template: "{% for item in items offset:2 limit:2 %}{{item}}{% endfor %}"
@@ -2459,7 +2459,7 @@
   render_errors: false
   expected: '34'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/for_tag_test.rb#L444
-  required_features:
+  features:
   - ruby_drops
 - name: ForTagTest#test_iterate_with_load_slice_when_limit_applied_fd17a528
   template: "{% for item in items limit:1 %}{{item}}{% endfor %}"
@@ -2475,7 +2475,7 @@
   render_errors: false
   expected: '1'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/for_tag_test.rb#L434
-  required_features:
+  features:
   - ruby_drops
 - name: ForTagTest#test_limiting_4a572a26
   template: "{%for i in array limit: 4 offset: 2 %}{{ i }}{%endfor%}"
@@ -2847,7 +2847,7 @@
   render_errors: false
   expected: '{"numbers"=>[{:foo=>42}]}'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/hash_rendering_test.rb#L77
-  required_features:
+  features:
   - ruby_types
 - name: HashRenderingTest#test_render_hash_with_hash_key_e0cefbd9
   template: "{{ my_hash }}"
@@ -2876,7 +2876,7 @@
   render_errors: false
   expected: "{:key1=>1, :key2=>2}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/hash_rendering_test.rb#L15
-  required_features:
+  features:
   - ruby_types
 - name: HashRenderingTest#test_render_nested_hash_6b16a507
   template: "{{ my_hash }}"
@@ -2904,7 +2904,7 @@
   render_errors: false
   expected: kewl
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/hash_rendering_test.rb#L91
-  required_features:
+  features:
   - ruby_drops
 - name: HashRenderingTest#test_rendering_hash_without_custom_to_s_uses_default_inspect_5098df4b
   template: "{{ my_hash }}"
@@ -2915,7 +2915,7 @@
   render_errors: false
   expected: "{:foo=>:bar}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/hash_rendering_test.rb#L98
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: IfElseTagTest#test_comparison_of_expressions_starting_with_and_or_or_0ba70a25
@@ -3742,7 +3742,7 @@
   filesystem:
     foo: "{{ foo.standard_error }}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/include_tag_test.rb#L384
-  required_features:
+  features:
   - ruby_drops
 - name: IncludeTagTest#test_render_tag_renders_error_with_template_name_from_template_factory_8842ca42
   template: "{% include 'foo' with errors %}"
@@ -3756,7 +3756,7 @@
   filesystem:
     foo: "{{ foo.standard_error }}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/include_tag_test.rb#L394
-  required_features:
+  features:
   - ruby_drops
 - name: IncludeTagTest#test_strict2_parsing_errors_574c8b26
   template: '{% include "snippet" !!! arg1: "value1" ~~~ arg2: "value2" %}'
@@ -4425,7 +4425,7 @@
   filesystem:
     loop: "{{ value.foo }}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/render_tag_test.rb#L276
-  required_features:
+  features:
   - ruby_drops
 - name: RenderTagTest#test_render_tag_forloop_385fc4dd
   template: "{% render 'product' for products %}"
@@ -4456,7 +4456,7 @@
   filesystem:
     foo: "{{ foo.standard_error }}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/render_tag_test.rb#L298
-  required_features:
+  features:
   - ruby_drops
 - name: RenderTagTest#test_render_tag_renders_error_with_template_name_from_template_factory_dacc144e
   template: "{% render 'foo' with errors %}"
@@ -4470,7 +4470,7 @@
   filesystem:
     foo: "{{ foo.standard_error }}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/render_tag_test.rb#L308
-  required_features:
+  features:
   - ruby_drops
 - name: RenderTagTest#test_render_tag_with_39fadbdf
   template: "{% render 'product' with products[0] %}"
@@ -4506,7 +4506,7 @@
   filesystem:
     loop: "{{ value }}"
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/render_tag_test.rb#L287
-  required_features:
+  features:
   - ruby_drops
 - name: RenderTagTest#test_render_tag_within_if_statement_6b13a27e
   template: '{% if true %}{% render "snippet" %}{% endif %}'
@@ -4632,7 +4632,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L839
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_at_least_a060ad5f
   template: "{{ 5 | at_least: width }}"
@@ -4643,7 +4643,7 @@
   render_errors: false
   expected: '6'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L840
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_at_least_aaf61adc
   template: "{{ width | at_least:5 }}"
@@ -4654,7 +4654,7 @@
   render_errors: false
   expected: '6'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L838
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_at_most_2d96296b
   template: "{{ width | at_most:5 }}"
@@ -4665,7 +4665,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L827
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_at_most_5574738c
   template: "{{ 5 | at_most: width }}"
@@ -4676,7 +4676,7 @@
   render_errors: false
   expected: '4'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L829
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_at_most_8295a338
   template: "{{ width | at_most:5 }}"
@@ -4687,7 +4687,7 @@
   render_errors: false
   expected: '4'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L828
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_at_most_a310f354
   template: "{{ 5 | at_most:5 }}"
@@ -4735,7 +4735,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L808
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_date_raises_nothing_63e134c4
   template: "{{ 'abc' | date: '%D' }}"
@@ -4756,7 +4756,7 @@
   render_errors: false
   expected: Yay
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L874
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_default_c933af38
   template: "{{ false | default: 'bar' }}"
@@ -4772,7 +4772,7 @@
   render_errors: false
   expected: bar
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L873
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_default_handle_false_8fb3aa7f
   template: "{{ false | default: 'bar', allow_false: true }}"
@@ -4788,7 +4788,7 @@
   render_errors: false
   expected: Nay
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L885
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_default_handle_false_d4715f99
   template: "{{ drop | default: 'bar', allow_false: true }}"
@@ -4799,7 +4799,7 @@
   render_errors: false
   expected: Yay
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L886
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_divided_by_4b236710
   template: "{{ 15 | divided_by:3 }}"
@@ -4825,7 +4825,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L777
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_divided_by_fa7032a8
   template: "{{ 12 | divided_by:3 }}"
@@ -4900,7 +4900,7 @@
   render_errors: false
   expected: foobar
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L592
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_first_and_last_call_to_liquid_e68e43c2
   template: "{{ foo | first }}"
@@ -4910,7 +4910,7 @@
   render_errors: false
   expected: foobar
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L591
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_first_last_on_strings_via_template_39483e1f
   template: "{{ name | last }}"
@@ -4949,7 +4949,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L818
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_floor_95ae89b6
   template: "{{ input | floor }}"
@@ -5114,7 +5114,7 @@
   render_errors: false
   expected: 'woot: 1'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L494
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_map_doesnt_call_arbitrary_stuff_047e3303
   template: '{{ "foo" | map: "inspect" }}'
@@ -5158,7 +5158,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L739
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_minus_e5e28610
   template: "{{ input | minus:operand }}"
@@ -5182,7 +5182,7 @@
   render_errors: false
   expected: '1'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L786
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_modulo_e58d50f0
   template: "{{ 3 | modulo:2 }}"
@@ -5236,7 +5236,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L732
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_prepend_27296fe9
   template: "{{ a | prepend: b}}"
@@ -5343,7 +5343,7 @@
   render_errors: false
   expected: '5'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L797
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_round_a9cde38e
   template: "{{ input | round }}"
@@ -5361,7 +5361,7 @@
   render_errors: false
   expected: '4'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L798
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_round_bfef0082
   template: "{{ input | round: 2 }}"
@@ -5392,7 +5392,7 @@
   render_errors: false
   expected: '213'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L587
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_strip_43de48e5
   template: "{{ source | strip }}"
@@ -5518,7 +5518,7 @@
   render_errors: false
   expected: '4'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L762
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_times_0d94427d
   template: "{{ 3 | times:4 }}"
@@ -5559,7 +5559,7 @@
   render_errors: false
   expected: wo...
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/standard_filter_test.rb#L596
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFiltersTest#test_where_7111322f
   template: "{{ array | where: 'ok' | map: 'handle' | join: ' ' }}"
@@ -6341,7 +6341,7 @@
   render_errors: false
   expected: hash has 4 elements
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/standard_tag_test.rb#L336
-  required_features:
+  features:
   - ruby_types
 - name: StatementsTest#test_is_collection_empty_4af3fc35
   template: " {% if array == empty %} true {% else %} false {% endif %} "
@@ -6517,7 +6517,7 @@
     <td class="col1"> 1 </td><td class="col2"> 2 </td><td class="col3"> 3 </td></tr>
     <tr class="row2"><td class="col1"> 4 </td><td class="col2"> 5 </td><td class="col3"> 6 </td></tr>
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/tags/table_row_test.rb#L64
-  required_features:
+  features:
   - ruby_drops
 - name: TableRowTest#test_nil_limit_is_treated_as_zero_2897eb01
   template: "{% tablerow i in (1..2) limit:nil %}{{ i }}{% endtablerow %}"
@@ -7449,7 +7449,7 @@
   render_errors: false
   expected: One
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L48
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_combining_trailing_comma_and_empty_args_27becf87
   template: '{{ "test" | append: "x", | upcase: }}'
@@ -7471,7 +7471,7 @@
   render_errors: false
   expected: bar
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L168
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_dynamic_find_var_8fd4cb4f
   template: "{{ [key] }}"
@@ -7494,7 +7494,7 @@
   render_errors: false
   expected: foo
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L156
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_dynamic_find_var_with_drop_d1fd92c9
   template: "{{ [list[settings.zero]] }}"
@@ -7509,7 +7509,7 @@
   render_errors: false
   expected: bar
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L146
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_expression_with_whitespace_in_square_brackets_04d8a149
   template: "{{ a[ 'b' ] }}"
@@ -7583,7 +7583,7 @@
   render_errors: false
   expected: 'true'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L32
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_2159fa48
   template: "{% if foo == 1 %}one{% endif %}"
@@ -7594,7 +7594,7 @@
   render_errors: false
   expected: one
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L27
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_2914c337
   template: "{% if foo and true %}SHOULD NOT HAPPEN{% endif %}"
@@ -7605,7 +7605,7 @@
   render_errors: false
   expected: ''
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L37
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_5996f88f
   template: "{% if foo == eqv %}one{% endif %}"
@@ -7619,7 +7619,7 @@
   render_errors: false
   expected: one
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L28
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_9f617983
   template: "{% if foo > 0 %}one{% endif %}"
@@ -7630,7 +7630,7 @@
   render_errors: false
   expected: one
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L30
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_a9e57fd0
   template: "{% if a contains x %}one{% endif %}"
@@ -7643,7 +7643,7 @@
   render_errors: false
   expected: one
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L39
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_beb794c0
   template: "{% if b > a %}one{% endif %}"
@@ -7657,7 +7657,7 @@
   render_errors: false
   expected: one
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L31
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_d3fc1f6e
   template: "{% if 0 < foo %}one{% endif %}"
@@ -7668,7 +7668,7 @@
   render_errors: false
   expected: one
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L29
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_e162081a
   template: "{% if foo == true %}True{% endif %}"
@@ -7679,7 +7679,7 @@
   render_errors: false
   expected: ''
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L36
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_ebf53802
   template: "{% if foo %}true{% endif %}"
@@ -7690,7 +7690,7 @@
   render_errors: false
   expected: 'true'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L33
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_if_tag_calls_to_liquid_value_ffebcff7
   template: "{% if foo %}true{% endif %}"
@@ -7701,7 +7701,7 @@
   render_errors: false
   expected: ''
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L35
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_ignore_unknown_614171b5
   template: "{{ test }}"
@@ -7794,7 +7794,7 @@
   render_errors: false
   expected: 'true'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L44
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_unless_tag_calls_to_liquid_value_33d2b786
   template: "{% unless foo %}true{% endunless %}"
@@ -7805,7 +7805,7 @@
   render_errors: false
   expected: ''
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L43
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_using_blank_as_variable_name_f3a2e22f
   template: "{% assign foo = blank %}{{ foo }}"
@@ -7828,7 +7828,7 @@
   render_errors: false
   expected: one
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L21
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: VariableTest#test_variable_lookup_calls_to_liquid_value_06333239
@@ -7844,7 +7844,7 @@
   render_errors: false
   expected: '2'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L20
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_variable_lookup_calls_to_liquid_value_64e7e768
   template: "{{ foo }}"
@@ -7855,7 +7855,7 @@
   render_errors: false
   expected: Yay
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L22
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_variable_lookup_calls_to_liquid_value_d8c9669a
   template: "{{ foo | upcase }}"
@@ -7866,7 +7866,7 @@
   render_errors: false
   expected: YAY
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L23
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_variable_lookup_calls_to_liquid_value_e91aed83
   template: "{{ foo }}"
@@ -7877,7 +7877,7 @@
   render_errors: false
   expected: '1'
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L19
-  required_features:
+  features:
   - ruby_drops
 - name: VariableTest#test_variable_lookup_should_not_hang_with_invalid_syntax_0aefa9bd
   template: "{{['foo'}}"
@@ -7922,5 +7922,5 @@
   render_errors: false
   expected: foobar
   url: https://github.com/Shopify/liquid/blob/59d8d0d22db3b4865deecde0ab2683bea25a1e9f/test/integration/variable_test.rb#L15
-  required_features:
+  features:
   - ruby_drops

--- a/specs/liquid_ruby/standard_filters.yml
+++ b/specs/liquid_ruby/standard_filters.yml
@@ -51,7 +51,7 @@
     - - foo
     - :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_abs_8169b90f
@@ -67,7 +67,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_abs_b248a944
   template: "{{ a0 | abs }}"
@@ -85,7 +85,7 @@
     a0:
       :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_abs_d18cb3bf
   template: "{{ a0 | abs }}"
@@ -98,7 +98,7 @@
     a0:
       1: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_abs_d79d1bb4
   template: "{{ a0 | abs }}"
@@ -155,7 +155,7 @@
     - - foo
     - :foo: bar
   expected: WyJmb28iLCAxMjMsIG5pbCwgdHJ1ZSwgZmFsc2UsIExpcXVpZDo6RHJvcCwgWyJmb28iXSwgezpmb289PiJiYXIifV0=
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_base64_encode_1107ae74
@@ -164,7 +164,7 @@
     a0:
       1: bar
   expected: ezE9PiJiYXIifQ==
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_base64_encode_18c6c9c8
   template: "{{ a0 | base64_encode }}"
@@ -226,7 +226,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: d29vdDogMA==
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_base64_encode_cbe9e66f
   template: "{{ a0 | base64_encode }}"
@@ -256,7 +256,7 @@
     a0:
       :foo: bar
   expected: ezpmb289PiJiYXIifQ==
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_base64_encode_f5c3c752
   template: "{{ a0 | base64_encode }}"
@@ -314,7 +314,7 @@
     - - foo
     - :foo: bar
   expected: WyJmb28iLCAxMjMsIG5pbCwgdHJ1ZSwgZmFsc2UsIExpcXVpZDo6RHJvcCwgWyJmb28iXSwgezpmb289PiJiYXIifV0=
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_base64_url_safe_encode_2d47c17d
@@ -350,7 +350,7 @@
     a0:
       1: bar
   expected: ezE9PiJiYXIifQ==
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_base64_url_safe_encode_5827a928
   template: "{{ a0 | base64_url_safe_encode }}"
@@ -391,7 +391,7 @@
     a0:
       :foo: bar
   expected: ezpmb289PiJiYXIifQ==
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_base64_url_safe_encode_a5e8f0a9
   template: "{{ a0 | base64_url_safe_encode }}"
@@ -415,7 +415,7 @@
       'instantiate:ToSDrop:':
         foo: 0
   expected: d29vdDogMQ==
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_capitalize_04d26e85
   template: "{{ a0 | capitalize }}"
@@ -428,7 +428,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_capitalize_17453339
   template: "{{ a0 | capitalize }}"
@@ -446,7 +446,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_capitalize_38a9a61f
   template: "{{ a0 | capitalize }}"
@@ -461,7 +461,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, liquid::drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_capitalize_3ff86554
@@ -532,7 +532,7 @@
       'instantiate:ToSDrop:':
         foo: 4
   expected: 'Woot: 5'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_ceil_1f10ca85
   template: "{{ a0 | ceil }}"
@@ -540,7 +540,7 @@
     a0:
       1: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_ceil_20e88c97
   template: "{{ a0 | ceil }}"
@@ -548,7 +548,7 @@
     a0:
       :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_ceil_296cf205
   template: "{{ a0 | ceil }}"
@@ -578,7 +578,7 @@
     - - foo
     - :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_ceil_4f5c4da1
@@ -616,7 +616,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_ceil_e5a0f77f
   template: "{{ a0 | ceil }}"
@@ -667,7 +667,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: 'woot: 1'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_compact_2b01e238
   template: "{{ a0 | compact }}"
@@ -682,7 +682,7 @@
     - - foo
     - :foo: bar
   expected: foo123truefalseLiquid::Dropfoo{:foo=>"bar"}
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_compact_2fdb07df
@@ -718,7 +718,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_compact_8f8a64eb
   template: "{{ a0 | compact }}"
@@ -764,7 +764,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_compact_fc6ebab1
   template: "{{ a0 | compact: a1 }}"
@@ -938,7 +938,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_default_2f14ba4e
   template: "{{ a0 | default: a1 }}"
@@ -977,7 +977,7 @@
       'instantiate:ToSDrop:':
         foo: 7
   expected: 'woot: 9'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_default_446f9bac
   template: "{{ a0 | default }}"
@@ -997,7 +997,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_default_59e6b2cd
   template: "{{ a0 | default }}"
@@ -1088,7 +1088,7 @@
     - - foo
     - :foo: bar
   expected: foo123truefalseLiquid::Dropfoo{:foo=>"bar"}
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_default_a963f327
@@ -1115,7 +1115,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, liquid::drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_downcase_0fe5e452
@@ -1135,7 +1135,7 @@
       'instantiate:ToSDrop:':
         foo: 4
   expected: 'woot: 5'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_downcase_385c4591
   template: "{{ a0 | downcase }}"
@@ -1173,7 +1173,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_downcase_92e1d269
   template: "{{ a0 | downcase }}"
@@ -1222,7 +1222,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_escape_015bf946
   template: "{{ a0 | escape }}"
@@ -1235,7 +1235,7 @@
     a0:
       :foo: bar
   expected: "{:foo=&gt;&quot;bar&quot;}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_escape_27b5ea83
   template: "{{ a0 | escape }}"
@@ -1248,7 +1248,7 @@
     a0:
       1: bar
   expected: "{1=&gt;&quot;bar&quot;}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_escape_4269ff9d
   template: "{{ a0 | escape }}"
@@ -1290,7 +1290,7 @@
     - :foo: bar
   expected: "[&quot;foo&quot;, 123, nil, true, false, Liquid::Drop, [&quot;foo&quot;],
     {:foo=&gt;&quot;bar&quot;}]"
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_escape_8d927a70
@@ -1317,7 +1317,7 @@
       'instantiate:ToSDrop:':
         foo: 3
   expected: 'woot: 4'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_escape_db3990d0
   template: "{{ a0 | escape }}"
@@ -1387,7 +1387,7 @@
     a0:
       :foo: bar
   expected: "{:foo=&gt;&quot;bar&quot;}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_escape_once_24a25f87
   template: "{{ a0 | escape_once }}"
@@ -1418,7 +1418,7 @@
     - :foo: bar
   expected: "[&quot;foo&quot;, 123, nil, true, false, Liquid::Drop, [&quot;foo&quot;],
     {:foo=&gt;&quot;bar&quot;}]"
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_escape_once_6c11fb5b
@@ -1454,7 +1454,7 @@
     a0:
       1: bar
   expected: "{1=&gt;&quot;bar&quot;}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_escape_once_ae0ac47d
   template: "{{ a0 | escape_once }}"
@@ -1463,7 +1463,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: 'woot: 0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_escape_once_b1335893
   template: "{{ a0 | escape_once }}"
@@ -1501,7 +1501,7 @@
       'instantiate:ToSDrop:':
         foo: 7
   expected: ''
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_first_103b3aa9
   template: "{{ a0 | first }}"
@@ -1514,7 +1514,7 @@
     a0:
       1: bar
   expected: 1bar
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_first_2e9dd802
   template: "{{ a0 | first }}"
@@ -1562,7 +1562,7 @@
     - - foo
     - :foo: bar
   expected: foo
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_first_9546f643
@@ -1608,7 +1608,7 @@
     a0:
       :foo: bar
   expected: foobar
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_first_d9a563ef
   template: "{{ a0 | first }}"
@@ -1651,7 +1651,7 @@
     - - foo
     - :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_floor_29259403
@@ -1687,7 +1687,7 @@
     a0:
       :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_floor_79de08ab
   template: "{{ a0 | floor }}"
@@ -1724,7 +1724,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_floor_af74b0fe
   template: "{{ a0 | floor }}"
@@ -1747,7 +1747,7 @@
     a0:
       1: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_h_15d599cb
   template: "{{ a0 | h }}"
@@ -1755,7 +1755,7 @@
     a0:
       1: bar
   expected: "{1=&gt;&quot;bar&quot;}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_h_168177ce
   template: "{{ a0 | h }}"
@@ -1781,7 +1781,7 @@
     - :foo: bar
   expected: "[&quot;foo&quot;, 123, nil, true, false, Liquid::Drop, [&quot;foo&quot;],
     {:foo=&gt;&quot;bar&quot;}]"
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_h_2ef8277e
@@ -1815,7 +1815,7 @@
     a0:
       :foo: bar
   expected: "{:foo=&gt;&quot;bar&quot;}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_h_82dc265e
   template: "{{ a0 | h }}"
@@ -1854,7 +1854,7 @@
       'instantiate:ToSDrop:':
         foo: 8
   expected: 'woot: 9'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_h_c2040486
   template: "{{ a0 | h }}"
@@ -1925,7 +1925,7 @@
         value: i did it
     a1: ", "
   expected: i did it, i did it
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_join_37113f09
   template: "{{ a0 | join: a1 }}"
@@ -1974,7 +1974,7 @@
       'instantiate:ToSDrop:':
         foo: 5
   expected: 'woot: 7'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_join_89aba551
   template: "{{ a0 | join }}"
@@ -2006,7 +2006,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_join_a43bcd49
   template: "{{ a0 | join }}"
@@ -2014,7 +2014,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_join_a91697b6
   template: "{{ a0 | join }}"
@@ -2039,7 +2039,7 @@
     - - foo
     - :foo: bar
   expected: foo 123  true false Liquid::Drop foo {:foo=>"bar"}
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_join_fcf4f163
@@ -2075,7 +2075,7 @@
     a0:
       1: bar
   expected: ''
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_last_1b048787
   template: "{{ a0 | last }}"
@@ -2090,7 +2090,7 @@
     - - foo
     - :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_last_2125a94f
@@ -2125,7 +2125,7 @@
     a0:
       :foo: bar
   expected: ''
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_last_b12b4f55
   template: "{{ a0 | last }}"
@@ -2179,7 +2179,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: ''
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_last_fca759f7
   template: "{{ a0 | last }}"
@@ -2199,7 +2199,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_lstrip_287bf5e9
@@ -2224,7 +2224,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_lstrip_691fd32c
   template: "{{ a0 | lstrip }}"
@@ -2277,7 +2277,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_lstrip_f4f42172
   template: "{{ a0 | lstrip }}"
@@ -2301,7 +2301,7 @@
       'instantiate:ToSDrop:':
         foo: 6
   expected: 'woot: 7'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_map_519eec4b
   template: "{{ a0 | map: a1 }}"
@@ -2354,7 +2354,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_newline_to_br_652ed44a
   template: "{{ a0 | newline_to_br }}"
@@ -2369,7 +2369,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_newline_to_br_88717d1a
   template: "{{ a0 | newline_to_br }}"
@@ -2402,7 +2402,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_newline_to_br_91643ffe
@@ -2428,7 +2428,7 @@
       'instantiate:ToSDrop:':
         foo: 1
   expected: 'woot: 2'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_remove_147c7a7d
   template: "{{ a0 | remove: a1 }}"
@@ -2571,7 +2571,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_reverse_4a4b9b4a
   template: "{{ a0 | reverse }}"
@@ -2591,7 +2591,7 @@
     - - foo
     - :foo: bar
   expected: '{:foo=>"bar"}fooLiquid::Dropfalsetrue123foo'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_reverse_612dbe14
@@ -2601,7 +2601,7 @@
       'instantiate:ToSDrop:':
         foo: 4
   expected: 'woot: 6'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_reverse_7d361a86
   template: "{{ a0 | reverse }}"
@@ -2636,7 +2636,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_reverse_e630c96e
   template: "{{ a0 | reverse }}"
@@ -2664,7 +2664,7 @@
       :a: 1
       :b: 2
   expected: "{:a=>1, :b=>2}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_round_0cc8a4b0
   template: "{{ a0 | round }}"
@@ -2689,7 +2689,7 @@
     - - foo
     - :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_round_64f03f6e
@@ -2698,7 +2698,7 @@
     a0:
       1: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_round_64f27055
   template: "{{ a0 | round }}"
@@ -2717,7 +2717,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_round_93e6c0cb
   template: "{{ a0 | round }}"
@@ -2741,7 +2741,7 @@
     a0:
       :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_round_ca1b586c
   template: "{{ a0 | round }}"
@@ -2789,7 +2789,7 @@
       'instantiate:ToSDrop:':
         foo: 6
   expected: 'woot: 7'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_rstrip_0e32369a
   template: "{{ a0 | rstrip }}"
@@ -2797,7 +2797,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_rstrip_1f72cde9
   template: "{{ a0 | rstrip }}"
@@ -2845,7 +2845,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_rstrip_87a01f76
@@ -2897,7 +2897,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_size_11612dc3
   template: "{{ a0 | size }}"
@@ -2927,7 +2927,7 @@
     - - foo
     - :foo: bar
   expected: '8'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_size_350f32de
@@ -2941,7 +2941,7 @@
     a0:
       1: bar
   expected: '1'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_size_8b29fccf
   template: "{{ a0 | size }}"
@@ -2966,7 +2966,7 @@
     a0:
       :foo: bar
   expected: '1'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_size_bdbea2e5
   template: "{{ a0 | size }}"
@@ -2999,7 +2999,7 @@
       'instantiate:ToSDrop:':
         foo: 4
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_size_cca95d86
   template: "{{ a0 | size }}"
@@ -3325,7 +3325,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_sort_02927a93
   template: "{{ a0 | sort }}"
@@ -3395,7 +3395,7 @@
       :a: 1
       :b: 2
   expected: "{:a=>1, :b=>2}"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_sort_60fd1f75
   template: "{{ a0 | sort }}"
@@ -3492,7 +3492,7 @@
       'instantiate:ToSDrop:':
         foo: 6
   expected: 'woot: 8'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_sort_f6400a55
   template: "{{ a0 | sort }}"
@@ -3505,7 +3505,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_sort_natural_067881c5
   template: "{{ a0 | sort_natural }}"
@@ -3568,7 +3568,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_sort_natural_5c26e91e
   template: "{{ a0 | sort_natural }}"
@@ -3596,7 +3596,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_sort_natural_889ad3ca
   template: "{{ a0 | sort_natural }}"
@@ -3611,7 +3611,7 @@
     - - foo
     - :foo: bar
   expected: 123falsefoofooLiquid::Droptrue{:foo=>"bar"}
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sort_natural_88efd2cb
@@ -3678,7 +3678,7 @@
       'instantiate:ToSDrop:':
         foo: 3
   expected: 'woot: 5'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_sort_natural_cc938040
   template: "{{ a0 | sort_natural }}"
@@ -3761,7 +3761,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_squish_145ca951
@@ -3775,7 +3775,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_squish_33f01c11
   template: "{{ a0 | squish }}"
@@ -3800,7 +3800,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: 'woot: 0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_squish_6301637d
   template: "{{ a0 | squish }}"
@@ -3815,7 +3815,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_squish_97c21bbf
   template: "{{ a0 | squish }}"
@@ -3861,7 +3861,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_strip_298c499e
   template: "{{ a0 | strip }}"
@@ -3897,7 +3897,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_strip_a93bd80e
   template: "{{ a0 | strip }}"
@@ -3916,7 +3916,7 @@
       'instantiate:ToSDrop:':
         foo: 6
   expected: 'woot: 7'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_strip_bb0e5336
   template: "{{ a0 | strip }}"
@@ -3959,7 +3959,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_strip_ef9277f9
@@ -4011,7 +4011,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_strip_html_4b83faf1
   template: "{{ a0 | strip_html }}"
@@ -4071,7 +4071,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_strip_html_a3081ea4
   template: "{{ a0 | strip_html }}"
@@ -4080,7 +4080,7 @@
       'instantiate:ToSDrop:':
         foo: 3
   expected: 'woot: 4'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_strip_html_ae94334b
   template: "{{ a0 | strip_html }}"
@@ -4107,7 +4107,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_strip_html_dc4a80f8
@@ -4169,7 +4169,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_strip_newlines_7c67b363
@@ -4190,7 +4190,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_strip_newlines_9a2228de
   template: "{{ a0 | strip_newlines }}"
@@ -4210,7 +4210,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: 'woot: 0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_strip_newlines_cb41d77d
   template: "{{ a0 | strip_newlines }}"
@@ -4218,7 +4218,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_strip_newlines_d61eb5c8
   template: "{{ a0 | strip_newlines }}"
@@ -4336,7 +4336,7 @@
     a0:
       :foo: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_sum_5d8d0b22
   template: "{{ a0 | sum }}"
@@ -4367,7 +4367,7 @@
       : 0.4
     a1:
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sum_7d73388f
@@ -4384,7 +4384,7 @@
     a0:
       1: bar
   expected: '0'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_sum_81cb6a64
   template: "{{ a0 | sum: a1 }}"
@@ -4399,7 +4399,7 @@
       : 0.4
     a1: ''
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sum_821b1e54
@@ -4455,7 +4455,7 @@
       : 0.4
     a1: 1
   expected: "-0.3"
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sum_9e90e288
@@ -4488,7 +4488,7 @@
       - 1
       - 5
   expected: '0.4'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sum_b088741e
@@ -4508,7 +4508,7 @@
       'instantiate:ToSDrop:':
         foo: 1
   expected: '0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_sum_bb643a30
   template: "{{ a0 | sum }}"
@@ -4532,7 +4532,7 @@
       : 0.4
     a1: 1.0
   expected: '0.2'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sum_d4e0176c
@@ -4568,7 +4568,7 @@
     - - foo
     - :foo: bar
   expected: '123'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sum_e855bd12
@@ -4600,7 +4600,7 @@
       : 0.4
     a1: true
   expected: '1'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_sum_fb61db9c
@@ -4635,7 +4635,7 @@
       'instantiate:ToSDrop:':
         foo: -1
   expected: 'woot: 0'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_truncate_4aa3cbc9
   template: "{{ a0 | truncate: a1 }}"
@@ -4698,7 +4698,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_truncate_b1979814
   template: "{{ a0 | truncate }}"
@@ -4740,7 +4740,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["...'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_truncate_f1369736
@@ -4773,7 +4773,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_truncatewords_1bfd0354
   template: "{{ a0 | truncatewords }}"
@@ -4831,7 +4831,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_truncatewords_54c75947
   template: "{{ a0 | truncatewords }}"
@@ -4851,7 +4851,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_truncatewords_5b3e76bb
@@ -4898,7 +4898,7 @@
       'instantiate:ToSDrop:':
         foo: 1
   expected: 'woot: 2'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_truncatewords_b366b670
   template: "{{ a0 | truncatewords }}"
@@ -4942,7 +4942,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_truncatewords_f331f0c8
   template: "{{ a0 | truncatewords }}"
@@ -4970,7 +4970,7 @@
     - 'instantiate:StringDrop:':
         value: bar
   expected: foobar
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_uniq_0ce0fecb
   template: "{{ a0 | uniq }}"
@@ -5022,7 +5022,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_uniq_7ab73682
   template: "{{ a0 | uniq }}"
@@ -5052,7 +5052,7 @@
     - - foo
     - :foo: bar
   expected: foo123truefalseLiquid::Drop{:foo=>"bar"}
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_uniq_879d03c3
@@ -5065,7 +5065,7 @@
         value: bar
     - foo
   expected: foobar
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_uniq_9c0e7ae6
   template: "{{ a0 | uniq }}"
@@ -5073,7 +5073,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_uniq_a417ebce
   template: "{{ a0 | uniq }}"
@@ -5112,7 +5112,7 @@
         value: test
     a1: value
   expected: TestDrop
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_uniq_dfc0bb7e
   template: "{{ a0 | uniq: a1 }}"
@@ -5141,7 +5141,7 @@
       'instantiate:ToSDrop:':
         foo: 0
   expected: 'woot: 2'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_upcase_1ab477f2
   template: "{{ a0 | upcase }}"
@@ -5159,7 +5159,7 @@
     a0:
       :foo: bar
   expected: '{:FOO=>"BAR"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_upcase_2a366551
   template: "{{ a0 | upcase }}"
@@ -5167,7 +5167,7 @@
     a0:
       1: bar
   expected: '{1=>"BAR"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_upcase_2abc21fb
   template: "{{ a0 | upcase }}"
@@ -5195,7 +5195,7 @@
     - - foo
     - :foo: bar
   expected: '["FOO", 123, NIL, TRUE, FALSE, LIQUID::DROP, ["FOO"], {:FOO=>"BAR"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_upcase_406bfebc
@@ -5226,7 +5226,7 @@
       'instantiate:ToSDrop:':
         foo: 4
   expected: 'WOOT: 5'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_upcase_971ad481
   template: "{{ a0 | upcase }}"
@@ -5335,7 +5335,7 @@
     a0:
       :foo: bar
   expected: '{:foo=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_url_decode_8007b58b
   template: "{{ a0 | url_decode }}"
@@ -5348,7 +5348,7 @@
     a0:
       1: bar
   expected: '{1=>"bar"}'
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_url_decode_9580d768
   template: "{{ a0 | url_decode }}"
@@ -5368,7 +5368,7 @@
     - - foo
     - :foo: bar
   expected: '["foo", 123, nil, true, false, Liquid::Drop, ["foo"], {:foo=>"bar"}]'
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_url_decode_bf1f382b
@@ -5383,7 +5383,7 @@
       'instantiate:ToSDrop:':
         foo: 1
   expected: 'woot: 2'
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_url_decode_c3985058
   template: "{{ a0 | url_decode }}"
@@ -5440,7 +5440,7 @@
     - - foo
     - :foo: bar
   expected: "%5B%22foo%22%2C+123%2C+nil%2C+true%2C+false%2C+Liquid%3A%3ADrop%2C+%5B%22foo%22%5D%2C+%7B%3Afoo%3D%3E%22bar%22%7D%5D"
-  required_features:
+  features:
   - ruby_drops
   - ruby_types
 - name: StandardFilterTest#test_url_encode_26a6b4f3
@@ -5460,7 +5460,7 @@
       'instantiate:ToSDrop:':
         foo: 1
   expected: woot%3A+2
-  required_features:
+  features:
   - ruby_drops
 - name: StandardFilterTest#test_url_encode_41ca8a5e
   template: "{{ a0 | url_encode }}"
@@ -5528,7 +5528,7 @@
     a0:
       :foo: bar
   expected: "%7B%3Afoo%3D%3E%22bar%22%7D"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_url_encode_eb214d0d
   template: "{{ a0 | url_encode }}"
@@ -5536,7 +5536,7 @@
     a0:
       1: bar
   expected: "%7B1%3D%3E%22bar%22%7D"
-  required_features:
+  features:
   - ruby_types
 - name: StandardFilterTest#test_where_1553f876
   template: "{{ a0 | where: a1 }}"

--- a/specs/liquid_ruby/suite.yml
+++ b/specs/liquid_ruby/suite.yml
@@ -9,7 +9,7 @@ hint: |
   Failures indicate missing or incorrect Liquid behavior.
 
 # No required_features at suite level - allows JSON-RPC adapters to run
-# Individual specs that need runtime drops declare required_features: [runtime_drops]
+# Individual specs that need runtime drops declare features: [runtime_drops]
 
 # Feature documentation:
 # - :core includes :runtime_drops (full implementation)

--- a/specs/liquid_ruby_lax/specs.yml
+++ b/specs/liquid_ruby_lax/specs.yml
@@ -3,7 +3,7 @@ _metadata:
   hint: |
     These specs require lax parsing mode. The syntax tested here was never valid
     Liquid - it was accidentally tolerated by the lax parser.
-  required_features: [lax_parsing]
+  features: [lax_parsing]
   required_options:
     error_mode: :lax
 specs:
@@ -55,7 +55,7 @@ specs:
   template: "{% if a true %}{% endif %}"
   expected: ""
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     Lax mode quirk: unknown operators in conditions with empty bodies are
     silently swallowed (no error in output). Requires render_errors: true
@@ -65,7 +65,7 @@ specs:
   template: "{% if true true %}{% endif %}"
   expected: ""
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     Lax mode quirk: blank tag bodies swallow render errors entirely.
     Requires render_errors: true so the runner doesn't raise exceptions,
@@ -76,7 +76,7 @@ specs:
   errors:
       output: "Unknown operator true"
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     Even in lax mode, errors are shown when there's an else block with content.
 - name: Does not output error when unknown operators are used in elsif but if is true
@@ -95,7 +95,7 @@ specs:
   errors:
       output: "Unknown operator true"
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     When the if branch is false, the elsif is evaluated and the error is shown.
 - name: Unsupported operators render an error
@@ -103,7 +103,7 @@ specs:
   errors:
       output: "Unknown operator ="
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   hint: |
     The = operator is not valid in conditions (use ==). Shows error because body has content.
 - name: Does not output error when short circuit evaluation avoids using the unknown operator
@@ -407,7 +407,7 @@ specs:
   template: "{% tablerow n in (1...10) limit:true %} {{n}} {% endtablerow %}"
   error_mode: :warn
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - "invalid integer"
@@ -416,7 +416,7 @@ specs:
   template: "{% tablerow n in (1...10) cols:true %} {{n}} {% endtablerow %}"
   error_mode: :warn
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - "invalid integer"
@@ -425,7 +425,7 @@ specs:
   template: "{% tablerow n in (1...10) offset:true %} {{n}} {% endtablerow %}"
   error_mode: :warn
   render_errors: true
-  required_features: [inline_errors]
+  features: [inline_errors]
   errors:
     output:
       - "invalid integer"

--- a/specs/liquid_ruby_lax/suite.yml
+++ b/specs/liquid_ruby_lax/suite.yml
@@ -9,7 +9,7 @@ hint: |
   Lax mode is a deprecated backwards-compatible parsing mode that tolerates invalid syntax.
   It exists for legacy Shopify templates but can be safely ignored by new implementations.
 
-required_features:
+features:
   - lax_parsing
 
 # Lax parsing is an advanced feature - implementations should focus on

--- a/specs/shopify_production_recordings/error_handling.yml
+++ b/specs/shopify_production_recordings/error_handling.yml
@@ -3,7 +3,7 @@
 # These require the shopify_error_handling feature
 
 - name: RecordedTest#test_subcontext_enter_fails_and_leaves_runtime_in_good_state_ec4f06d3a
-  required_features:
+  features:
     - shopify_error_handling
     - inline_errors
   render_errors: true

--- a/specs/shopify_production_recordings/recorded_specs.yml
+++ b/specs/shopify_production_recordings/recorded_specs.yml
@@ -1,6 +1,6 @@
 ---
 - name: RecordedTest#test_basic_filter_833a117e
-  required_features: [shopify_filters]
+  features: [shopify_filters]
   template: "{{ 'hello' | upcase | capitalize | t }}"
   expected: translated-Hello-
   environment: {}
@@ -65,41 +65,41 @@
   template: "{% case blank %}{% when ' ' %}when{% else %}else{% endcase %}"
   expected: else
   environment: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "Shopify blank matches whitespace-only strings. Standard liquid blank is just ''."
 - name: RecordedTest#test_case_method_literal_3f10d7af
   template: "{% case ' ' %}{% when blank %}when{% else %}else{% endcase %}"
   expected: when
   environment: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "Shopify blank matches whitespace-only strings. Standard liquid blank is just ''."
 - name: RecordedTest#test_case_no_else_bb1c6565
   template: "{% case 2 %}{% when 1 %}when{% endcase %}"
   expected: ""
   environment: {}
 - name: RecordedTest#test_comparison_errors_7595d936
-  required_features:
+  features:
     - shopify_error_format
   template: "{% if 'abc' < 1 %}true{% else %}false{% endif %}"
   expected: "Liquid error (templates/test line 1): comparison of String with 1 failed"
   environment: {}
   template_name: templates/test
 - name: RecordedTest#test_comparison_errors_8141317d
-  required_features:
+  features:
     - shopify_error_format
   template: "{% if 'abc' > 1 %}true{% else %}false{% endif %}"
   expected: "Liquid error (templates/test line 1): comparison of String with 1 failed"
   environment: {}
   template_name: templates/test
 - name: RecordedTest#test_comparison_errors_d4f8ab6f
-  required_features:
+  features:
     - shopify_error_format
   template: "{% if 'abc' <= 1 %}true{% else %}false{% endif %}"
   expected: "Liquid error (templates/test line 1): comparison of String with 1 failed"
   environment: {}
   template_name: templates/test
 - name: RecordedTest#test_comparison_errors_f811bec9
-  required_features:
+  features:
     - shopify_error_format
   template: "{% if 'abc' >= 1 %}true{% else %}false{% endif %}"
   expected: "Liquid error (templates/test line 1): comparison of String with 1 failed"
@@ -212,7 +212,7 @@
   filesystem:
     snippet.liquid: "{% assign inner = 1 %}"
 - name: RecordedTest#test_include_tag_with_disallowed_includes_and_no_line_number_93c59f75
-  required_features:
+  features:
     - shopify_includes
   template: "{% render 'missing.liquid' %}"
   expected: "Liquid error (line 1): This liquid context does not allow includes."
@@ -270,7 +270,7 @@
   environment: {}
 
 - name: RecordedTest#test_encoding_binary_binary_binary_usascii_utf8_utf8_utf8_630b778b
-  required_features: [binary_data]
+  features: [binary_data]
   template: &template "{% assign v0 = iv0 | base64_encode | base64_decode %}{{ v0 }}{% assign
     v1 = iv1 | base64_encode | base64_decode %}{{ v1 }}{% assign v2 = iv2 | base64_encode
     | base64_decode %}{{ v2 }}{% assign v3 = iv3 | base64_encode | base64_decode %}{{
@@ -291,7 +291,7 @@
     iv5: &iv5 asciiiii
     iv6: &iv6 "\U0001F32A\U0001F32A\U0001F32A\U0001F32A\U0001F32A\U0001F32A\U0001F32A\U0001F32A️"
 - name: RecordedTest#test_encoding_binary_binary_binary_utf8_usascii_utf8_utf8_ebfbd90a
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQC6FLg2AI6rpN488V3+BFe8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -304,7 +304,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_binary_utf8_utf8_usascii_utf8_d8d01ee4
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQC6FLg2AI6rpN488V3+BFe8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -317,7 +317,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_binary_utf8_utf8_utf8_usascii_ba2a591c
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQC6FLg2AI6rpN488V3+BFe8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -330,7 +330,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_binary_usascii_binary_utf8_utf8_utf8_aea48eb9
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQAAAAAAAAAAALoUuDYAjquk3jzxXf4EV7wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -343,7 +343,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_usascii_utf8_binary_utf8_utf8_aab80b71
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQAAAAAAAAAAPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKEC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -356,7 +356,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_usascii_utf8_utf8_binary_utf8_53feacf6
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQAAAAAAAAAAPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKFhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -369,7 +369,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_usascii_utf8_utf8_utf8_binary_2d6b41df
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQAAAAAAAAAAPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKFhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -382,7 +382,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_binary_utf8_binary_usascii_utf8_utf8_0dd2ee52
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShAuhS4NgCOq6TePPFd/gRXgAAAAAAAAAAYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -395,7 +395,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_utf8_binary_utf8_usascii_utf8_d7ddb016
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShAuhS4NgCOq6TePPFd/gRXmFzY2lpaWlpAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -408,7 +408,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_utf8_binary_utf8_utf8_usascii_f9b9d827
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShAuhS4NgCOq6TePPFd/gRXmFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -421,7 +421,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_binary_utf8_usascii_binary_utf8_utf8_790300cf
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShAAAAAAAAAAAC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -434,7 +434,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_utf8_usascii_utf8_binary_utf8_c4258215
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShAAAAAAAAAABhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -447,7 +447,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_utf8_usascii_utf8_utf8_binary_477c9027
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShAAAAAAAAAABhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -460,7 +460,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_binary_utf8_utf8_binary_usascii_utf8_2e4b2d61
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWkC6FLg2AI6rpN488V3+BFeAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -473,7 +473,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_utf8_utf8_binary_utf8_usascii_d314808e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWkC6FLg2AI6rpN488V3+BFe8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -486,7 +486,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_binary_utf8_utf8_usascii_binary_utf8_ae237472
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWkAAAAAAAAAAALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -499,7 +499,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_binary_utf8_utf8_usascii_utf8_binary_e08f7ef9
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWkAAAAAAAAAAPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -512,7 +512,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_binary_utf8_utf8_utf8_binary_usascii_cb00ae42
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwLoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -525,7 +525,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_binary_utf8_utf8_utf8_usascii_binary_420e2617
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -538,7 +538,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_usascii_binary_binary_utf8_utf8_utf8_d74c5149
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAAA4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -551,7 +551,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_usascii_binary_utf8_binary_utf8_utf8_67d3a4f7
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAAA4ODg4OGJpdPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKEC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -564,7 +564,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_usascii_binary_utf8_utf8_binary_utf8_e8b7c77c
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAAA4ODg4OGJpdPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKFhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -577,7 +577,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_usascii_binary_utf8_utf8_utf8_binary_18a82d12
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAAA4ODg4OGJpdPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKFhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -590,7 +590,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_usascii_utf8_binary_binary_utf8_utf8_dfdf5527
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShODg4ODhiaXQC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -603,7 +603,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_usascii_utf8_binary_utf8_binary_utf8_09ea414e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShODg4ODhiaXRhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -616,7 +616,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_usascii_utf8_binary_utf8_utf8_binary_98981496
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShODg4ODhiaXRhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -629,7 +629,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_usascii_utf8_utf8_binary_binary_utf8_4b413d2a
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWk4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -642,7 +642,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_usascii_utf8_utf8_binary_utf8_binary_a72e99b4
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWk4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -655,7 +655,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_usascii_utf8_utf8_utf8_binary_binary_7fdf8acc
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -668,7 +668,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_binary_binary_usascii_utf8_utf8_00c77fc0
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXgAAAAAAAAAAYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -681,7 +681,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_binary_binary_utf8_usascii_utf8_526ee9de
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXmFzY2lpaWlpAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -694,7 +694,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_binary_binary_utf8_utf8_usascii_ee6c9fd1
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXmFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -707,7 +707,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_utf8_binary_usascii_binary_utf8_utf8_fda39a00
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0AAAAAAAAAAAC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -720,7 +720,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_binary_usascii_utf8_binary_utf8_802e405f
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0AAAAAAAAAABhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -733,7 +733,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_binary_usascii_utf8_utf8_binary_b6be7968
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0AAAAAAAAAABhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -746,7 +746,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_binary_utf8_binary_usascii_utf8_90047dd2
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0YXNjaWlpaWkC6FLg2AI6rpN488V3+BFeAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -759,7 +759,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_binary_utf8_binary_utf8_usascii_d1d8a2b0
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0YXNjaWlpaWkC6FLg2AI6rpN488V3+BFe8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -772,7 +772,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_utf8_binary_utf8_usascii_binary_utf8_bd9d3ac1
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0YXNjaWlpaWkAAAAAAAAAAALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -785,7 +785,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_binary_utf8_usascii_utf8_binary_25a66421
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0YXNjaWlpaWkAAAAAAAAAAPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -798,7 +798,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_binary_utf8_utf8_binary_usascii_c3c2505c
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0YXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwLoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -811,7 +811,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_utf8_binary_utf8_utf8_usascii_binary_c8701dcc
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koTg4ODg4Yml0YXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -824,7 +824,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_usascii_binary_binary_utf8_utf8_92c8ca57
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAODg4ODhiaXQC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -837,7 +837,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_usascii_binary_utf8_binary_utf8_a03bc6f3
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAODg4ODhiaXRhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -850,7 +850,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_usascii_binary_utf8_utf8_binary_88c39c4f
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAODg4ODhiaXRhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -863,7 +863,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_usascii_utf8_binary_binary_utf8_598e267f
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWk4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -876,7 +876,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_usascii_utf8_binary_utf8_binary_558a1212
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWk4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -889,7 +889,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_usascii_utf8_utf8_binary_binary_a0347e5d
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -902,7 +902,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_utf8_binary_binary_usascii_utf8_b40e58aa
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpODg4ODhiaXQC6FLg2AI6rpN488V3+BFeAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -915,7 +915,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_utf8_binary_binary_utf8_usascii_85ba58f6
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpODg4ODhiaXQC6FLg2AI6rpN488V3+BFe8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -928,7 +928,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_utf8_utf8_binary_usascii_binary_utf8_3c2764a9
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpODg4ODhiaXQAAAAAAAAAAALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -941,7 +941,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_utf8_binary_usascii_utf8_binary_d67fd879
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpODg4ODhiaXQAAAAAAAAAAPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -954,7 +954,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_utf8_binary_utf8_binary_usascii_812232b1
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpODg4ODhiaXTwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwLoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -967,7 +967,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_utf8_utf8_binary_utf8_usascii_binary_23f3a7c3
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpODg4ODhiaXTwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -980,7 +980,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_utf8_usascii_binary_binary_utf8_35643bc0
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAAA4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -993,7 +993,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_binary_utf8_utf8_usascii_binary_utf8_binary_9421ed8f
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAAA4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1006,7 +1006,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_utf8_usascii_utf8_binary_binary_d229fc2d
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1019,7 +1019,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_utf8_utf8_binary_binary_usascii_397e216d
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -1032,7 +1032,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_binary_utf8_utf8_utf8_binary_usascii_binary_2b0ca2e9
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI84ODg4OGJpdAAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -1045,7 +1045,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_binary_utf8_utf8_utf8_usascii_binary_binary_b2deaf1c
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAADg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1058,7 +1058,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_binary_binary_binary_utf8_utf8_utf8_a71212ca
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1071,7 +1071,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_binary_binary_utf8_binary_utf8_utf8_f4851f81
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKEC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1084,7 +1084,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_binary_binary_utf8_utf8_binary_utf8_f50ee725
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKFhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1097,7 +1097,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_binary_binary_utf8_utf8_utf8_binary_1d51814e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdPCfpKHwn6Sh8J+koQDwn6Sh8J+kofCfpKFhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1110,7 +1110,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_binary_utf8_binary_binary_utf8_utf8_f6629ca2
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShODg4ODhiaXQC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1123,7 +1123,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_binary_utf8_binary_utf8_binary_utf8_428f90e7
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShODg4ODhiaXRhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1136,7 +1136,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_binary_utf8_binary_utf8_utf8_binary_7bac4a4e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShODg4ODhiaXRhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1149,7 +1149,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_binary_utf8_utf8_binary_binary_utf8_25b291b0
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWk4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1162,7 +1162,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_binary_utf8_utf8_binary_utf8_binary_71983945
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWk4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1175,7 +1175,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_binary_utf8_utf8_utf8_binary_binary_5f331461
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1188,7 +1188,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_utf8_binary_binary_binary_utf8_utf8_23f26c43
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6Sh4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1201,7 +1201,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_utf8_binary_binary_utf8_binary_utf8_9d6c773b
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6Sh4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXRhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1214,7 +1214,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_utf8_binary_binary_utf8_utf8_binary_25491a82
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6Sh4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXRhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1227,7 +1227,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_utf8_binary_utf8_binary_binary_utf8_c58324a9
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6Sh4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPYXNjaWlpaWk4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1240,7 +1240,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_utf8_binary_utf8_binary_utf8_binary_2d95f63c
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6Sh4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPYXNjaWlpaWk4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1253,7 +1253,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_utf8_binary_utf8_utf8_binary_binary_3463b59d
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6Sh4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1266,7 +1266,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_utf8_utf8_binary_binary_binary_utf8_5d4cd68a
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1279,7 +1279,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_usascii_utf8_utf8_binary_binary_utf8_binary_46f91dc1
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1292,7 +1292,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_utf8_utf8_binary_utf8_binary_binary_cbd8962b
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1305,7 +1305,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_usascii_utf8_utf8_utf8_binary_binary_binary_d3de0de8
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     AAAAAAAAAADwn6Sh8J+kofCfpKEA8J+kofCfpKHwn6ShYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1318,7 +1318,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_binary_binary_usascii_utf8_utf8_21bb32f8
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXgAAAAAAAAAAYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1331,7 +1331,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_binary_binary_utf8_usascii_utf8_b0c8dc26
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXmFzY2lpaWlpAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1344,7 +1344,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_binary_binary_utf8_utf8_usascii_5f168ae1
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXmFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -1357,7 +1357,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_binary_binary_usascii_binary_utf8_utf8_07f43385
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AAAAAAAAAAAC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1370,7 +1370,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_binary_usascii_utf8_binary_utf8_bf3ae198
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AAAAAAAAAABhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1383,7 +1383,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_binary_usascii_utf8_utf8_binary_f3ea132b
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AAAAAAAAAABhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1396,7 +1396,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_binary_utf8_binary_usascii_utf8_efda94fb
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0YXNjaWlpaWkC6FLg2AI6rpN488V3+BFeAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1409,7 +1409,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_binary_utf8_binary_utf8_usascii_bd6fc6cf
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0YXNjaWlpaWkC6FLg2AI6rpN488V3+BFe8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -1422,7 +1422,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_binary_binary_utf8_usascii_binary_utf8_805510be
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0YXNjaWlpaWkAAAAAAAAAAALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1435,7 +1435,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_binary_utf8_usascii_utf8_binary_fe0c1663
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0YXNjaWlpaWkAAAAAAAAAAPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1448,7 +1448,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_binary_utf8_utf8_binary_usascii_978eda1e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0YXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwLoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -1461,7 +1461,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_binary_binary_utf8_utf8_usascii_binary_7f1f63ad
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0YXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -1474,7 +1474,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_usascii_binary_binary_utf8_utf8_8fd88250
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jwAAAAAAAAAAODg4ODhiaXQC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1487,7 +1487,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_usascii_binary_utf8_binary_utf8_290fdded
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jwAAAAAAAAAAODg4ODhiaXRhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1500,7 +1500,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_usascii_binary_utf8_utf8_binary_2e8ce92e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jwAAAAAAAAAAODg4ODhiaXRhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1513,7 +1513,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_usascii_utf8_binary_binary_utf8_34700f6f
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jwAAAAAAAAAAYXNjaWlpaWk4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1526,7 +1526,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_usascii_utf8_binary_utf8_binary_559136aa
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jwAAAAAAAAAAYXNjaWlpaWk4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1539,7 +1539,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_usascii_utf8_utf8_binary_binary_254cb58e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jwAAAAAAAAAAYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1552,7 +1552,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_utf8_binary_binary_usascii_utf8_9366d5c2
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpODg4ODhiaXQC6FLg2AI6rpN488V3+BFeAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1565,7 +1565,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_utf8_binary_binary_utf8_usascii_5799ded2
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpODg4ODhiaXQC6FLg2AI6rpN488V3+BFe8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -1578,7 +1578,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_binary_utf8_binary_usascii_binary_utf8_778848ea
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpODg4ODhiaXQAAAAAAAAAAALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1591,7 +1591,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_utf8_binary_usascii_utf8_binary_c65a5987
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpODg4ODhiaXQAAAAAAAAAAPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1604,7 +1604,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_utf8_binary_utf8_binary_usascii_c1410f66
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpODg4ODhiaXTwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwLoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -1617,7 +1617,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_binary_utf8_binary_utf8_usascii_binary_26f9e349
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpODg4ODhiaXTwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -1630,7 +1630,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_utf8_usascii_binary_binary_utf8_927ae2cd
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpAAAAAAAAAAA4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1643,7 +1643,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_binary_utf8_usascii_binary_utf8_binary_13dc2d3b
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpAAAAAAAAAAA4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1656,7 +1656,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_utf8_usascii_utf8_binary_binary_e7c99bb8
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlpAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1669,7 +1669,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_utf8_utf8_binary_binary_usascii_589018f5
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -1682,7 +1682,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_binary_utf8_utf8_binary_usascii_binary_39966668
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI84ODg4OGJpdAAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -1695,7 +1695,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_binary_utf8_utf8_usascii_binary_binary_ac72fcbb
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koeKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j2FzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAADg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1708,7 +1708,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_usascii_binary_binary_binary_utf8_utf8_709f258c
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAA4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQC6FLg2AI6rpN488V3+BFeYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1721,7 +1721,7 @@
     iv5: *iv5
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_usascii_binary_binary_utf8_binary_utf8_7c759f86
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAA4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXRhc2NpaWlpaQLoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1734,7 +1734,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_usascii_binary_binary_utf8_utf8_binary_0fe536f1
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAA4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXRhc2NpaWlpafCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1747,7 +1747,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_usascii_binary_utf8_binary_binary_utf8_69edf179
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAA4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPYXNjaWlpaWk4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1760,7 +1760,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_usascii_binary_utf8_binary_utf8_binary_2ef1c008
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAA4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPYXNjaWlpaWk4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1773,7 +1773,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_usascii_binary_utf8_utf8_binary_binary_deb2781c
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAA4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1786,7 +1786,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_usascii_utf8_binary_binary_binary_utf8_19005acf
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWnim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1799,7 +1799,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_usascii_utf8_binary_binary_utf8_binary_77491cb9
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWnim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1812,7 +1812,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_usascii_utf8_binary_utf8_binary_binary_3b3223bd
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWnim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1825,7 +1825,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_usascii_utf8_utf8_binary_binary_binary_cbfc6fb3
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koQAAAAAAAAAAYXNjaWlpaWnwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1838,7 +1838,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_binary_binary_binary_usascii_utf8_0f40b8eb
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQC6FLg2AI6rpN488V3+BFeAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1851,7 +1851,7 @@
     iv5: *iv3
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_utf8_binary_binary_binary_utf8_usascii_bc1d7063
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQC6FLg2AI6rpN488V3+BFe8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAA==
@@ -1864,7 +1864,7 @@
     iv5: *iv6
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_utf8_binary_binary_usascii_binary_utf8_a614e821
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQAAAAAAAAAAALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1877,7 +1877,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_utf8_binary_binary_usascii_utf8_binary_d77d0ffa
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXQAAAAAAAAAAPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1890,7 +1890,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_binary_binary_utf8_binary_usascii_6e53a9c4
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwLoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -1903,7 +1903,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_utf8_binary_binary_utf8_usascii_binary_d0b63e5b
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPODg4ODhiaXTwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jwAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -1916,7 +1916,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_binary_usascii_binary_binary_utf8_63d8c552
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAAA4ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -1929,7 +1929,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_utf8_binary_usascii_binary_utf8_binary_a32af3d1
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAAA4ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -1942,7 +1942,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_binary_usascii_utf8_binary_binary_af833032
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iPAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1955,7 +1955,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_binary_utf8_binary_binary_usascii_94127997
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -1968,7 +1968,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_utf8_binary_utf8_binary_usascii_binary_12edbb13
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI84ODg4OGJpdAAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -1981,7 +1981,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_binary_utf8_usascii_binary_binary_3dfa6630
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP4pu977iP8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAADg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -1994,7 +1994,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_usascii_binary_binary_binary_utf8_9214db18
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV7wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jw==
@@ -2007,7 +2007,7 @@
     iv5: *iv2
     iv6: *iv6
 - name: RecordedTest#test_encoding_utf8_utf8_usascii_binary_binary_utf8_binary_785864e9
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdPCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq77iPAuhS4NgCOq6TePPFd/gRXg==
@@ -2020,7 +2020,7 @@
     iv5: *iv6
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_usascii_binary_utf8_binary_binary_9cf04b37
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAADim73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/wn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -2033,7 +2033,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_usascii_utf8_binary_binary_binary_4f0f608b
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlpAAAAAAAAAADwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+Mqu+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -2046,7 +2046,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_utf8_binary_binary_binary_usascii_d6286344
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdALoUuDYAjquk3jzxXf4EV4AAAAAAAAAAA==
@@ -2059,7 +2059,7 @@
     iv5: *iv2
     iv6: *iv3
 - name: RecordedTest#test_encoding_utf8_utf8_utf8_binary_binary_usascii_binary_62490583
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI84ODg4OGJpdAAAAAAAAAAAAuhS4NgCOq6TePPFd/gRXg==
@@ -2072,7 +2072,7 @@
     iv5: *iv3
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_utf8_binary_usascii_binary_binary_2dab4bd3
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI/im73vuI8AAAAAAAAAADg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -2085,7 +2085,7 @@
     iv5: *iv1
     iv6: *iv2
 - name: RecordedTest#test_encoding_utf8_utf8_utf8_usascii_binary_binary_binary_8b848d4e
-  required_features: [binary_data]
+  features: [binary_data]
   template: *template
   expected: !binary |-
     8J+kofCfpKHwn6ShAPCfpKHwn6Sh8J+koWFzY2lpaWlp8J+MqvCfjKrwn4yq8J+MqvCfjKrwn4yq8J+MqvCfjKrvuI8AAAAAAAAAAOKbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4j+Kbve+4jzg4ODg4Yml0AuhS4NgCOq6TePPFd/gRXg==
@@ -2182,13 +2182,13 @@
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_conditional_tag_returns_false_when_the_operator_is_unknown_5c21eaec8
-  required_features:
+  features:
     - lax_parsing
   expected: ''
   template: "{% if a true %}{% endif %}"
   environment: {}
 - name: RecordedTest#test_correct_error_when_unknown_operators_are_used_in_elsif_and_if_is_false_0589cd983
-  required_features:
+  features:
     - lax_parsing
   expected: 'Liquid error (line 1): Unknown operator true'
   template: |-
@@ -2199,20 +2199,20 @@
     {% endif %}
   environment: {}
 - name: RecordedTest#test_does_not_ignore_unknown_operators_when_the_tags_body_is_empty_but_there_is_an_else_c330ba20b
-  required_features:
+  features:
     - lax_parsing
   expected: 'Liquid error (line 1): Unknown operator true'
   template: "{% if true true %}{% else %}1{% endif %}"
   environment: {}
 - name: RecordedTest#test_does_not_output_error_when_short_circuit_evaluation_avoids_using_the_unknown_operator_68463361a
-  required_features:
+  features:
     - lax_parsing
   expected: b
   template: "{% if dynamic and true true %}a{% else %}b{% endif %}"
   environment:
     dynamic: false
 - name: RecordedTest#test_does_not_output_error_when_unknown_operators_are_used_in_elsif_but_if_is_true_9f923dacb
-  required_features:
+  features:
     - lax_parsing
   expected: a
   template: "{% if true %}a{% elsif true true %}b{% endif %}"
@@ -2254,7 +2254,7 @@
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_ignore_unknown_operators_when_the_tags_body_is_empty_c0bf47389
-  required_features:
+  features:
     - lax_parsing
   expected: ''
   template: "{% if true true %}{% endif %}"
@@ -2397,20 +2397,20 @@
   filesystem:
     child: "{{ item }}"
 - name: RecordedTest#test_rendering_include_asset_not_found_error_from_snippet_9b4ebca33
-  required_features: [shopify_error_handling]
+  features: [shopify_error_handling]
   expected: 'Liquid error (foo line 1): Could not find asset bar'
   template: "{% include 'foo' %}"
   environment: {}
   filesystem:
     foo: "{% include 'bar' %}"
 - name: RecordedTest#test_rendering_include_tag_with_file_does_not_exist_does_not_repeat_dot_liquid_extension_da1add0e3
-  required_features: [shopify_error_format]
+  features: [shopify_error_format]
   expected: 'Liquid error (line 1): Could not find asset foo.liquid'
   template: "{% include 'foo.liquid' %}"
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_rendering_include_tag_with_variables_and_file_does_not_exist_528dba57f
-  required_features: [shopify_error_format]
+  features: [shopify_error_format]
   expected: 'Liquid error (line 1): Could not find asset locale_variables'
   template: "{% include 'locale_variables' echo1: 'test123' %}"
   environment: {}
@@ -2510,7 +2510,7 @@
   environment:
     x: "\vGround\tcontrol\nto\rMajor\nTom."
 - name: RecordedTest#test_unsupported_operators_render_an_error_618870a92
-  required_features:
+  features:
     - lax_parsing
   expected: 'Liquid error (line 1): Unknown operator ='
   template: "{% if 0 = 0 %}NOPE{% endif %}"
@@ -2540,7 +2540,7 @@
     x: 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_0bf709cdb
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,0)y"
   template: "(4,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2548,7 +2548,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_30d06a02d
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,6)y"
   template: "(6,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2558,7 +2558,7 @@
     b: *1
   filesystem: {}
 - name: RecordedTest#test_array_equality_acb840454
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,0)n"
   template: "(7,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2567,7 +2567,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_177c8451b
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,1)y"
   template: "(7,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2577,7 +2577,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_66cb5d9e8
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,2)n"
   template: "(7,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2588,7 +2588,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_942654985
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,3)y"
   template: "(7,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2598,7 +2598,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_5fcfca576
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,4)n"
   template: "(7,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2607,7 +2607,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_52682e874
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,5)y"
   template: "(7,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2617,7 +2617,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_d7fbf88ea
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,6)n"
   template: "(7,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2628,7 +2628,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_883546623
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,6)n"
   template: "(3,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2639,7 +2639,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_79693fe3c
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,5)y"
   template: "(3,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2649,7 +2649,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_b03a01068
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,4)n"
   template: "(3,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2658,7 +2658,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_28ad15de5
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,3)y"
   template: "(3,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2667,7 +2667,7 @@
     b: *2
   filesystem: {}
 - name: RecordedTest#test_array_equality_ef0cb720f
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,7)y"
   template: "(7,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2676,7 +2676,7 @@
     b: *3
   filesystem: {}
 - name: RecordedTest#test_array_equality_89e0cea30
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,2)n"
   template: "(3,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2687,7 +2687,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_5ccaa46da
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,1)y"
   template: "(3,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2697,7 +2697,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_601794035
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,0)n"
   template: "(3,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2706,7 +2706,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_fe011c5b4
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,7)n"
   template: "(2,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2717,7 +2717,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_42a0bd643
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,6)y"
   template: "(2,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2729,7 +2729,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_8f51adcfc
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,5)n"
   template: "(2,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2740,7 +2740,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_6c527aed3
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,4)n"
   template: "(2,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2750,7 +2750,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_6dde0dcf7
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,3)n"
   template: "(2,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2761,7 +2761,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_6276c612b
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,2)y"
   template: "(2,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2771,7 +2771,7 @@
     b: *4
   filesystem: {}
 - name: RecordedTest#test_array_equality_e13b66d26
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,1)n"
   template: "(2,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2782,7 +2782,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_8f3d8f269
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,0)n"
   template: "(2,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2792,7 +2792,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_4c29cbf04
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,7)y"
   template: "(1,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2802,7 +2802,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_5a66f2593
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,6)n"
   template: "(1,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2813,7 +2813,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_90f598e19
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,5)y"
   template: "(1,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2823,7 +2823,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_813c1adf9
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,4)n"
   template: "(1,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2832,7 +2832,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_8af728851
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,3)y"
   template: "(1,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2842,7 +2842,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_44a21d70e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,2)n"
   template: "(1,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2853,7 +2853,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_97cd5b0c9
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,1)y"
   template: "(1,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2862,7 +2862,7 @@
     b: *5
   filesystem: {}
 - name: RecordedTest#test_array_equality_5e12d42dd
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,0)n"
   template: "(1,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2871,7 +2871,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_2ac642825
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,7)n"
   template: "(0,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2880,7 +2880,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_a7165c91e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,6)n"
   template: "(0,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2890,7 +2890,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_4e80dd7e0
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,5)n"
   template: "(0,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2899,7 +2899,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_82ca91136
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,4)y"
   template: "(0,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2907,7 +2907,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_37c61c7ec
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,3)n"
   template: "(0,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2916,7 +2916,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_f10d67b70
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,2)n"
   template: "(0,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2926,7 +2926,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_5c8001355
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,1)n"
   template: "(0,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2935,7 +2935,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_1f9d960e5
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,0)y"
   template: "(0,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2943,7 +2943,7 @@
     b: *6
   filesystem: {}
 - name: RecordedTest#test_array_equality_6b83cba66
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,7)y"
   template: "(3,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2953,7 +2953,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_f48a900fc
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,1)n"
   template: "(4,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2962,7 +2962,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_c6e7cfc53
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,2)n"
   template: "(4,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2972,7 +2972,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_9fabb3d69
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,3)n"
   template: "(4,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2981,7 +2981,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_d2b2dadd4
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,4)y"
   template: "(4,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2989,7 +2989,7 @@
     b: *7
   filesystem: {}
 - name: RecordedTest#test_array_equality_b08bddfbb
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,5)n"
   template: "(4,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -2998,7 +2998,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_53787360a
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,6)n"
   template: "(4,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3008,7 +3008,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_2c7a0fe4a
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,7)n"
   template: "(4,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3017,7 +3017,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_2b8d64542
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,0)n"
   template: "(5,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3026,7 +3026,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_7527aba0d
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,1)y"
   template: "(5,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3036,7 +3036,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_1dfbfd714
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,2)n"
   template: "(5,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3047,7 +3047,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_0e0558d41
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,3)y"
   template: "(5,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3057,7 +3057,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_7b1d9698c
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,4)n"
   template: "(5,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3066,7 +3066,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_06368e270
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,5)y"
   template: "(5,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3075,7 +3075,7 @@
     b: *8
   filesystem: {}
 - name: RecordedTest#test_array_equality_17eb50c09
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,6)n"
   template: "(5,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3086,7 +3086,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_d8bd79d9d
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,7)y"
   template: "(5,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3096,7 +3096,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_e37dfe191
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,0)n"
   template: "(6,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3106,7 +3106,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_10f72890c
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,1)n"
   template: "(6,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3117,7 +3117,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_7f20cc13c
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,2)y"
   template: "(6,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3129,7 +3129,7 @@
     - 2
   filesystem: {}
 - name: RecordedTest#test_array_equality_95643fa49
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,3)n"
   template: "(6,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3140,7 +3140,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_5ec79d27f
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,4)n"
   template: "(6,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3150,7 +3150,7 @@
     b: []
   filesystem: {}
 - name: RecordedTest#test_array_equality_24802c9ea
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,5)n"
   template: "(6,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3161,7 +3161,7 @@
     - 1
   filesystem: {}
 - name: RecordedTest#test_array_equality_6a75997f8
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,7)n"
   template: "(6,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -3252,7 +3252,7 @@
     bar: 10
   filesystem: {}
 - name: RecordedTest#test_assign_binds_to_the_template_name_with_much_quirks-1_b2bd69483
-  required_features:
+  features:
     - shopify_includes
   expected: blueberry-other_flavor
   template: '{%- include "product" -%}
@@ -3275,7 +3275,7 @@
       {%- assign product = all_products["other_product"] -%}
       {{ product.flavor }}-{{ all_products["other_product"].flavor -}}
 - name: RecordedTest#test_assign_binds_to_the_template_name_with_much_quirks-2_b9250013b
-  required_features:
+  features:
     - shopify_includes
   expected: other_flavor-other_flavorother_flavor-other_flavor
   template: |
@@ -3298,7 +3298,7 @@
       {%- assign product = all_products["other_product"] -%}
       {{ product.flavor }}-{{ all_products["other_product"].flavor -}}
 - name: RecordedTest#test_assign_binds_to_the_template_name_with_much_quirks-3_1fcf60910
-  required_features:
+  features:
     - shopify_includes
   expected: blueberry-other_flavorother_flavor-other_flavor
   template: |
@@ -3321,7 +3321,7 @@
       {%- assign product = all_products["other_product"] -%}
       {{ product.flavor }}-{{ all_products["other_product"].flavor -}}
 - name: RecordedTest#test_assign_which_raises_does_not_assign_and_does_not_output_error_7bd3f534f
-  required_features: [runtime_drops, shopify_filters]
+  features: [runtime_drops, shopify_filters]
   expected: |2+
 
 
@@ -3353,7 +3353,7 @@
   environment:
     a: []
   filesystem: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "a['size'] returns nil which is blank in Shopify. Standard Ruby nil lacks blank?"
 - name: RecordedTest#test_auto_methods_c35cdf16c
   expected: 4,blank
@@ -3365,7 +3365,7 @@
     - 3
     - wtf
   filesystem: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "a['size'] returns nil which is blank in Shopify. Standard Ruby nil lacks blank?"
 - name: RecordedTest#test_auto_methods_23431d0f8
   expected: 1,
@@ -3441,7 +3441,7 @@
     h:
       a: 1
   filesystem: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "h['size'] returns nil which is blank in Shopify. Standard Ruby nil lacks blank?"
 - name: RecordedTest#test_base64_decode_filter_54a7308e9
   expected: bar
@@ -3595,7 +3595,7 @@
   environment:
     x: false
   filesystem: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "Shopify blank includes false. Standard liquid blank is just empty string."
 - name: RecordedTest#test_blank_a322ef41c
   expected: is not blank
@@ -3618,7 +3618,7 @@
   environment:
     h: {}
   filesystem: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "Shopify blank includes empty hashes. Standard liquid blank is just empty string."
 - name: RecordedTest#test_blank_12cb41d0c
   expected: "n"
@@ -3633,7 +3633,7 @@
   environment:
     x: " "
   filesystem: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "Shopify blank includes whitespace-only strings. Standard liquid blank is just empty string."
 - name: RecordedTest#test_blank_c068a3ab1
   expected: "y"
@@ -3641,10 +3641,10 @@
   environment:
     a: []
   filesystem: {}
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "Shopify blank includes empty arrays. Standard liquid blank is just empty string."
 - name: RecordedTest#test_bool_key_c7d471301
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -3653,7 +3653,7 @@
       true: "y"
   filesystem: {}
 - name: RecordedTest#test_bool_key_053c698c0
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -3662,7 +3662,7 @@
       true: "y"
   filesystem: {}
 - name: RecordedTest#test_bool_key_f2a45499d
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -3671,7 +3671,7 @@
       true: "y"
   filesystem: {}
 - name: RecordedTest#test_bool_key_9c9d20806
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -3749,7 +3749,7 @@
   environment:
     encoded_bytes: SWJ3wY8OTdgJ+GjR
   filesystem: {}
-  required_features: [shopify_string_access]
+  features: [shopify_string_access]
   hint: "Shopify supports string.first to get first character. Standard liquid-ruby doesn't."
 - name: RecordedTest#test_bytes_last_1ac9e3dfb
   expected: e
@@ -3757,7 +3757,7 @@
   environment:
     name: mike
   filesystem: {}
-  required_features: [shopify_string_access]
+  features: [shopify_string_access]
   hint: "Shopify supports string.last to get last character. Standard liquid-ruby doesn't."
 - name: RecordedTest#test_bytes_size_ee552c07e
   expected: ''
@@ -4222,7 +4222,7 @@
     b: 2
   filesystem: {}
 - name: RecordedTest#test_compiles_files_with_unconventional_names_52e6df11b
-  required_features:
+  features:
     - shopify_includes
   expected: |-
     case-extension
@@ -4246,7 +4246,7 @@
     '': no-basename
     a b: spaces
 - name: RecordedTest#test_contains_188808998
-  required_features:
+  features:
     - activesupport
   expected: "n"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4263,7 +4263,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_e0b16b4bf
-  required_features:
+  features:
     - activesupport
   expected: "n"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4278,7 +4278,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_63cadb7e8
-  required_features:
+  features:
     - activesupport
   expected: "n"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4293,7 +4293,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_691d731c9
-  required_features:
+  features:
     - activesupport
   expected: "n"
   template: "{%if a contains b%}y{%else%}n{%endif%}"
@@ -4309,7 +4309,7 @@
     - true
   filesystem: {}
 - name: RecordedTest#test_contains_dc8ba9547
-  required_features:
+  features:
     - activesupport
   expected: "y"
   template: "{%if a contains b%}y{%else%}n{%endif%}"
@@ -4325,7 +4325,7 @@
     - true
   filesystem: {}
 - name: RecordedTest#test_contains_c91ceee8f
-  required_features:
+  features:
     - activesupport
   expected: "n"
   template: "{%if a contains b%}y{%else%}n{%endif%}"
@@ -4339,7 +4339,7 @@
     - true
   filesystem: {}
 - name: RecordedTest#test_contains_a01f9e979
-  required_features:
+  features:
     - activesupport
   expected: "y"
   template: "{%if a contains b%}y{%else%}n{%endif%}"
@@ -4353,7 +4353,7 @@
     - true
   filesystem: {}
 - name: RecordedTest#test_contains_66f7834f6
-  required_features:
+  features:
     - activesupport
   expected: "n"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4368,7 +4368,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_b30528265
-  required_features:
+  features:
     - activesupport
   expected: "y"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4383,7 +4383,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_d3921c296
-  required_features:
+  features:
     - activesupport
   expected: "n"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4398,7 +4398,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_83c205efd
-  required_features:
+  features:
     - activesupport
   expected: "y"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4415,7 +4415,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_05d00bfac
-  required_features:
+  features:
     - activesupport
   expected: "y"
   template: "{%if h contains b%}y{%else%}n{%endif%}"
@@ -4430,7 +4430,7 @@
       - 2
   filesystem: {}
 - name: RecordedTest#test_contains_always_false_for_falsy_targets_c906fc9dc
-  required_features:
+  features:
     - activesupport
   expected: 'no'
   template: "{% if a contains b %}yes{% else %}no{% endif %}"
@@ -4440,7 +4440,7 @@
     b: false
   filesystem: {}
 - name: RecordedTest#test_contains_casts_to_string_if_left_is_string_39ca4d1a1
-  required_features:
+  features:
     - activesupport
   expected: 'yes'
   template: "{% if a contains b %}yes{% else %}no{% endif %}"
@@ -4449,7 +4449,7 @@
     b: 2
   filesystem: {}
 - name: RecordedTest#test_contains_operator_with_array_not_matching_type_e7aecf6a7
-  required_features:
+  features:
     - activesupport
   expected: 'no'
   template: "{% if a contains b %}yes{% else %}no{% endif %}"
@@ -4461,7 +4461,7 @@
     b: '2'
   filesystem: {}
 - name: RecordedTest#test_contains_operator_with_string_and_false_87aa46715
-  required_features:
+  features:
     - activesupport
   expected: ''
   template: "{% if a contains b %}yes{% endif %}"
@@ -4470,7 +4470,7 @@
     b: false
   filesystem: {}
 - name: RecordedTest#test_contains_operator_with_string_and_nil_4d77ff9b8
-  required_features:
+  features:
     - activesupport
   expected: ''
   template: "{% if a contains b %}yes{% endif %}"
@@ -4479,7 +4479,7 @@
     b:
   filesystem: {}
 - name: RecordedTest#test_contains_operator_with_strings_b532debf2
-  required_features:
+  features:
     - activesupport
   expected: 'yes'
   template: "{% if a contains b %}yes{% else %}no{% endif %}"
@@ -4512,7 +4512,7 @@
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_data_escaping_9e876fe0d
-  required_features:
+  features:
     - lax_parsing
   expected: "\n\r\t'\"\\\U0001F44B\U0001F3FB"
   template: "\n\r\t'\"\\\U0001F44B\U0001F3FB{{_✅}}"
@@ -4530,7 +4530,7 @@
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_display_non_utf8_string_6d9a4e58e
-  required_features: [binary_data]
+  features: [binary_data]
   expected: !binary |-
     SGVsbG8sIMA=
   template: "{{ input }}"
@@ -4539,7 +4539,7 @@
       SGVsbG8sIMA=
   filesystem: {}
 - name: RecordedTest#test_dynamic_include_not_found_9d6ba106c
-  required_features: [shopify_error_handling]
+  features: [shopify_error_handling]
   expected: 'Liquid error (line 1): Could not find asset baz'
   template: "{% include template %}"
   environment:
@@ -4547,7 +4547,7 @@
   filesystem:
     foo: bar
 - name: RecordedTest#test_dynamic_include_not_found_two_9d6ba106a
-  required_features: [shopify_error_handling]
+  features: [shopify_error_handling]
   expected: 'Liquid error (line 1): Could not find asset BAz'
   template: "{% include template %}"
   environment:
@@ -4636,7 +4636,7 @@
     flavors: []
   filesystem: {}
 - name: RecordedTest#test_equality_a815b7f6a
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,2)n"
   template: "(4,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4646,7 +4646,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_4ba0c4dad
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,3)n"
   template: "(4,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4655,7 +4655,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_78afa6653
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,4)y"
   template: "(4,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4663,7 +4663,7 @@
     b: *9
   filesystem: {}
 - name: RecordedTest#test_equality_080c1667e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,7)y"
   template: "(3,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4673,7 +4673,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_572248119
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,6)n"
   template: "(3,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4684,7 +4684,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_b73d04416
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,6)n"
   template: "(4,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4694,7 +4694,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_1acd92938
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,7)n"
   template: "(4,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4703,7 +4703,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_79d48239f
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,0)n"
   template: "(5,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4712,7 +4712,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_b8d575167
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,1)y"
   template: "(5,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4722,7 +4722,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_c191dcccb
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,2)n"
   template: "(5,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4733,7 +4733,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_bf03b78eb
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,3)y"
   template: "(5,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4743,7 +4743,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_ba794d264
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,4)n"
   template: "(5,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4752,7 +4752,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_6f852d8e3
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,5)y"
   template: "(3,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4762,7 +4762,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_651574345
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,3)y"
   template: "(3,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4771,7 +4771,7 @@
     b: *10
   filesystem: {}
 - name: RecordedTest#test_equality_c03ff9183
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,4)n"
   template: "(3,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4780,7 +4780,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_d79c4cb55
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,6)n"
   template: "(5,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4791,7 +4791,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_3b0db3259
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,1)y"
   template: "(1,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4800,7 +4800,7 @@
     b: *11
   filesystem: {}
 - name: RecordedTest#test_equality_bd0680f5a
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,0)y"
   template: "(4,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4808,7 +4808,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_746213c6d
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,7)n"
   template: "(6,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4819,7 +4819,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_ee9b21e78
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,7)n"
   template: "(0,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4828,7 +4828,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_2ea0b47d4
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,6)n"
   template: "(0,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4838,7 +4838,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_f1db4f13e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,2)n"
   template: "(1,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4849,7 +4849,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_a95f5e3a9
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,3)y"
   template: "(1,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4859,7 +4859,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_11e1e4e8c
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,4)n"
   template: "(1,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4868,7 +4868,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_d95e6f8fc
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,5)y"
   template: "(1,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4878,7 +4878,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_c07131bea
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,0)n"
   template: "(7,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4887,7 +4887,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_4fdad3c27
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,5)n"
   template: "(0,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4896,7 +4896,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_8fd696fe9
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,4)y"
   template: "(0,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4904,7 +4904,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_19e5ac63e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,6)y"
   template: "(6,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4914,7 +4914,7 @@
     b: *12
   filesystem: {}
 - name: RecordedTest#test_equality_6bb657da3
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,5)n"
   template: "(6,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4925,7 +4925,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_737ac4596
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,4)n"
   template: "(6,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4935,7 +4935,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_4cd40ee19
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,3)n"
   template: "(6,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4946,7 +4946,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_8c99c5e09
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,2)y"
   template: "(6,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4958,7 +4958,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_9c07ffbc5
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,1)n"
   template: "(6,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4969,7 +4969,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_cdc5b02af
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,0)n"
   template: "(1,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4978,7 +4978,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_363196cb6
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(6,0)n"
   template: "(6,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4988,7 +4988,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_667e2baa1
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,1)y"
   template: "(7,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -4998,7 +4998,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_0988d5bf2
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,6)n"
   template: "(1,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5009,7 +5009,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_bc128c27a
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(1,7)y"
   template: "(1,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5019,7 +5019,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_8bcb67279
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,0)n"
   template: "(2,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5029,7 +5029,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_de06d7025
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,1)n"
   template: "(2,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5040,7 +5040,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_0148d6700
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,2)y"
   template: "(2,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5050,7 +5050,7 @@
     b: *13
   filesystem: {}
 - name: RecordedTest#test_equality_9108aba65
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,3)n"
   template: "(2,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5061,7 +5061,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_ffb667541
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,3)n"
   template: "(0,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5070,7 +5070,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_3629b980e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,4)n"
   template: "(2,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5080,7 +5080,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_046e1b5d0
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,2)n"
   template: "(0,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5090,7 +5090,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_53bb9e5b2
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,5)n"
   template: "(2,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5101,7 +5101,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_bc36f44d6
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,6)y"
   template: "(2,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5113,7 +5113,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_9f580f4a4
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(2,7)n"
   template: "(2,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5124,7 +5124,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_1d2d3788c
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,0)n"
   template: "(3,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5133,7 +5133,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_cc53da9ab
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,7)y"
   template: "(5,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5143,7 +5143,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_2e000f0ff
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,1)n"
   template: "(0,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5152,7 +5152,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_4109f0676
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,2)n"
   template: "(7,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5163,7 +5163,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_bb299a5d6
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(0,0)y"
   template: "(0,0){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5171,7 +5171,7 @@
     b: *14
   filesystem: {}
 - name: RecordedTest#test_equality_80790cf44
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,2)n"
   template: "(3,2){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5182,7 +5182,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_0604d6615
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(3,1)y"
   template: "(3,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5192,7 +5192,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_a4c345725
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(5,5)y"
   template: "(5,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5201,7 +5201,7 @@
     b: *15
   filesystem: {}
 - name: RecordedTest#test_equality_3f5b4f148
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,5)n"
   template: "(4,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5210,7 +5210,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_6c1374a33
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,7)y"
   template: "(7,7){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5219,7 +5219,7 @@
     b: *16
   filesystem: {}
 - name: RecordedTest#test_equality_3408a7d9b
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,6)n"
   template: "(7,6){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5230,7 +5230,7 @@
       b: 2
   filesystem: {}
 - name: RecordedTest#test_equality_37610c451
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,5)y"
   template: "(7,5){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5240,7 +5240,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_849ea560e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(4,1)n"
   template: "(4,1){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5249,7 +5249,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_equality_e4a24d991
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,4)n"
   template: "(7,4){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5258,7 +5258,7 @@
     b: {}
   filesystem: {}
 - name: RecordedTest#test_equality_033b8b1d3
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "(7,3)y"
   template: "(7,3){% if a == b %}y{%else%}n{%endif%}"
   environment:
@@ -5268,7 +5268,7 @@
       a: 1
   filesystem: {}
 - name: RecordedTest#test_errors_when_comparing_uncomparable_types_05fff3843
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{% if a < b %}something{% endif %}"
   environment:
@@ -5314,7 +5314,7 @@
     b: a
   filesystem: {}
 - name: RecordedTest#test_errors_when_comparing_uncomparable_types_07a79164e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{% if a < b %}something{% endif %}"
   environment:
@@ -5338,7 +5338,7 @@
     b: 1.0
   filesystem: {}
 - name: RecordedTest#test_errors_when_comparing_uncomparable_types_0e4b4dde0
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{% if a < b %}something{% endif %}"
   environment:
@@ -5362,7 +5362,7 @@
     b:
   filesystem: {}
 - name: RecordedTest#test_errors_when_comparing_uncomparable_types_ba4c0069b
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{% if a < b %}something{% endif %}"
   environment:
@@ -5393,7 +5393,7 @@
     b: false
   filesystem: {}
 - name: RecordedTest#test_errors_when_comparing_uncomparable_types_0ce277577
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{% if a < b %}something{% endif %}"
   environment:
@@ -5431,7 +5431,7 @@
     b: true
   filesystem: {}
 - name: RecordedTest#test_errors_when_comparing_uncomparable_types_750a27a39
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{% if a < b %}something{% endif %}"
   environment:
@@ -5551,7 +5551,7 @@
     b: a
   filesystem: {}
 - name: RecordedTest#test_errors_when_comparing_uncomparable_types_624e423c0
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{% if a < b %}something{% endif %}"
   environment:
@@ -5576,7 +5576,7 @@
       alt:
   filesystem: {}
 - name: RecordedTest#test_filter_hash_argument_has_correct_key_order_e77960f36
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "primary: test\n\"a\" => 1, \"b\" => 2, \"c\" => 3, \"d\" => 4, \"e\"
     => 5, "
   template: "{{ 'test' | args_to_s: a: 1, b: 2, c: 3, d: 4, e: 5 }}"
@@ -12793,7 +12793,7 @@
     - bro
   filesystem: {}
 - name: RecordedTest#test_for_loop_on_object_with_limit_a6030f943
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: 'foobarbazqux
 
     '
@@ -12805,7 +12805,7 @@
       :hello: world
   filesystem: {}
 - name: RecordedTest#test_for_loop_on_object_with_offset_f66369261
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: 'helloworld
 
     '
@@ -21382,7 +21382,7 @@
     i: true
   filesystem: {}
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_50099cb54
-  required_features:
+  features:
     - shopify_includes
   expected: |
     other_product-
@@ -21405,7 +21405,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_56687d174
-  required_features:
+  features:
     - shopify_includes
   expected: |
     product-
@@ -21429,7 +21429,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_7d6f093f7
-  required_features:
+  features:
     - shopify_includes
   expected: |
     product-
@@ -21452,7 +21452,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_4213e9b69
-  required_features:
+  features:
     - shopify_includes
   expected: |
     foo is not a product-
@@ -21475,7 +21475,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_d446dd9a8
-  required_features:
+  features:
     - shopify_includes
   expected: |
     product-product
@@ -21498,7 +21498,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_a3b152cc9
-  required_features:
+  features:
     - shopify_includes
   expected: |
     other_product-
@@ -21521,7 +21521,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_d2d5a2c4d
-  required_features:
+  features:
     - shopify_includes
   expected: |
     product-
@@ -21546,7 +21546,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_bfa86ade0
-  required_features:
+  features:
     - shopify_includes
   expected: |
     product-
@@ -21571,7 +21571,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_367b036ba
-  required_features:
+  features:
     - shopify_includes
   expected: |
     product-other_product
@@ -21594,7 +21594,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_binds_the_expression_name_or_the_template_name_15942a706
-  required_features:
+  features:
     - shopify_includes
   expected: |
     product-product
@@ -21619,7 +21619,7 @@
     product: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
     foo: "{{ product.name }}-{{ other_product_with_explicit_binding.name }}\n"
 - name: RecordedTest#test_include_recursive_af1515727
-  required_features:
+  features:
     - shopify_includes
   expected: |+
     0
@@ -21827,7 +21827,7 @@
       {{depth}}{% assign depth = depth | plus: 1 %}
       {% include 'foo' %}
 - name: RecordedTest#test_include_recursive_after_long_chain_of_ifs_fd300544e
-  required_features:
+  features:
     - shopify_includes
   expected: |+
     rendered
@@ -22105,7 +22105,7 @@
     - foo
   filesystem: {}
 - name: RecordedTest#test_int_key_b2d924401
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -22114,7 +22114,7 @@
       1: "y"
   filesystem: {}
 - name: RecordedTest#test_int_key_959411012
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -22123,7 +22123,7 @@
       1: "y"
   filesystem: {}
 - name: RecordedTest#test_int_key_f26e1d4c8
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -22132,7 +22132,7 @@
       1: "y"
   filesystem: {}
 - name: RecordedTest#test_int_key_d82edf6d2
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -22153,7 +22153,7 @@
     b: "666666\0"
   filesystem: {}
 - name: RecordedTest#test_integer_key_7b669b10c
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: huh
   template: "{{h[2]}}"
   environment:
@@ -22161,7 +22161,7 @@
       2: huh
   filesystem: {}
 - name: RecordedTest#test_integer_key_539a5b206
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: huh
   template: "{{h[b]}}"
   environment:
@@ -22170,7 +22170,7 @@
       2: huh
   filesystem: {}
 - name: RecordedTest#test_integer_key_737d732a6
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -22219,7 +22219,7 @@
     - a
   filesystem: {}
 - name: RecordedTest#test_jwt_0b15043ff
-  required_features:
+  features:
     - shopify_filters
   expected: '"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzbm93ZGV2aWwuY2EiLCJzdWIiOjEyMzQsImlhdCI6ICIwIgogICAgICAgICwiZXhwIjogIjAiCiAgICAgICAgLCJlbWFpbCI6InRvYmlAZXhhbXBsZS5jb20ifQ.KiA"'
   template: |
@@ -22347,19 +22347,19 @@
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_native_filter_invalid_arity_99a37cdd0
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   expected: 'Liquid error (line 1): wrong number of arguments (given 1, expected 2..3)'
   template: "{{ 'hello world' | replace | asset_url }}"
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_native_filter_invalid_arity_8ba189846
-  required_features: [runtime_drops, shopify_filters]
+  features: [runtime_drops, shopify_filters]
   expected: 'Liquid error (line 1): wrong number of arguments (given 2, expected 1)'
   template: "{{ 'foo.png' | asset_url: '200x' }}"
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_native_filter_invalid_arity_1e6cd7909
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   expected: 'Liquid error (line 1): wrong number of arguments (given 1, expected 2..3)'
   template: "{{ 'hello world' | replace }}"
   environment: {}
@@ -22392,7 +22392,7 @@
     - 3
   filesystem: {}
 - name: RecordedTest#test_nil_key_c8c21159a
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -22401,7 +22401,7 @@
       ! '': "y"
   filesystem: {}
 - name: RecordedTest#test_nil_key_e442c9113
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -22410,7 +22410,7 @@
       ! '': "y"
   filesystem: {}
 - name: RecordedTest#test_nil_key_3d271b639
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -22443,35 +22443,35 @@
     x: 1
   filesystem: {}
 - name: RecordedTest#test_number_variables_784001a16
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: '1'
   template: "{{ x }}"
   environment:
     x: 1
   filesystem: {}
 - name: RecordedTest#test_number_variables_edae2a053
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: NaN
   template: "{{ x }}"
   environment:
     x: .nan
   filesystem: {}
 - name: RecordedTest#test_number_variables_9dc50eeff
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: '1.1'
   template: "{{ x }}"
   environment:
     x: 1.1
   filesystem: {}
 - name: RecordedTest#test_number_variables_a6d2a17b7
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: Infinity
   template: "{{ x }}"
   environment:
     x: .inf
   filesystem: {}
 - name: RecordedTest#test_number_variables_9709b923e
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: '20.060000000000002'
   template: "{{ x }}"
   environment:
@@ -22513,7 +22513,7 @@
     h: {}
   filesystem: {}
 - name: RecordedTest#test_output_of_filters_is_html_safe_for_integers_f3d4c8ee7
-  required_features:
+  features:
     - lax_parsing
   expected: 1000&lt;
   template: '{{ foo | truncate:  5, "<",  | escape }}'
@@ -22620,7 +22620,7 @@
   template: "{%for item in (2147483645..2147483647) %}->{{item}}{%endfor%}"
   filesystem: {}
 - name: RecordedTest#test_read_current_tags_correctly_6bb14e24f
-  required_features: [shopify_filters]
+  features: [shopify_filters]
   expected: hello,world
   template: "{{'hello' | read_current_tags | join: ','}}"
   environment:
@@ -22629,7 +22629,7 @@
     - world
   filesystem: {}
 - name: RecordedTest#test_read_current_tags_correctly_a11c1d3be
-  required_features: [shopify_filters]
+  features: [shopify_filters]
   expected: foo,bar
   template: "{% assign current_tags = 'foo,bar' | split: ',' %}{{'hello' | read_current_tags
     | join: ','}}"
@@ -22639,14 +22639,14 @@
     - world
   filesystem: {}
 - name: RecordedTest#test_read_template_correctly_d4c8dd1ec
-  required_features: [shopify_filters]
+  features: [shopify_filters]
   expected: blog
   template: "{{ 'hello' | read_template }}"
   environment:
     template: blog
   filesystem: {}
 - name: RecordedTest#test_read_template_correctly_2b5202fc1
-  required_features: [shopify_filters]
+  features: [shopify_filters]
   expected: article
   template: "{% assign template = 'article' %}{{ 'hello' | read_template }}"
   environment:
@@ -22730,13 +22730,13 @@
       %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif
       %}{% endif %}{% endif %}{% endif %}"
 - name: RecordedTest#test_render_for_missing_snippet_8c3eb0359
-  required_features: [shopify_error_handling]
+  features: [shopify_error_handling]
   expected: 'Liquid error (line 1): Could not find asset missing'
   template: "{% render 'missing' %}"
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_render_for_missing_snippet_with_case_1a518dd67
-  required_features: [shopify_error_handling]
+  features: [shopify_error_handling]
   expected: 'Liquid error (line 1): Could not find asset MISSSing'
   template: "{% render 'MISSSing' %}"
   environment: {}
@@ -22881,33 +22881,33 @@
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_runtime_filter_67c93827d
-  required_features: [runtime_drops, shopify_filters]
+  features: [runtime_drops, shopify_filters]
   expected: muffin (fake)
   template: "{{ muffin | fakey }}"
   environment:
     muffin: muffin
   filesystem: {}
 - name: RecordedTest#test_runtime_filter_cannot_reach_instance_eval_cb4a6a167
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   expected: object_id
   template: "{{ 'object_id' | instance_eval }}"
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_runtime_filter_miss_f98681654
-  required_features: [runtime_drops]
+  features: [runtime_drops]
   expected: test
   template: "{{ 'test' | unknown }}"
   environment: {}
   filesystem: {}
 - name: RecordedTest#test_runtime_filter_which_raises_e40958296
-  required_features: [runtime_drops, shopify_filters]
+  features: [runtime_drops, shopify_filters]
   expected: 'Liquid error (line 1): internal'
   template: "{{ muffin | raisy }}"
   environment:
     muffin: muffin
   filesystem: {}
 - name: RecordedTest#test_runtime_filter_with_hash_parameter_1a5314d7d
-  required_features: [runtime_drops, shopify_filters]
+  features: [runtime_drops, shopify_filters]
   expected: MUFFIN
   template: '{{ muffin | modify_case: case: "upcase" }}'
   environment:
@@ -22993,7 +22993,7 @@
   filesystem:
     my snippet: All good here
 - name: RecordedTest#test_static_includes_delegates_to_file_system_4bc51e66c
-  required_features:
+  features:
     - shopify_includes
   expected: |
     child.liquid: child.liquid content
@@ -23006,7 +23006,7 @@
     child.liquid: child.liquid content
     child: child content
 - name: RecordedTest#test_static_render_delegates_to_file_system_a3f69e304
-  required_features:
+  features:
     - shopify_includes
   expected: |
     child.liquid: child.liquid content
@@ -23025,7 +23025,7 @@
   filesystem:
     snippet.with.dots: Hello
 - name: RecordedTest#test_string_first_4cdb3e099
-  required_features:
+  features:
     - lax_parsing
   expected: m
   template: "{{ name.first }}"
@@ -23033,7 +23033,7 @@
     name: mike
   filesystem: {}
 - name: RecordedTest#test_string_first_ca67215ba
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if name.first == blank %}correct{% endif %}"
@@ -23041,7 +23041,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_first_2b3ae31a3
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if name.first == empty %}correct{% endif %}"
@@ -23049,7 +23049,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_first_65823d54f
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if !name.first %}correct{% endif %}"
@@ -23057,7 +23057,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_first_9077c9ae0
-  required_features:
+  features:
     - lax_parsing
   expected: ''
   template: "{{ name.first }}"
@@ -23065,7 +23065,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_first_b6aeab42d
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if name.first == '' %}correct{% endif %}"
@@ -23073,7 +23073,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_first_6cd361f51
-  required_features:
+  features:
     - lax_parsing
   expected: 고
   template: "{{ name.first }}"
@@ -23081,7 +23081,7 @@
     name: 고규빈
   filesystem: {}
 - name: RecordedTest#test_string_key_da6504da9
-  required_features:
+  features:
     - activesupport
   expected: ''
   template: "{{h[b]}}"
@@ -23091,7 +23091,7 @@
       word: "y"
   filesystem: {}
 - name: RecordedTest#test_string_key_48d7b0c61
-  required_features:
+  features:
     - activesupport
   expected: ''
   template: "{{h[b]}}"
@@ -23101,7 +23101,7 @@
       word: "y"
   filesystem: {}
 - name: RecordedTest#test_string_key_00509b222
-  required_features:
+  features:
     - activesupport
   expected: "y"
   template: "{{h[b]}}"
@@ -23111,7 +23111,7 @@
       word: "y"
   filesystem: {}
 - name: RecordedTest#test_string_key_fe38efada
-  required_features:
+  features:
     - activesupport
   expected: "y"
   template: "{{h[b]}}"
@@ -23131,7 +23131,7 @@
       word: "y"
   filesystem: {}
 - name: RecordedTest#test_string_last_035516211
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if !name.last %}correct{% endif %}"
@@ -23139,7 +23139,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_last_bd7cab30f
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if name.last == blank %}correct{% endif %}"
@@ -23147,7 +23147,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_last_c4fbb6fd6
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if name.last == empty %}correct{% endif %}"
@@ -23155,7 +23155,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_last_292076b0f
-  required_features:
+  features:
     - lax_parsing
   expected: correct
   template: "{% if name.last == '' %}correct{% endif %}"
@@ -23163,7 +23163,7 @@
     name: ''
   filesystem: {}
 - name: RecordedTest#test_string_last_f6e46feef
-  required_features:
+  features:
     - lax_parsing
   expected: e
   template: "{{ name.last }}"
@@ -23171,7 +23171,7 @@
     name: mike
   filesystem: {}
 - name: RecordedTest#test_string_last_dd7c79283
-  required_features:
+  features:
     - lax_parsing
   expected: 빈
   template: "{{ name.last }}"
@@ -23179,7 +23179,7 @@
     name: 고규빈
   filesystem: {}
 - name: RecordedTest#test_string_last_fc92b0a8a
-  required_features:
+  features:
     - lax_parsing
   expected: ''
   template: "{{ name.last }}"
@@ -23360,7 +23360,7 @@
       - c: 2
   filesystem: {}
 - name: RecordedTest#test_truncate_does_not_double_escape_suffix_fa67cd2ab
-  required_features:
+  features:
     - activesupport
   expected: 1 &gt;
   template: "{{ input | truncate: 6, suffix }}"
@@ -23385,7 +23385,7 @@
       instantiate:SafeBuffer:
         value: you&#39;re doing great
   filesystem: {}
-  required_features:
+  features:
     - activesupport
 - name: RecordedTest#test_truncate_with_ut8_uses_char_count_not_bytesize_0e6b525e3
   expected: L'homme à la tête de lion
@@ -23394,7 +23394,7 @@
     text: L'homme à la tête de lion
   filesystem: {}
 - name: RecordedTest#test_truncatewords_for_html_6782ac38f
-  required_features:
+  features:
     - activesupport
   expected: you&#39;re doing<
   template: "{{ description | truncatewords: 2, '<' }}"
@@ -23480,7 +23480,7 @@
     baz: baz
   filesystem: {}
 - name: RecordedTest#test_weird_keys_9494c968a
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -23493,7 +23493,7 @@
       : "y"
   filesystem: {}
 - name: RecordedTest#test_weird_keys_189fe4118
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -23502,7 +23502,7 @@
       1.1234: "y"
   filesystem: {}
 - name: RecordedTest#test_weird_keys_420cf20a4
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -23515,7 +23515,7 @@
       : "y"
   filesystem: {}
 - name: RecordedTest#test_weird_keys_ff594362d
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -23524,7 +23524,7 @@
       1.1234: "y"
   filesystem: {}
 - name: RecordedTest#test_weird_keys_8d0cd456b
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -23534,7 +23534,7 @@
       !binary "/w==": "y"
   filesystem: {}
 - name: RecordedTest#test_weird_keys_3884a16bb
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -23545,7 +23545,7 @@
       : "y"
   filesystem: {}
 - name: RecordedTest#test_weird_keys_7cd25d108
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: ''
   template: "{{h[b]}}"
   environment:
@@ -23556,7 +23556,7 @@
       : "y"
   filesystem: {}
 - name: RecordedTest#test_weird_keys_d48a90abf
-  required_features: [ruby_types]
+  features: [ruby_types]
   expected: "y"
   template: "{{h[b]}}"
   environment:
@@ -23642,7 +23642,7 @@
     a: "asdf\v"
   filesystem: {}
 - name: RecordedTest#test_missing_operator_and_rhs_in_conditional_6dc36bcf
-  required_features:
+  features:
     - strict_parsing
   template: "{% if blank %}true{% endif %}"
   expected: 'true'
@@ -23650,7 +23650,7 @@
     Using 'blank' as a standalone conditional value has inconsistent behavior
     in lax mode on some Liquid versions. Restrict to strict parsing.
 - name: RecordedTest#test_missing_operator_in_conditional_fedb552c
-  required_features:
+  features:
     - lax_parsing
   template: "{% if blank foo %}true{% endif %}"
   expected: 'Liquid error (line 1): Unknown operator foo'
@@ -23719,7 +23719,7 @@
     {%- endcase -%}
   expected: OK
 - name: RecordedTest#test_rendering_assign_whitespace_with_for_97e11238
-  required_features: [shopify_blank]
+  features: [shopify_blank]
   hint: "Uses != blank to check for non-empty collections. Requires Shopify's blank implementation."
   template: |+
     <ul class="site-nav list--inline {{ nav_alignment }}" id="SiteNav">
@@ -24777,7 +24777,7 @@
       outer:
         inner: value
 - name: RecordedTest#test_render_recursive_hash_60c54eef
-  required_features: [ruby_types]
+  features: [ruby_types]
   template: "{{ my_hash }}"
   expected: '{"self"=>{"self"=>{...}}}'
   environment:
@@ -24791,7 +24791,7 @@
     my_hash:
       numbers: []
 - name: RecordedTest#test_render_hash_with_array_values_hash_b49125a7
-  required_features: [ruby_types]
+  features: [ruby_types]
   template: "{{ my_hash }}"
   expected: '{"numbers"=>[{:foo=>42}]}'
   environment:
@@ -24799,7 +24799,7 @@
       numbers:
       - :foo: 42
 - name: RecordedTest#test_render_hash_with_hash_key_00c16c83
-  required_features: [ruby_types]
+  features: [ruby_types]
   template: "{{ my_hash }}"
   expected: '{{"foo"=>"bar"}=>42}'
   environment:

--- a/specs/shopify_production_recordings/recorded_specs_lax.yml
+++ b/specs/shopify_production_recordings/recorded_specs_lax.yml
@@ -3,7 +3,7 @@ _metadata:
   hint: |
     These specs require lax parsing mode. The syntax tested here was never valid
     Liquid - it was accidentally tolerated by the lax parser.
-  required_features: [lax_parsing]
+  features: [lax_parsing]
   required_options:
     error_mode: :lax
 specs:

--- a/specs/shopify_production_recordings/suite.yml
+++ b/specs/shopify_production_recordings/suite.yml
@@ -9,7 +9,7 @@ hint: |
   They test internal compiler behavior and may include Shopify-specific extensions.
   Failures here may be expected if your implementation differs from Shopify's.
 
-required_features:
+features:
   - inline_errors
 
 # Default complexity for unscored specs in this suite (see COMPLEXITY.md)

--- a/specs/shopify_theme_dawn/suite.yml
+++ b/specs/shopify_theme_dawn/suite.yml
@@ -16,8 +16,7 @@ hint: |
   To run these specs, your Liquid implementation must support Shopify theme tags.
 
 # Required features for this suite
-required_features:
-  - core
+features:
   - shopify_tags        # {% schema %}, {% style %}, {% section %}, etc.
   - shopify_objects     # section, block, content_for_header, etc.
   - shopify_filters     # asset_url, image_url, etc.

--- a/test/lazy_spec_test.rb
+++ b/test/lazy_spec_test.rb
@@ -68,35 +68,36 @@ class LazySpecTest < Minitest::Test
     assert patterns[1].match?("UNEXPECTED token")
   end
 
-  def test_required_features
-    spec = create_spec(required_features: [:shopify_tags, :shopify_filters])
-    assert_equal [:shopify_tags, :shopify_filters], spec.required_features
+  def test_features
+    spec = create_spec(features: [:shopify_tags, :shopify_filters])
+    assert_equal [:shopify_tags, :shopify_filters], spec.features
   end
 
   def test_error_mode_adds_lax_parsing_feature
     spec = create_spec(error_mode: :lax)
-    assert_includes spec.required_features, :lax_parsing
+    assert_includes spec.features, :lax_parsing
   end
 
   def test_error_mode_adds_strict_parsing_feature
     spec = create_spec(error_mode: :strict)
-    assert_includes spec.required_features, :strict_parsing
+    assert_includes spec.features, :strict_parsing
   end
 
-  def test_runnable_with_features
-    spec = create_spec(required_features: [:core, :shopify_tags])
+  def test_skipped_by_missing_features
+    spec = create_spec(features: [:core, :shopify_tags])
 
-    assert spec.runnable_with?([:core, :shopify_tags, :shopify_filters])
-    refute spec.runnable_with?([:core])
+    refute spec.skipped_by?([:shopify_filters])
+    assert spec.skipped_by?([:shopify_tags])
+    assert spec.skipped_by?([:core, :shopify_tags])
   end
 
-  def test_missing_features
-    spec = create_spec(required_features: [:core, :shopify_tags, :shopify_filters])
-    missing = spec.missing_features([:core])
+  def test_skipped_by_empty_missing_features
+    spec = create_spec(features: [:core, :shopify_tags, :shopify_filters])
 
-    assert_includes missing, :shopify_tags
-    assert_includes missing, :shopify_filters
-    refute_includes missing, :core
+    refute spec.skipped_by?([])
+    assert spec.skipped_by?([:shopify_tags])
+    assert spec.skipped_by?([:shopify_filters])
+    refute spec.skipped_by?([:runtime_drops])
   end
 
   def test_location_with_file_and_line


### PR DESCRIPTION
Previously adapters declared what they support (allowlist / default-deny). This caused silent test-skipping: a new spec with `required_features` that no adapter declared would silently never run anywhere. The 27 broken `ToSDrop` specs from `caf34da` went undetected for 4 months because `ruby_drops` wasn't in the reference adapter's allowlist.

## What changed

**Polarity flip:**
- Specs declare `features:` — informational tags describing what the spec exercises (renamed from `required_features`)
- Adapters declare `config.missing_features = [...]` — an explicit denylist of capabilities they can't provide
- A spec runs unless its tags intersect the adapter's `missing_features`

Default is now **run everything**. Skipping requires a conscious opt-out.

**Coverage check (new):**

Added a `coverage_check` rake task, wired into CI, that verifies every feature tag used in the spec YAML is "covered" — i.e. not in *every* adapter's `missing_features`. This makes orphan tags a CI failure rather than a silent gap.

```
Coverage check passed: all 15 feature tags covered across 10 reference adapters.
```

**Reference adapters updated** — each now declares what it genuinely can't handle:
- `liquid_ruby.rb`: missing Shopify-specific features + activesupport + lax_parsing
- `liquid_ruby_shopify.rb`: empty (runs everything — full Shopify Ruby Liquid)
- `liquid_c.rb`: missing runtime_drops, ruby_types, etc.

Also includes the `ToSDrop` counter restore fix and the `[](key)` method needed for `map` filter tests.

## Migration for adapters outside this repo

```ruby
# Before:
config.features = [:core, :strict_parsing, :ruby_types]

# After (conservative — preserves current skip behavior exactly):
config.missing_features = [:lax_parsing, :activesupport, :shopify_filters, ...]

# After (ideal — only list what you genuinely can't handle):
config.missing_features = [:shopify_filters, :shopify_tags]
```