### PR TITLE
Introduce `parser_errors` spec test suite

### DIFF
--- a/specs/parser_errors/assign.yml
+++ b/specs/parser_errors/assign.yml
@@ -1,0 +1,1494 @@
+---
+- name: assign-mut-end-trail-close_round
+  template: "{% assign x = x ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x = x
+      )"'
+  complexity: 100
+- name: assign-mut-end-trail-close_square
+  template: "{% assign x = x ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x =
+      x ]"'
+  complexity: 100
+- name: assign-mut-end-trail-colon
+  template: "{% assign x = x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x = x :"'
+  complexity: 100
+- name: assign-mut-end-trail-comma
+  template: "{% assign x = x , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x = x ,"'
+  complexity: 100
+- name: assign-mut-end-trail-comparison
+  template: "{% assign x = x == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x = x
+      =="'
+  complexity: 100
+- name: assign-mut-end-trail-dash
+  template: "{% assign x = x - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x = x -"'
+  complexity: 100
+- name: assign-mut-end-trail-dot
+  template: "{% assign x = x . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x = x ."'
+  complexity: 100
+- name: assign-mut-end-trail-id
+  template: "{% assign x = x extra %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x = x extra"'
+  complexity: 100
+- name: assign-mut-end-trail-number
+  template: "{% assign x = x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x = x 42"'
+  complexity: 100
+- name: assign-mut-end-trail-open_round
+  template: "{% assign x = x ( %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x = x
+      ("'
+  complexity: 100
+- name: assign-mut-end-trail-open_square
+  template: "{% assign x = x [ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x = x ["'
+  complexity: 100
+- name: assign-mut-end-trail-pipe
+  template: "{% assign x = x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x = x |"'
+  complexity: 100
+- name: assign-mut-end-trail-question
+  template: "{% assign x = x ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x = x ?"'
+  complexity: 100
+- name: assign-mut-end-trail-string
+  template: "{% assign x = x 'hi' %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x = x ''hi''"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-bare_bracket
+  template: "{% assign x = x | x : x , , [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , [0]"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-close_round-004
+  template: "{% assign x = x | x : x , , ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , )"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-close_square-003
+  template: "{% assign x = x | x : x , , ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , ]"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-colon-002
+  template: "{% assign x = x | x : x , , : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , :"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comma-001
+  template: "{% assign x = x | x : x , , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , ,"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comparison-009
+  template: "{% assign x = x | x : x , , == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , =="'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comparison-010
+  template: "{% assign x = x | x : x , , != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , !="'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comparison-011
+  template: "{% assign x = x | x : x , , < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , <"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comparison-012
+  template: "{% assign x = x | x : x , , > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , >"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comparison-013
+  template: "{% assign x = x | x : x , , <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , <="'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comparison-014
+  template: "{% assign x = x | x : x , , >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , >="'
+  complexity: 100
+- name: assign-mut-filter_arg_value-comparison-015
+  template: "{% assign x = x | x : x , , contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , contains"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-dash-006
+  template: "{% assign x = x | x : x , , - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , -"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-dot-007
+  template: "{% assign x = x | x : x , , . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , ."'
+  complexity: 100
+- name: assign-mut-filter_arg_value-dotdot-008
+  template: "{% assign x = x | x : x , , .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , .."'
+  complexity: 100
+- name: assign-mut-filter_arg_value-eos-016
+  template: "{% assign x = x | x : x , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , ,"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-ampersand
+  template: "{% assign x = x | x : x , , & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x = x | x : x , , &"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-asterisk
+  template: "{% assign x = x | x : x , , * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x = x | x : x , , *"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-at
+  template: "{% assign x = x | x : x , , @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x = x | x : x , , @"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-backslash
+  template: "{% assign x = x | x : x , , \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x = x | x : x , , \"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-backtick
+  template: "{% assign x = x | x : x , , ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x = x | x : x , , `"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-caret
+  template: "{% assign x = x | x : x , , ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x = x | x : x , , ^"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-dollar
+  template: "{% assign x = x | x : x , , $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x = x | x : x , , $"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-hash
+  template: "{% assign x = x | x : x , , # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x = x | x : x , , #"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-semicolon
+  template: "{% assign x = x | x : x , , ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x = x | x : x , , ;"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-tilde
+  template: "{% assign x = x | x : x , , ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x = x | x : x , , ~"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-unclosed_double_quote
+  template: '{% assign x = x | x : x , , "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x = x | x : x , , "hello"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lexerr-unclosed_single_quote
+  template: "{% assign x = x | x : x , , 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x = x | x : x , , ''hello"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-bracket_wrong_content
+  template: "{% assign x = x | x : x , , x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x[,]"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-dot_number
+  template: "{% assign x = x | x : x , , x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x.123"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-dot_string
+  template: '{% assign x = x | x : x , , x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x."y""'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-range_bad_separator
+  template: "{% assign x = x | x : x , , (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , (1, 5)"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-range_missing_end
+  template: "{% assign x = x | x : x , , (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , (1..)"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-trailing_dot
+  template: "{% assign x = x | x : x , , x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x."'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-unclosed_bracket
+  template: "{% assign x = x | x : x , , x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x[0"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-lookup-unclosed_range
+  template: "{% assign x = x | x : x , , (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , (1..5"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-pipe-000
+  template: "{% assign x = x | x : x , , | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , |"'
+  complexity: 100
+- name: assign-mut-filter_arg_value-question-005
+  template: "{% assign x = x | x : x , , ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , ?"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-bare_bracket
+  template: "{% assign x = x | x : [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x = x | x : [0]"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-close_round-004
+  template: "{% assign x = x | x : ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
+      x | x : )"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-close_square-003
+  template: "{% assign x = x | x : ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x =
+      x | x : ]"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-colon-002
+  template: "{% assign x = x | x : : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x = x | x
+      : :"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comma-001
+  template: "{% assign x = x | x : , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : ,"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comparison-009
+  template: "{% assign x = x | x : == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x =
+      x | x : =="'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comparison-010
+  template: "{% assign x = x | x : != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x =
+      x | x : !="'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comparison-011
+  template: "{% assign x = x | x : < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x = x
+      | x : <"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comparison-012
+  template: "{% assign x = x | x : > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x = x
+      | x : >"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comparison-013
+  template: "{% assign x = x | x : <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x =
+      x | x : <="'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comparison-014
+  template: "{% assign x = x | x : >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x =
+      x | x : >="'
+  complexity: 100
+- name: assign-mut-filter_first_arg-comparison-015
+  template: "{% assign x = x | x : contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x = x | x : contains"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-dash-006
+  template: "{% assign x = x | x : - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x = x | x :
+      -"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-dot-007
+  template: "{% assign x = x | x : . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x = x | x :
+      ."'
+  complexity: 100
+- name: assign-mut-filter_first_arg-dotdot-008
+  template: "{% assign x = x | x : .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x = x |
+      x : .."'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-ampersand
+  template: "{% assign x = x | x : & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x = x | x : &"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-asterisk
+  template: "{% assign x = x | x : * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x = x | x : *"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-at
+  template: "{% assign x = x | x : @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x = x | x : @"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-backslash
+  template: "{% assign x = x | x : \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x = x | x : \"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-backtick
+  template: "{% assign x = x | x : ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x = x | x : `"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-caret
+  template: "{% assign x = x | x : ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x = x | x : ^"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-dollar
+  template: "{% assign x = x | x : $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x = x | x : $"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-hash
+  template: "{% assign x = x | x : # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x = x | x : #"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-semicolon
+  template: "{% assign x = x | x : ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x = x | x : ;"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-tilde
+  template: "{% assign x = x | x : ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x = x | x : ~"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-unclosed_double_quote
+  template: '{% assign x = x | x : "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x = x | x : "hello"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lexerr-unclosed_single_quote
+  template: "{% assign x = x | x : 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x = x | x : ''hello"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-bracket_wrong_content
+  template: "{% assign x = x | x : x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x[,]"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-dot_number
+  template: "{% assign x = x | x : x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x = x | x : x.123"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-dot_string
+  template: '{% assign x = x | x : x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x = x | x : x."y""'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-range_bad_separator
+  template: "{% assign x = x | x : (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x = x | x : (1, 5)"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-range_missing_end
+  template: "{% assign x = x | x : (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
+      x | x : (1..)"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-trailing_dot
+  template: "{% assign x = x | x : x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x = x | x : x."'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-unclosed_bracket
+  template: "{% assign x = x | x : x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x =
+      x | x : x[0"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-lookup-unclosed_range
+  template: "{% assign x = x | x : (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x = x
+      | x : (1..5"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-pipe-000
+  template: "{% assign x = x | x : | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x = x | x : |"'
+  complexity: 100
+- name: assign-mut-filter_first_arg-question-005
+  template: "{% assign x = x | x : ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x = x |
+      x : ?"'
+  complexity: 100
+- name: assign-mut-filter_name-eos
+  template: "{% assign x = x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x = x |"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-ampersand
+  template: "{% assign x = x | & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x = x | &"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-asterisk
+  template: "{% assign x = x | * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x = x | *"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-at
+  template: "{% assign x = x | @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x = x | @"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-backslash
+  template: "{% assign x = x | \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x = x | \"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-backtick
+  template: "{% assign x = x | ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x = x | `"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-caret
+  template: "{% assign x = x | ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x = x | ^"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-dollar
+  template: "{% assign x = x | $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x = x | $"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-hash
+  template: "{% assign x = x | # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x = x | #"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-semicolon
+  template: "{% assign x = x | ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x = x | ;"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-tilde
+  template: "{% assign x = x | ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x = x | ~"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-unclosed_double_quote
+  template: '{% assign x = x | "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x = x | "hello"'
+  complexity: 100
+- name: assign-mut-filter_name-lexerr-unclosed_single_quote
+  template: "{% assign x = x | 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x = x | ''hello"'
+  complexity: 100
+- name: assign-mut-filter_name-number
+  template: "{% assign x = x | 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x = x | 42"'
+  complexity: 100
+- name: assign-mut-kwarg_colon-eos
+  template: "{% assign x = x | x : x , , x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x"'
+  complexity: 100
+- name: assign-mut-kwarg_colon-number
+  template: "{% assign x = x | x : x , , x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x 42"'
+  complexity: 100
+- name: assign-mut-kwarg_value-bare_bracket
+  template: "{% assign x = x | x : x , , x : [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : [0]"'
+  complexity: 100
+- name: assign-mut-kwarg_value-close_round-004
+  template: "{% assign x = x | x : x , , x : ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : )"'
+  complexity: 100
+- name: assign-mut-kwarg_value-close_square-003
+  template: "{% assign x = x | x : x , , x : ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : ]"'
+  complexity: 100
+- name: assign-mut-kwarg_value-colon-002
+  template: "{% assign x = x | x : x , , x : : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : :"'
+  complexity: 100
+- name: assign-mut-kwarg_value-comma-001
+  template: "{% assign x = x | x : x , , x : , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : ,"'
+  complexity: 100
+- name: assign-mut-kwarg_value-comparison-009
+  template: "{% assign x = x | x : x , , x : == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : =="'
+  complexity: 100
+- name: assign-mut-kwarg_value-comparison-010
+  template: "{% assign x = x | x : x , , x : != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : !="'
+  complexity: 100
+- name: assign-mut-kwarg_value-comparison-011
+  template: "{% assign x = x | x : x , , x : < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : <"'
+  complexity: 100
+- name: assign-mut-kwarg_value-comparison-012
+  template: "{% assign x = x | x : x , , x : > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : >"'
+  complexity: 100
+- name: assign-mut-kwarg_value-comparison-013
+  template: "{% assign x = x | x : x , , x : <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : <="'
+  complexity: 100
+- name: assign-mut-kwarg_value-comparison-014
+  template: "{% assign x = x | x : x , , x : >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : >="'
+  complexity: 100
+- name: assign-mut-kwarg_value-comparison-015
+  template: "{% assign x = x | x : x , , x : contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : contains"'
+  complexity: 100
+- name: assign-mut-kwarg_value-dash-006
+  template: "{% assign x = x | x : x , , x : - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : -"'
+  complexity: 100
+- name: assign-mut-kwarg_value-dot-007
+  template: "{% assign x = x | x : x , , x : . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : ."'
+  complexity: 100
+- name: assign-mut-kwarg_value-dotdot-008
+  template: "{% assign x = x | x : x , , x : .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : .."'
+  complexity: 100
+- name: assign-mut-kwarg_value-eos-016
+  template: "{% assign x = x | x : x , , x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x :"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-ampersand
+  template: "{% assign x = x | x : x , , x : & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x = x | x : x , , x : &"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-asterisk
+  template: "{% assign x = x | x : x , , x : * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x = x | x : x , , x : *"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-at
+  template: "{% assign x = x | x : x , , x : @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x = x | x : x , , x : @"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-backslash
+  template: "{% assign x = x | x : x , , x : \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x = x | x : x , , x : \"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-backtick
+  template: "{% assign x = x | x : x , , x : ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x = x | x : x , , x : `"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-caret
+  template: "{% assign x = x | x : x , , x : ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x = x | x : x , , x : ^"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-dollar
+  template: "{% assign x = x | x : x , , x : $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x = x | x : x , , x : $"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-hash
+  template: "{% assign x = x | x : x , , x : # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x = x | x : x , , x : #"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-semicolon
+  template: "{% assign x = x | x : x , , x : ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x = x | x : x , , x : ;"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-tilde
+  template: "{% assign x = x | x : x , , x : ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x = x | x : x , , x : ~"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% assign x = x | x : x , , x : "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x = x | x : x , , x : "hello"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% assign x = x | x : x , , x : 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x = x | x : x , , x : ''hello"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% assign x = x | x : x , , x : x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : x[,]"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-dot_number
+  template: "{% assign x = x | x : x , , x : x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : x.123"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-dot_string
+  template: '{% assign x = x | x : x , , x : x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : x."y""'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% assign x = x | x : x , , x : (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : (1, 5)"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-range_missing_end
+  template: "{% assign x = x | x : x , , x : (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : (1..)"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-trailing_dot
+  template: "{% assign x = x | x : x , , x : x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : x."'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% assign x = x | x : x , , x : x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : x[0"'
+  complexity: 100
+- name: assign-mut-kwarg_value-lookup-unclosed_range
+  template: "{% assign x = x | x : x , , x : (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : (1..5"'
+  complexity: 100
+- name: assign-mut-kwarg_value-pipe-000
+  template: "{% assign x = x | x : x , , x : | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : |"'
+  complexity: 100
+- name: assign-mut-kwarg_value-question-005
+  template: "{% assign x = x | x : x , , x : ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
+      : x , , x : ?"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-close_round
+  template: "{% assign x ) = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "x ) = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-close_square
+  template: "{% assign x ] = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found close_square in "x ] = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-colon
+  template: "{% assign x : = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "x : = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-comma
+  template: "{% assign x , = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "x , = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-comparison
+  template: "{% assign x == = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character = in "x == = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-dash
+  template: "{% assign x - = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found dash in "x - = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-dot
+  template: "{% assign x . = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found dot in "x . = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-number
+  template: "{% assign x 42 = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x 42 = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-open_round
+  template: "{% assign x ( = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "x ( = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-open_square
+  template: "{% assign x [ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found open_square in "x [ = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-pipe
+  template: "{% assign x | = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "x | = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-question
+  template: "{% assign x ? = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "x ? = x"'
+  complexity: 100
+- name: assign-mut-lhs_eos-trail-string
+  template: "{% assign x 'hi' = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "x ''hi'' = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-eos
+  template: "{% assign  = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "= x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-ampersand
+  template: "{% assign & = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "& = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-asterisk
+  template: "{% assign * = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "* = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-at
+  template: "{% assign @ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "@ = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-backslash
+  template: "{% assign \\ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "\ = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-backtick
+  template: "{% assign ` = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "` = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-caret
+  template: "{% assign ^ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "^ = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-dollar
+  template: "{% assign $ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "$ = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-hash
+  template: "{% assign # = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "# = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-semicolon
+  template: "{% assign ; = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "; = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-lexerr-tilde
+  template: "{% assign ~ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "~ = x"'
+  complexity: 100
+- name: assign-mut-lhs_id-number
+  template: "{% assign 42 = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "42 = x"'
+  complexity: 100
+- name: assign-mut-pregate-000
+  template: "{% assign  = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "= x"'
+  complexity: 100
+- name: assign-mut-pregate-001
+  template: "{% assign = = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "= = x"'
+  complexity: 100
+- name: assign-mut-pregate-001-2
+  template: "{% assign x = = %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character = in "x = ="'
+  complexity: 100
+- name: assign-mut-pregate-002
+  template: "{% assign ? = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "? = x"'
+  complexity: 100
+- name: assign-mut-pregate-002-2
+  template: "{% assign x = ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x = ?"'
+  complexity: 100
+- name: assign-mut-pregate-003
+  template: '{% assign "hi" = x %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in ""hi" = x"'
+  complexity: 100
+- name: assign-mut-pregate-004
+  template: "{% assign @ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "@ = x"'
+  complexity: 100
+- name: assign-mut-pregate-004-2
+  template: "{% assign x = @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x = @"'
+  complexity: 100
+- name: assign-mut-pregate-005
+  template: "{% assign # = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "# = x"'
+  complexity: 100
+- name: assign-mut-pregate-005-2
+  template: "{% assign x = # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x = #"'
+  complexity: 100
+- name: assign-mut-pregate-006
+  template: "{% assign $ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "$ = x"'
+  complexity: 100
+- name: assign-mut-pregate-006-2
+  template: "{% assign x = $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x = $"'
+  complexity: 100
+- name: assign-mut-pregate-007
+  template: "{% assign ^ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "^ = x"'
+  complexity: 100
+- name: assign-mut-pregate-007-2
+  template: "{% assign x = ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x = ^"'
+  complexity: 100
+- name: assign-mut-pregate-008
+  template: "{% assign & = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "& = x"'
+  complexity: 100
+- name: assign-mut-pregate-008-2
+  template: "{% assign x = & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x = &"'
+  complexity: 100
+- name: assign-mut-pregate-009
+  template: "{% assign * = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "* = x"'
+  complexity: 100
+- name: assign-mut-pregate-009-2
+  template: "{% assign x = * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x = *"'
+  complexity: 100
+- name: assign-mut-pregate-010
+  template: "{% assign ~ = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "~ = x"'
+  complexity: 100
+- name: assign-mut-pregate-010-2
+  template: "{% assign x = ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x = ~"'
+  complexity: 100
+- name: assign-mut-pregate-011
+  template: "{% assign ; = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "; = x"'
+  complexity: 100
+- name: assign-mut-pregate-011-2
+  template: "{% assign x = ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x = ;"'
+  complexity: 100
+- name: assign-mut-pregate-012
+  template: "{% assign | = x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in "| = x"'
+  complexity: 100
+- name: assign-mut-pregate-012-2
+  template: "{% assign x = | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x = |"'
+  complexity: 100
+- name: assign-mut-value-bare_bracket
+  template: "{% assign x = [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x = [0]"'
+  complexity: 100
+- name: assign-mut-value-close_round-004
+  template: "{% assign x = ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
+      )"'
+  complexity: 100
+- name: assign-mut-value-close_square-003
+  template: "{% assign x = ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x =
+      ]"'
+  complexity: 100
+- name: assign-mut-value-colon-002
+  template: "{% assign x = : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x = :"'
+  complexity: 100
+- name: assign-mut-value-comma-001
+  template: "{% assign x = , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = ,"'
+  complexity: 100
+- name: assign-mut-value-comparison-009
+  template: "{% assign x = == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x =
+      =="'
+  complexity: 100
+- name: assign-mut-value-comparison-010
+  template: "{% assign x = != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x =
+      !="'
+  complexity: 100
+- name: assign-mut-value-comparison-011
+  template: "{% assign x = < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x = <"'
+  complexity: 100
+- name: assign-mut-value-comparison-012
+  template: "{% assign x = > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x = >"'
+  complexity: 100
+- name: assign-mut-value-comparison-013
+  template: "{% assign x = <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x =
+      <="'
+  complexity: 100
+- name: assign-mut-value-comparison-014
+  template: "{% assign x = >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x =
+      >="'
+  complexity: 100
+- name: assign-mut-value-comparison-015
+  template: "{% assign x = contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x = contains"'
+  complexity: 100
+- name: assign-mut-value-dash-006
+  template: "{% assign x = - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x = -"'
+  complexity: 100
+- name: assign-mut-value-dot-007
+  template: "{% assign x = . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x = ."'
+  complexity: 100
+- name: assign-mut-value-dotdot-008
+  template: "{% assign x = .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x = .."'
+  complexity: 100
+- name: assign-mut-value-lexerr-ampersand
+  template: "{% assign x = & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x = &"'
+  complexity: 100
+- name: assign-mut-value-lexerr-asterisk
+  template: "{% assign x = * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x = *"'
+  complexity: 100
+- name: assign-mut-value-lexerr-at
+  template: "{% assign x = @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x = @"'
+  complexity: 100
+- name: assign-mut-value-lexerr-backslash
+  template: "{% assign x = \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x = \"'
+  complexity: 100
+- name: assign-mut-value-lexerr-backtick
+  template: "{% assign x = ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x = `"'
+  complexity: 100
+- name: assign-mut-value-lexerr-caret
+  template: "{% assign x = ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x = ^"'
+  complexity: 100
+- name: assign-mut-value-lexerr-dollar
+  template: "{% assign x = $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x = $"'
+  complexity: 100
+- name: assign-mut-value-lexerr-hash
+  template: "{% assign x = # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x = #"'
+  complexity: 100
+- name: assign-mut-value-lexerr-semicolon
+  template: "{% assign x = ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x = ;"'
+  complexity: 100
+- name: assign-mut-value-lexerr-tilde
+  template: "{% assign x = ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x = ~"'
+  complexity: 100
+- name: assign-mut-value-lexerr-unclosed_double_quote
+  template: '{% assign x = "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x = "hello"'
+  complexity: 100
+- name: assign-mut-value-lexerr-unclosed_single_quote
+  template: "{% assign x = 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x = ''hello"'
+  complexity: 100
+- name: assign-mut-value-lookup-bracket_wrong_content
+  template: "{% assign x = x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x[,]"'
+  complexity: 100
+- name: assign-mut-value-lookup-dot_number
+  template: "{% assign x = x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x = x.123"'
+  complexity: 100
+- name: assign-mut-value-lookup-dot_string
+  template: '{% assign x = x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x = x."y""'
+  complexity: 100
+- name: assign-mut-value-lookup-range_bad_separator
+  template: "{% assign x = (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x = (1, 5)"'
+  complexity: 100
+- name: assign-mut-value-lookup-range_missing_end
+  template: "{% assign x = (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
+      (1..)"'
+  complexity: 100
+- name: assign-mut-value-lookup-trailing_dot
+  template: "{% assign x = x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x = x."'
+  complexity: 100
+- name: assign-mut-value-lookup-unclosed_bracket
+  template: "{% assign x = x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x =
+      x[0"'
+  complexity: 100
+- name: assign-mut-value-lookup-unclosed_range
+  template: "{% assign x = (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x = (1..5"'
+  complexity: 100
+- name: assign-mut-value-pipe-000
+  template: "{% assign x = | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x = |"'
+  complexity: 100
+- name: assign-mut-value-question-005
+  template: "{% assign x = ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x = ?"'
+  complexity: 100

--- a/specs/parser_errors/assign.yml
+++ b/specs/parser_errors/assign.yml
@@ -3,1492 +3,1373 @@
   template: "{% assign x = x ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x = x
-      )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: assign-mut-end-trail-close_square
   template: "{% assign x = x ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x =
-      x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: assign-mut-end-trail-colon
   template: "{% assign x = x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x = x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: assign-mut-end-trail-comma
   template: "{% assign x = x , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x = x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: assign-mut-end-trail-comparison
   template: "{% assign x = x == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x = x
-      =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: assign-mut-end-trail-dash
   template: "{% assign x = x - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x = x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: assign-mut-end-trail-dot
   template: "{% assign x = x . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x = x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: assign-mut-end-trail-id
   template: "{% assign x = x extra %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x = x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: assign-mut-end-trail-number
   template: "{% assign x = x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x = x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: assign-mut-end-trail-open_round
   template: "{% assign x = x ( %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x = x
-      ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: assign-mut-end-trail-open_square
   template: "{% assign x = x [ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x = x ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: assign-mut-end-trail-pipe
   template: "{% assign x = x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x = x |"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: assign-mut-end-trail-question
   template: "{% assign x = x ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x = x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: assign-mut-end-trail-string
   template: "{% assign x = x 'hi' %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x = x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: assign-mut-filter_arg_value-bare_bracket
   template: "{% assign x = x | x : x , , [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , [0]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-close_round-004
   template: "{% assign x = x | x : x , , ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , )"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-close_square-003
   template: "{% assign x = x | x : x , , ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , ]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-colon-002
   template: "{% assign x = x | x : x , , : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , :"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comma-001
   template: "{% assign x = x | x : x , , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comparison-009
   template: "{% assign x = x | x : x , , == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , =="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comparison-010
   template: "{% assign x = x | x : x , , != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , !="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comparison-011
   template: "{% assign x = x | x : x , , < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , <"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comparison-012
   template: "{% assign x = x | x : x , , > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , >"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comparison-013
   template: "{% assign x = x | x : x , , <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , <="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comparison-014
   template: "{% assign x = x | x : x , , >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , >="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-comparison-015
   template: "{% assign x = x | x : x , , contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , contains"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-dash-006
   template: "{% assign x = x | x : x , , - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , -"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-dot-007
   template: "{% assign x = x | x : x , , . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , ."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-dotdot-008
   template: "{% assign x = x | x : x , , .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , .."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-eos-016
   template: "{% assign x = x | x : x , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-ampersand
   template: "{% assign x = x | x : x , , & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x = x | x : x , , &"'
+    - Unexpected character &
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-asterisk
   template: "{% assign x = x | x : x , , * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x = x | x : x , , *"'
+    - Unexpected character *
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-at
   template: "{% assign x = x | x : x , , @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x = x | x : x , , @"'
+    - Unexpected character @
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-backslash
   template: "{% assign x = x | x : x , , \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x = x | x : x , , \"'
+    - Unexpected character \
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-backtick
   template: "{% assign x = x | x : x , , ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x = x | x : x , , `"'
+    - Unexpected character `
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-caret
   template: "{% assign x = x | x : x , , ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x = x | x : x , , ^"'
+    - Unexpected character ^
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-dollar
   template: "{% assign x = x | x : x , , $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x = x | x : x , , $"'
+    - Unexpected character $
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-hash
   template: "{% assign x = x | x : x , , # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x = x | x : x , , #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-semicolon
   template: "{% assign x = x | x : x , , ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x = x | x : x , , ;"'
+    - Unexpected character ;
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-tilde
   template: "{% assign x = x | x : x , , ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x = x | x : x , , ~"'
+    - Unexpected character ~
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-unclosed_double_quote
   template: '{% assign x = x | x : x , , "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x = x | x : x , , "hello"'
+    - Unexpected character "
   complexity: 100
 - name: assign-mut-filter_arg_value-lexerr-unclosed_single_quote
   template: "{% assign x = x | x : x , , 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x = x | x : x , , ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-bracket_wrong_content
   template: "{% assign x = x | x : x , , x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-dot_number
   template: "{% assign x = x | x : x , , x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x.123"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-dot_string
   template: '{% assign x = x | x : x , , x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x."y""'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-range_bad_separator
   template: "{% assign x = x | x : x , , (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , (1, 5)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-range_missing_end
   template: "{% assign x = x | x : x , , (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , (1..)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-trailing_dot
   template: "{% assign x = x | x : x , , x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-unclosed_bracket
   template: "{% assign x = x | x : x , , x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x[0"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-lookup-unclosed_range
   template: "{% assign x = x | x : x , , (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , (1..5"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-pipe-000
   template: "{% assign x = x | x : x , , | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , |"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_arg_value-question-005
   template: "{% assign x = x | x : x , , ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , ?"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-bare_bracket
   template: "{% assign x = x | x : [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x = x | x : [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: assign-mut-filter_first_arg-close_round-004
   template: "{% assign x = x | x : ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
-      x | x : )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-close_square-003
   template: "{% assign x = x | x : ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x =
-      x | x : ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-colon-002
   template: "{% assign x = x | x : : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x = x | x
-      : :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comma-001
   template: "{% assign x = x | x : , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comparison-009
   template: "{% assign x = x | x : == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x =
-      x | x : =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comparison-010
   template: "{% assign x = x | x : != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x =
-      x | x : !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comparison-011
   template: "{% assign x = x | x : < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x = x
-      | x : <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comparison-012
   template: "{% assign x = x | x : > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x = x
-      | x : >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comparison-013
   template: "{% assign x = x | x : <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x =
-      x | x : <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comparison-014
   template: "{% assign x = x | x : >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x =
-      x | x : >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-comparison-015
   template: "{% assign x = x | x : contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x = x | x : contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-dash-006
   template: "{% assign x = x | x : - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x = x | x :
-      -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-dot-007
   template: "{% assign x = x | x : . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x = x | x :
-      ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-dotdot-008
   template: "{% assign x = x | x : .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x = x |
-      x : .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-ampersand
   template: "{% assign x = x | x : & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x = x | x : &"'
+    - Unexpected character &
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-asterisk
   template: "{% assign x = x | x : * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x = x | x : *"'
+    - Unexpected character *
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-at
   template: "{% assign x = x | x : @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x = x | x : @"'
+    - Unexpected character @
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-backslash
   template: "{% assign x = x | x : \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x = x | x : \"'
+    - Unexpected character \
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-backtick
   template: "{% assign x = x | x : ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x = x | x : `"'
+    - Unexpected character `
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-caret
   template: "{% assign x = x | x : ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x = x | x : ^"'
+    - Unexpected character ^
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-dollar
   template: "{% assign x = x | x : $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x = x | x : $"'
+    - Unexpected character $
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-hash
   template: "{% assign x = x | x : # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x = x | x : #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-semicolon
   template: "{% assign x = x | x : ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x = x | x : ;"'
+    - Unexpected character ;
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-tilde
   template: "{% assign x = x | x : ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x = x | x : ~"'
+    - Unexpected character ~
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-unclosed_double_quote
   template: '{% assign x = x | x : "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x = x | x : "hello"'
+    - Unexpected character "
   complexity: 100
 - name: assign-mut-filter_first_arg-lexerr-unclosed_single_quote
   template: "{% assign x = x | x : 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x = x | x : ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-bracket_wrong_content
   template: "{% assign x = x | x : x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-dot_number
   template: "{% assign x = x | x : x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x = x | x : x.123"'
+    - Expected id but found number
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-dot_string
   template: '{% assign x = x | x : x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x = x | x : x."y""'
+    - Expected id but found string
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-range_bad_separator
   template: "{% assign x = x | x : (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x = x | x : (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-range_missing_end
   template: "{% assign x = x | x : (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
-      x | x : (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-trailing_dot
   template: "{% assign x = x | x : x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x = x | x : x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-unclosed_bracket
   template: "{% assign x = x | x : x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x =
-      x | x : x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: assign-mut-filter_first_arg-lookup-unclosed_range
   template: "{% assign x = x | x : (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x = x
-      | x : (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: assign-mut-filter_first_arg-pipe-000
   template: "{% assign x = x | x : | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x = x | x : |"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: assign-mut-filter_first_arg-question-005
   template: "{% assign x = x | x : ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x = x |
-      x : ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: assign-mut-filter_name-eos
   template: "{% assign x = x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x = x |"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: assign-mut-filter_name-lexerr-ampersand
   template: "{% assign x = x | & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x = x | &"'
+    - Unexpected character &
   complexity: 100
 - name: assign-mut-filter_name-lexerr-asterisk
   template: "{% assign x = x | * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x = x | *"'
+    - Unexpected character *
   complexity: 100
 - name: assign-mut-filter_name-lexerr-at
   template: "{% assign x = x | @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x = x | @"'
+    - Unexpected character @
   complexity: 100
 - name: assign-mut-filter_name-lexerr-backslash
   template: "{% assign x = x | \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x = x | \"'
+    - Unexpected character \
   complexity: 100
 - name: assign-mut-filter_name-lexerr-backtick
   template: "{% assign x = x | ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x = x | `"'
+    - Unexpected character `
   complexity: 100
 - name: assign-mut-filter_name-lexerr-caret
   template: "{% assign x = x | ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x = x | ^"'
+    - Unexpected character ^
   complexity: 100
 - name: assign-mut-filter_name-lexerr-dollar
   template: "{% assign x = x | $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x = x | $"'
+    - Unexpected character $
   complexity: 100
 - name: assign-mut-filter_name-lexerr-hash
   template: "{% assign x = x | # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x = x | #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: assign-mut-filter_name-lexerr-semicolon
   template: "{% assign x = x | ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x = x | ;"'
+    - Unexpected character ;
   complexity: 100
 - name: assign-mut-filter_name-lexerr-tilde
   template: "{% assign x = x | ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x = x | ~"'
+    - Unexpected character ~
   complexity: 100
 - name: assign-mut-filter_name-lexerr-unclosed_double_quote
   template: '{% assign x = x | "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x = x | "hello"'
+    - Unexpected character "
   complexity: 100
 - name: assign-mut-filter_name-lexerr-unclosed_single_quote
   template: "{% assign x = x | 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x = x | ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: assign-mut-filter_name-number
   template: "{% assign x = x | 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x = x | 42"'
+    - Expected id but found number
   complexity: 100
 - name: assign-mut-kwarg_colon-eos
   template: "{% assign x = x | x : x , , x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_colon-number
   template: "{% assign x = x | x : x , , x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x 42"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-bare_bracket
   template: "{% assign x = x | x : x , , x : [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : [0]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-close_round-004
   template: "{% assign x = x | x : x , , x : ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : )"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-close_square-003
   template: "{% assign x = x | x : x , , x : ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : ]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-colon-002
   template: "{% assign x = x | x : x , , x : : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : :"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comma-001
   template: "{% assign x = x | x : x , , x : , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comparison-009
   template: "{% assign x = x | x : x , , x : == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : =="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comparison-010
   template: "{% assign x = x | x : x , , x : != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : !="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comparison-011
   template: "{% assign x = x | x : x , , x : < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : <"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comparison-012
   template: "{% assign x = x | x : x , , x : > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : >"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comparison-013
   template: "{% assign x = x | x : x , , x : <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : <="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comparison-014
   template: "{% assign x = x | x : x , , x : >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : >="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-comparison-015
   template: "{% assign x = x | x : x , , x : contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : contains"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-dash-006
   template: "{% assign x = x | x : x , , x : - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : -"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-dot-007
   template: "{% assign x = x | x : x , , x : . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : ."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-dotdot-008
   template: "{% assign x = x | x : x , , x : .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : .."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-eos-016
   template: "{% assign x = x | x : x , , x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x :"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-ampersand
   template: "{% assign x = x | x : x , , x : & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x = x | x : x , , x : &"'
+    - Unexpected character &
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-asterisk
   template: "{% assign x = x | x : x , , x : * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x = x | x : x , , x : *"'
+    - Unexpected character *
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-at
   template: "{% assign x = x | x : x , , x : @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x = x | x : x , , x : @"'
+    - Unexpected character @
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-backslash
   template: "{% assign x = x | x : x , , x : \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x = x | x : x , , x : \"'
+    - Unexpected character \
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-backtick
   template: "{% assign x = x | x : x , , x : ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x = x | x : x , , x : `"'
+    - Unexpected character `
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-caret
   template: "{% assign x = x | x : x , , x : ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x = x | x : x , , x : ^"'
+    - Unexpected character ^
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-dollar
   template: "{% assign x = x | x : x , , x : $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x = x | x : x , , x : $"'
+    - Unexpected character $
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-hash
   template: "{% assign x = x | x : x , , x : # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x = x | x : x , , x : #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-semicolon
   template: "{% assign x = x | x : x , , x : ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x = x | x : x , , x : ;"'
+    - Unexpected character ;
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-tilde
   template: "{% assign x = x | x : x , , x : ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x = x | x : x , , x : ~"'
+    - Unexpected character ~
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-unclosed_double_quote
   template: '{% assign x = x | x : x , , x : "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x = x | x : x , , x : "hello"'
+    - Unexpected character "
   complexity: 100
 - name: assign-mut-kwarg_value-lexerr-unclosed_single_quote
   template: "{% assign x = x | x : x , , x : 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x = x | x : x , , x : ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-bracket_wrong_content
   template: "{% assign x = x | x : x , , x : x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-dot_number
   template: "{% assign x = x | x : x , , x : x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : x.123"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-dot_string
   template: '{% assign x = x | x : x , , x : x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : x."y""'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-range_bad_separator
   template: "{% assign x = x | x : x , , x : (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : (1, 5)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-range_missing_end
   template: "{% assign x = x | x : x , , x : (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : (1..)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-trailing_dot
   template: "{% assign x = x | x : x , , x : x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : x."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-unclosed_bracket
   template: "{% assign x = x | x : x , , x : x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : x[0"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-lookup-unclosed_range
   template: "{% assign x = x | x : x , , x : (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : (1..5"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-pipe-000
   template: "{% assign x = x | x : x , , x : | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : |"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-kwarg_value-question-005
   template: "{% assign x = x | x : x , , x : ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x | x
-      : x , , x : ?"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-lhs_eos-trail-close_round
   template: "{% assign x ) = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "x ) = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_eos-trail-close_square
   template: "{% assign x ] = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found close_square in "x ] = x"'
+    - Expected id but found close_square
   complexity: 100
 - name: assign-mut-lhs_eos-trail-colon
   template: "{% assign x : = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "x : = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_eos-trail-comma
   template: "{% assign x , = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "x , = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_eos-trail-comparison
   template: "{% assign x == = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character = in "x == = x"'
+    - Unexpected character =
   complexity: 100
 - name: assign-mut-lhs_eos-trail-dash
   template: "{% assign x - = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found dash in "x - = x"'
+    - Expected id but found dash
   complexity: 100
 - name: assign-mut-lhs_eos-trail-dot
   template: "{% assign x . = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found dot in "x . = x"'
+    - Expected id but found dot
   complexity: 100
 - name: assign-mut-lhs_eos-trail-number
   template: "{% assign x 42 = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x 42 = x"'
+    - Expected id but found number
   complexity: 100
 - name: assign-mut-lhs_eos-trail-open_round
   template: "{% assign x ( = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "x ( = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_eos-trail-open_square
   template: "{% assign x [ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found open_square in "x [ = x"'
+    - Expected id but found open_square
   complexity: 100
 - name: assign-mut-lhs_eos-trail-pipe
   template: "{% assign x | = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "x | = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_eos-trail-question
   template: "{% assign x ? = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "x ? = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_eos-trail-string
   template: "{% assign x 'hi' = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "x ''hi'' = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-eos
   template: "{% assign  = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "= x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-ampersand
   template: "{% assign & = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "& = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-asterisk
   template: "{% assign * = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "* = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-at
   template: "{% assign @ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "@ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-backslash
   template: "{% assign \\ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "\ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-backtick
   template: "{% assign ` = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "` = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-caret
   template: "{% assign ^ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "^ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-dollar
   template: "{% assign $ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "$ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-hash
   template: "{% assign # = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "# = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-semicolon
   template: "{% assign ; = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "; = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-lexerr-tilde
   template: "{% assign ~ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "~ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-lhs_id-number
   template: "{% assign 42 = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "42 = x"'
+    - Expected id but found number
   complexity: 100
 - name: assign-mut-pregate-000
   template: "{% assign  = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "= x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-001
   template: "{% assign = = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "= = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-001-2
   template: "{% assign x = = %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character = in "x = ="'
+    - Unexpected character =
   complexity: 100
 - name: assign-mut-pregate-002
   template: "{% assign ? = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "? = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-002-2
   template: "{% assign x = ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x = ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: assign-mut-pregate-003
   template: '{% assign "hi" = x %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in ""hi" = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-004
   template: "{% assign @ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "@ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-004-2
   template: "{% assign x = @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x = @"'
+    - Unexpected character @
   complexity: 100
 - name: assign-mut-pregate-005
   template: "{% assign # = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "# = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-005-2
   template: "{% assign x = # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x = #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: assign-mut-pregate-006
   template: "{% assign $ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "$ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-006-2
   template: "{% assign x = $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x = $"'
+    - Unexpected character $
   complexity: 100
 - name: assign-mut-pregate-007
   template: "{% assign ^ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "^ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-007-2
   template: "{% assign x = ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x = ^"'
+    - Unexpected character ^
   complexity: 100
 - name: assign-mut-pregate-008
   template: "{% assign & = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "& = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-008-2
   template: "{% assign x = & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x = &"'
+    - Unexpected character &
   complexity: 100
 - name: assign-mut-pregate-009
   template: "{% assign * = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "* = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-009-2
   template: "{% assign x = * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x = *"'
+    - Unexpected character *
   complexity: 100
 - name: assign-mut-pregate-010
   template: "{% assign ~ = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "~ = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-010-2
   template: "{% assign x = ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x = ~"'
+    - Unexpected character ~
   complexity: 100
 - name: assign-mut-pregate-011
   template: "{% assign ; = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "; = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-011-2
   template: "{% assign x = ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x = ;"'
+    - Unexpected character ;
   complexity: 100
 - name: assign-mut-pregate-012
   template: "{% assign | = x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in "| = x"'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: assign-mut-pregate-012-2
   template: "{% assign x = | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x = |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-bare_bracket
   template: "{% assign x = [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x = [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: assign-mut-value-close_round-004
   template: "{% assign x = ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
-      )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-close_square-003
   template: "{% assign x = ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x =
-      ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-colon-002
   template: "{% assign x = : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x = :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comma-001
   template: "{% assign x = , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comparison-009
   template: "{% assign x = == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x =
-      =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comparison-010
   template: "{% assign x = != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x =
-      !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comparison-011
   template: "{% assign x = < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x = <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comparison-012
   template: "{% assign x = > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x = >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comparison-013
   template: "{% assign x = <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x =
-      <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comparison-014
   template: "{% assign x = >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x =
-      >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-comparison-015
   template: "{% assign x = contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x = contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-dash-006
   template: "{% assign x = - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x = -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-dot-007
   template: "{% assign x = . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x = ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-dotdot-008
   template: "{% assign x = .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x = .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-lexerr-ampersand
   template: "{% assign x = & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x = &"'
+    - Unexpected character &
   complexity: 100
 - name: assign-mut-value-lexerr-asterisk
   template: "{% assign x = * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x = *"'
+    - Unexpected character *
   complexity: 100
 - name: assign-mut-value-lexerr-at
   template: "{% assign x = @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x = @"'
+    - Unexpected character @
   complexity: 100
 - name: assign-mut-value-lexerr-backslash
   template: "{% assign x = \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x = \"'
+    - Unexpected character \
   complexity: 100
 - name: assign-mut-value-lexerr-backtick
   template: "{% assign x = ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x = `"'
+    - Unexpected character `
   complexity: 100
 - name: assign-mut-value-lexerr-caret
   template: "{% assign x = ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x = ^"'
+    - Unexpected character ^
   complexity: 100
 - name: assign-mut-value-lexerr-dollar
   template: "{% assign x = $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x = $"'
+    - Unexpected character $
   complexity: 100
 - name: assign-mut-value-lexerr-hash
   template: "{% assign x = # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x = #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: assign-mut-value-lexerr-semicolon
   template: "{% assign x = ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x = ;"'
+    - Unexpected character ;
   complexity: 100
 - name: assign-mut-value-lexerr-tilde
   template: "{% assign x = ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x = ~"'
+    - Unexpected character ~
   complexity: 100
 - name: assign-mut-value-lexerr-unclosed_double_quote
   template: '{% assign x = "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x = "hello"'
+    - Unexpected character "
   complexity: 100
 - name: assign-mut-value-lexerr-unclosed_single_quote
   template: "{% assign x = 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x = ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: assign-mut-value-lookup-bracket_wrong_content
   template: "{% assign x = x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x = x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-lookup-dot_number
   template: "{% assign x = x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x = x.123"'
+    - Expected id but found number
   complexity: 100
 - name: assign-mut-value-lookup-dot_string
   template: '{% assign x = x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x = x."y""'
+    - Expected id but found string
   complexity: 100
 - name: assign-mut-value-lookup-range_bad_separator
   template: "{% assign x = (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x = (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: assign-mut-value-lookup-range_missing_end
   template: "{% assign x = (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x =
-      (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-lookup-trailing_dot
   template: "{% assign x = x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x = x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: assign-mut-value-lookup-unclosed_bracket
   template: "{% assign x = x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x =
-      x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: assign-mut-value-lookup-unclosed_range
   template: "{% assign x = (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x = (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: assign-mut-value-pipe-000
   template: "{% assign x = | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x = |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: assign-mut-value-question-005
   template: "{% assign x = ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x = ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100

--- a/specs/parser_errors/capture.yml
+++ b/specs/parser_errors/capture.yml
@@ -1,0 +1,169 @@
+---
+- name: capture-mut-end-trail-close_round
+  template: "{% capture x ) %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: capture-mut-end-trail-close_square
+  template: "{% capture x ] %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: capture-mut-end-trail-colon
+  template: "{% capture x : %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  complexity: 100
+- name: capture-mut-end-trail-comma
+  template: "{% capture x , %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  complexity: 100
+- name: capture-mut-end-trail-comparison
+  template: "{% capture x == %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  complexity: 100
+- name: capture-mut-end-trail-dash
+  template: "{% capture x - %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: capture-mut-end-trail-dot
+  template: "{% capture x . %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+  complexity: 100
+- name: capture-mut-end-trail-id
+  template: "{% capture x extra %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  complexity: 100
+- name: capture-mut-end-trail-number
+  template: "{% capture x 42 %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: capture-mut-end-trail-open_round
+  template: "{% capture x ( %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: capture-mut-end-trail-open_square
+  template: "{% capture x [ %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_square in "x ["'
+  complexity: 100
+- name: capture-mut-end-trail-pipe
+  template: "{% capture x | %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: capture-mut-end-trail-question
+  template: "{% capture x ? %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: capture-mut-end-trail-string
+  template: "{% capture x 'hi' %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100
+- name: capture-mut-variable_name-eos
+  template: "{% capture  %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-ampersand
+  template: "{% capture & %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-asterisk
+  template: "{% capture * %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-at
+  template: "{% capture @ %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-backslash
+  template: "{% capture \\ %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-backtick
+  template: "{% capture ` %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-caret
+  template: "{% capture ^ %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-dollar
+  template: "{% capture $ %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-hash
+  template: "{% capture # %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-semicolon
+  template: "{% capture ; %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-tilde
+  template: "{% capture ~ %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% capture "hello %}{% endcapture %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: capture-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% capture 'hello %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: capture-mut-variable_name-number
+  template: "{% capture 42 %}{% endcapture %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "42"'
+  complexity: 100

--- a/specs/parser_errors/capture.yml
+++ b/specs/parser_errors/capture.yml
@@ -3,167 +3,167 @@
   template: "{% capture x ) %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: capture-mut-end-trail-close_square
   template: "{% capture x ] %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: capture-mut-end-trail-colon
   template: "{% capture x : %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: capture-mut-end-trail-comma
   template: "{% capture x , %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: capture-mut-end-trail-comparison
   template: "{% capture x == %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: capture-mut-end-trail-dash
   template: "{% capture x - %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: capture-mut-end-trail-dot
   template: "{% capture x . %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+    - Expected end_of_string but found dot
   complexity: 100
 - name: capture-mut-end-trail-id
   template: "{% capture x extra %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: capture-mut-end-trail-number
   template: "{% capture x 42 %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: capture-mut-end-trail-open_round
   template: "{% capture x ( %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: capture-mut-end-trail-open_square
   template: "{% capture x [ %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_square in "x ["'
+    - Expected end_of_string but found open_square
   complexity: 100
 - name: capture-mut-end-trail-pipe
   template: "{% capture x | %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: capture-mut-end-trail-question
   template: "{% capture x ? %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: capture-mut-end-trail-string
   template: "{% capture x 'hi' %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: capture-mut-variable_name-eos
   template: "{% capture  %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+    - Expected id but found end_of_string
   complexity: 100
 - name: capture-mut-variable_name-lexerr-ampersand
   template: "{% capture & %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: capture-mut-variable_name-lexerr-asterisk
   template: "{% capture * %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: capture-mut-variable_name-lexerr-at
   template: "{% capture @ %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: capture-mut-variable_name-lexerr-backslash
   template: "{% capture \\ %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: capture-mut-variable_name-lexerr-backtick
   template: "{% capture ` %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: capture-mut-variable_name-lexerr-caret
   template: "{% capture ^ %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: capture-mut-variable_name-lexerr-dollar
   template: "{% capture $ %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: capture-mut-variable_name-lexerr-hash
   template: "{% capture # %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: capture-mut-variable_name-lexerr-semicolon
   template: "{% capture ; %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: capture-mut-variable_name-lexerr-tilde
   template: "{% capture ~ %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: capture-mut-variable_name-lexerr-unclosed_double_quote
   template: '{% capture "hello %}{% endcapture %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: capture-mut-variable_name-lexerr-unclosed_single_quote
   template: "{% capture 'hello %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: capture-mut-variable_name-number
   template: "{% capture 42 %}{% endcapture %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "42"'
+    - Expected id but found number
   complexity: 100

--- a/specs/parser_errors/case.yml
+++ b/specs/parser_errors/case.yml
@@ -3,860 +3,857 @@
   template: "{% case [0] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "[0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: case-mut-case_expression-close_round-004
   template: "{% case ) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-close_square-003
   template: "{% case ] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-colon-002
   template: "{% case : %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comma-001
   template: "{% case , %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comparison-009
   template: "{% case == %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comparison-010
   template: "{% case != %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comparison-011
   template: "{% case < %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comparison-012
   template: "{% case > %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comparison-013
   template: "{% case <= %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comparison-014
   template: "{% case >= %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-comparison-015
   template: "{% case contains %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-dash-006
   template: "{% case - %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-dot-007
   template: "{% case . %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-dotdot-008
   template: "{% case .. %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-eos-016
   template: "{% case  %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: case-mut-case_expression-lexerr-ampersand
   template: "{% case & %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: case-mut-case_expression-lexerr-asterisk
   template: "{% case * %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: case-mut-case_expression-lexerr-at
   template: "{% case @ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: case-mut-case_expression-lexerr-backslash
   template: "{% case \\ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: case-mut-case_expression-lexerr-backtick
   template: "{% case ` %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: case-mut-case_expression-lexerr-caret
   template: "{% case ^ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: case-mut-case_expression-lexerr-dollar
   template: "{% case $ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: case-mut-case_expression-lexerr-hash
   template: "{% case # %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: case-mut-case_expression-lexerr-semicolon
   template: "{% case ; %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: case-mut-case_expression-lexerr-tilde
   template: "{% case ~ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: case-mut-case_expression-lexerr-unclosed_double_quote
   template: '{% case "hello %}{% endcase %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: case-mut-case_expression-lexerr-unclosed_single_quote
   template: "{% case 'hello %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: case-mut-case_expression-lookup-bracket_wrong_content
   template: "{% case x[,] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-lookup-dot_number
   template: "{% case x.123 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x.123"'
+    - Expected id but found number
   complexity: 100
 - name: case-mut-case_expression-lookup-dot_string
   template: '{% case x."y" %}{% endcase %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x."y""'
+    - Expected id but found string
   complexity: 100
 - name: case-mut-case_expression-lookup-range_bad_separator
   template: "{% case (1, 5) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: case-mut-case_expression-lookup-range_missing_end
   template: "{% case (1..) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-lookup-trailing_dot
   template: "{% case x. %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: case-mut-case_expression-lookup-unclosed_bracket
   template: "{% case x[0 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: case-mut-case_expression-lookup-unclosed_range
   template: "{% case (1..5 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: case-mut-case_expression-pipe-000
   template: "{% case | %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: case-mut-case_expression-question-005
   template: "{% case ? %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: case-mut-end-trail-close_round
   template: "{% case x ) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: case-mut-end-trail-close_square
   template: "{% case x ] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: case-mut-end-trail-colon
   template: "{% case x : %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: case-mut-end-trail-comma
   template: "{% case x , %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: case-mut-end-trail-comparison
   template: "{% case x == %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: case-mut-end-trail-dash
   template: "{% case x - %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: case-mut-end-trail-dot
   template: "{% case x . %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: case-mut-end-trail-id
   template: "{% case x extra %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: case-mut-end-trail-number
   template: "{% case x 42 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: case-mut-end-trail-open_round
   template: "{% case x ( %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: case-mut-end-trail-open_square
   template: "{% case x [ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: case-mut-end-trail-pipe
   template: "{% case x | %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: case-mut-end-trail-question
   template: "{% case x ? %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: case-mut-end-trail-string
   template: "{% case x 'hi' %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: case-mut-when_end-trail-close_round
   template: "{% case x %}{% when x ) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: case-mut-when_end-trail-close_square
   template: "{% case x %}{% when x ] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: case-mut-when_end-trail-colon
   template: "{% case x %}{% when x : %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: case-mut-when_end-trail-comma
   template: "{% case x %}{% when x , %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: case-mut-when_end-trail-comparison
   template: "{% case x %}{% when x == %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: case-mut-when_end-trail-dash
   template: "{% case x %}{% when x - %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: case-mut-when_end-trail-dot
   template: "{% case x %}{% when x . %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string'
+    - Expected id but found end_of_string
   complexity: 100
 - name: case-mut-when_end-trail-id
   template: "{% case x %}{% when x extra %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id'
+    - Expected end_of_string but found id
   complexity: 100
 - name: case-mut-when_end-trail-number
   template: "{% case x %}{% when x 42 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number'
+    - Expected end_of_string but found number
   complexity: 100
 - name: case-mut-when_end-trail-open_round
   template: "{% case x %}{% when x ( %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: case-mut-when_end-trail-open_square
   template: "{% case x %}{% when x [ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: case-mut-when_end-trail-pipe
   template: "{% case x %}{% when x | %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: case-mut-when_end-trail-question
   template: "{% case x %}{% when x ? %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question'
+    - Expected end_of_string but found question
   complexity: 100
 - name: case-mut-when_end-trail-string
   template: "{% case x %}{% when x 'hi' %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string'
+    - Expected end_of_string but found string
   complexity: 100
 - name: case-mut-when_next_value-bare_bracket
   template: "{% case x %}{% when x , , [0] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-close_round-004
   template: "{% case x %}{% when x , , ) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-close_square-003
   template: "{% case x %}{% when x , , ] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-colon-002
   template: "{% case x %}{% when x , , : %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comma-001
   template: "{% case x %}{% when x , , , %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comparison-009
   template: "{% case x %}{% when x , , == %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comparison-010
   template: "{% case x %}{% when x , , != %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comparison-011
   template: "{% case x %}{% when x , , < %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comparison-012
   template: "{% case x %}{% when x , , > %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comparison-013
   template: "{% case x %}{% when x , , <= %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comparison-014
   template: "{% case x %}{% when x , , >= %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-comparison-015
   template: "{% case x %}{% when x , , contains %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-dash-006
   template: "{% case x %}{% when x , , - %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-dot-007
   template: "{% case x %}{% when x , , . %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-dotdot-008
   template: "{% case x %}{% when x , , .. %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-eos-016
   template: "{% case x %}{% when x , , %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lexerr-ampersand
   template: "{% case x %}{% when x , , & %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character &'
+    - Unexpected character &
   complexity: 100
 - name: case-mut-when_next_value-lexerr-asterisk
   template: "{% case x %}{% when x , , * %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character *'
+    - Unexpected character *
   complexity: 100
 - name: case-mut-when_next_value-lexerr-at
   template: "{% case x %}{% when x , , @ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @'
+    - Unexpected character @
   complexity: 100
 - name: case-mut-when_next_value-lexerr-backslash
   template: "{% case x %}{% when x , , \\ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \'
+    - Unexpected character \
   complexity: 100
 - name: case-mut-when_next_value-lexerr-backtick
   template: "{% case x %}{% when x , , ` %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character `'
+    - Unexpected character `
   complexity: 100
 - name: case-mut-when_next_value-lexerr-caret
   template: "{% case x %}{% when x , , ^ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^'
+    - Unexpected character ^
   complexity: 100
 - name: case-mut-when_next_value-lexerr-dollar
   template: "{% case x %}{% when x , , $ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $'
+    - Unexpected character $
   complexity: 100
 - name: case-mut-when_next_value-lexerr-hash
   template: "{% case x %}{% when x , , # %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character #'
+    - 'Unexpected character #'
   complexity: 100
 - name: case-mut-when_next_value-lexerr-semicolon
   template: "{% case x %}{% when x , , ; %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ;'
+    - Unexpected character ;
   complexity: 100
 - name: case-mut-when_next_value-lexerr-tilde
   template: "{% case x %}{% when x , , ~ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~'
+    - Unexpected character ~
   complexity: 100
 - name: case-mut-when_next_value-lexerr-unclosed_double_quote
   template: '{% case x %}{% when x , , "hello %}{% endcase %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character "'
+    - Unexpected character "
   complexity: 100
 - name: case-mut-when_next_value-lexerr-unclosed_single_quote
   template: "{% case x %}{% when x , , 'hello %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '''
+    - Unexpected character '
   complexity: 100
 - name: case-mut-when_next_value-lookup-bracket_wrong_content
   template: "{% case x %}{% when x , , x[,] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lookup-dot_number
   template: "{% case x %}{% when x , , x.123 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lookup-dot_string
   template: '{% case x %}{% when x , , x."y" %}{% endcase %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lookup-range_bad_separator
   template: "{% case x %}{% when x , , (1, 5) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lookup-range_missing_end
   template: "{% case x %}{% when x , , (1..) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lookup-trailing_dot
   template: "{% case x %}{% when x , , x. %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lookup-unclosed_bracket
   template: "{% case x %}{% when x , , x[0 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-lookup-unclosed_range
   template: "{% case x %}{% when x , , (1..5 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-pipe-000
   template: "{% case x %}{% when x , , | %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_next_value-question-005
   template: "{% case x %}{% when x , , ? %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-bare_bracket
   template: "{% case x %}{% when [0] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: case-mut-when_value-close_round-004
   template: "{% case x %}{% when ) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-close_square-003
   template: "{% case x %}{% when ] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-colon-002
   template: "{% case x %}{% when : %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comma-001
   template: "{% case x %}{% when , %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comparison-009
   template: "{% case x %}{% when == %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comparison-010
   template: "{% case x %}{% when != %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comparison-011
   template: "{% case x %}{% when < %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comparison-012
   template: "{% case x %}{% when > %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comparison-013
   template: "{% case x %}{% when <= %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comparison-014
   template: "{% case x %}{% when >= %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-comparison-015
   template: "{% case x %}{% when contains %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-dash-006
   template: "{% case x %}{% when - %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-dot-007
   template: "{% case x %}{% when . %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-dotdot-008
   template: "{% case x %}{% when .. %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-eos-016
   template: "{% case x %}{% when  %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: case-mut-when_value-lexerr-ampersand
   template: "{% case x %}{% when & %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character &'
+    - Unexpected character &
   complexity: 100
 - name: case-mut-when_value-lexerr-asterisk
   template: "{% case x %}{% when * %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character *'
+    - Unexpected character *
   complexity: 100
 - name: case-mut-when_value-lexerr-at
   template: "{% case x %}{% when @ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @'
+    - Unexpected character @
   complexity: 100
 - name: case-mut-when_value-lexerr-backslash
   template: "{% case x %}{% when \\ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \'
+    - Unexpected character \
   complexity: 100
 - name: case-mut-when_value-lexerr-backtick
   template: "{% case x %}{% when ` %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character `'
+    - Unexpected character `
   complexity: 100
 - name: case-mut-when_value-lexerr-caret
   template: "{% case x %}{% when ^ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^'
+    - Unexpected character ^
   complexity: 100
 - name: case-mut-when_value-lexerr-dollar
   template: "{% case x %}{% when $ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $'
+    - Unexpected character $
   complexity: 100
 - name: case-mut-when_value-lexerr-hash
   template: "{% case x %}{% when # %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character #'
+    - 'Unexpected character #'
   complexity: 100
 - name: case-mut-when_value-lexerr-semicolon
   template: "{% case x %}{% when ; %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ;'
+    - Unexpected character ;
   complexity: 100
 - name: case-mut-when_value-lexerr-tilde
   template: "{% case x %}{% when ~ %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~'
+    - Unexpected character ~
   complexity: 100
 - name: case-mut-when_value-lexerr-unclosed_double_quote
   template: '{% case x %}{% when "hello %}{% endcase %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character "'
+    - Unexpected character "
   complexity: 100
 - name: case-mut-when_value-lexerr-unclosed_single_quote
   template: "{% case x %}{% when 'hello %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '''
+    - Unexpected character '
   complexity: 100
 - name: case-mut-when_value-lookup-bracket_wrong_content
   template: "{% case x %}{% when x[,] %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-lookup-dot_number
   template: "{% case x %}{% when x.123 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number'
+    - Expected id but found number
   complexity: 100
 - name: case-mut-when_value-lookup-dot_string
   template: '{% case x %}{% when x."y" %}{% endcase %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string'
+    - Expected id but found string
   complexity: 100
 - name: case-mut-when_value-lookup-range_bad_separator
   template: "{% case x %}{% when (1, 5) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma'
+    - Expected dotdot but found comma
   complexity: 100
 - name: case-mut-when_value-lookup-range_missing_end
   template: "{% case x %}{% when (1..) %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-lookup-trailing_dot
   template: "{% case x %}{% when x. %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string'
+    - Expected id but found end_of_string
   complexity: 100
 - name: case-mut-when_value-lookup-unclosed_bracket
   template: "{% case x %}{% when x[0 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: case-mut-when_value-lookup-unclosed_range
   template: "{% case x %}{% when (1..5 %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: case-mut-when_value-pipe-000
   template: "{% case x %}{% when | %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: case-mut-when_value-question-005
   template: "{% case x %}{% when ? %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: case-parity-elsif-in-case
   template: "{% case x %}{% elsif %}{% endcase %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unknown tag ''elsif'''
+    - Unknown tag 'elsif'
   complexity: 100

--- a/specs/parser_errors/case.yml
+++ b/specs/parser_errors/case.yml
@@ -1,0 +1,862 @@
+---
+- name: case-mut-case_expression-bare_bracket
+  template: "{% case [0] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "[0]"'
+  complexity: 100
+- name: case-mut-case_expression-close_round-004
+  template: "{% case ) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  complexity: 100
+- name: case-mut-case_expression-close_square-003
+  template: "{% case ] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  complexity: 100
+- name: case-mut-case_expression-colon-002
+  template: "{% case : %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  complexity: 100
+- name: case-mut-case_expression-comma-001
+  template: "{% case , %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  complexity: 100
+- name: case-mut-case_expression-comparison-009
+  template: "{% case == %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  complexity: 100
+- name: case-mut-case_expression-comparison-010
+  template: "{% case != %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  complexity: 100
+- name: case-mut-case_expression-comparison-011
+  template: "{% case < %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  complexity: 100
+- name: case-mut-case_expression-comparison-012
+  template: "{% case > %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  complexity: 100
+- name: case-mut-case_expression-comparison-013
+  template: "{% case <= %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  complexity: 100
+- name: case-mut-case_expression-comparison-014
+  template: "{% case >= %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  complexity: 100
+- name: case-mut-case_expression-comparison-015
+  template: "{% case contains %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "contains"'
+  complexity: 100
+- name: case-mut-case_expression-dash-006
+  template: "{% case - %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  complexity: 100
+- name: case-mut-case_expression-dot-007
+  template: "{% case . %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  complexity: 100
+- name: case-mut-case_expression-dotdot-008
+  template: "{% case .. %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  complexity: 100
+- name: case-mut-case_expression-eos-016
+  template: "{% case  %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-ampersand
+  template: "{% case & %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-asterisk
+  template: "{% case * %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-at
+  template: "{% case @ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-backslash
+  template: "{% case \\ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-backtick
+  template: "{% case ` %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-caret
+  template: "{% case ^ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-dollar
+  template: "{% case $ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-hash
+  template: "{% case # %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-semicolon
+  template: "{% case ; %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-tilde
+  template: "{% case ~ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-unclosed_double_quote
+  template: '{% case "hello %}{% endcase %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: case-mut-case_expression-lexerr-unclosed_single_quote
+  template: "{% case 'hello %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: case-mut-case_expression-lookup-bracket_wrong_content
+  template: "{% case x[,] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  complexity: 100
+- name: case-mut-case_expression-lookup-dot_number
+  template: "{% case x.123 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x.123"'
+  complexity: 100
+- name: case-mut-case_expression-lookup-dot_string
+  template: '{% case x."y" %}{% endcase %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x."y""'
+  complexity: 100
+- name: case-mut-case_expression-lookup-range_bad_separator
+  template: "{% case (1, 5) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  complexity: 100
+- name: case-mut-case_expression-lookup-range_missing_end
+  template: "{% case (1..) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  complexity: 100
+- name: case-mut-case_expression-lookup-trailing_dot
+  template: "{% case x. %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  complexity: 100
+- name: case-mut-case_expression-lookup-unclosed_bracket
+  template: "{% case x[0 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  complexity: 100
+- name: case-mut-case_expression-lookup-unclosed_range
+  template: "{% case (1..5 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  complexity: 100
+- name: case-mut-case_expression-pipe-000
+  template: "{% case | %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  complexity: 100
+- name: case-mut-case_expression-question-005
+  template: "{% case ? %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  complexity: 100
+- name: case-mut-end-trail-close_round
+  template: "{% case x ) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: case-mut-end-trail-close_square
+  template: "{% case x ] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: case-mut-end-trail-colon
+  template: "{% case x : %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  complexity: 100
+- name: case-mut-end-trail-comma
+  template: "{% case x , %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  complexity: 100
+- name: case-mut-end-trail-comparison
+  template: "{% case x == %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  complexity: 100
+- name: case-mut-end-trail-dash
+  template: "{% case x - %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: case-mut-end-trail-dot
+  template: "{% case x . %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  complexity: 100
+- name: case-mut-end-trail-id
+  template: "{% case x extra %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  complexity: 100
+- name: case-mut-end-trail-number
+  template: "{% case x 42 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: case-mut-end-trail-open_round
+  template: "{% case x ( %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: case-mut-end-trail-open_square
+  template: "{% case x [ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  complexity: 100
+- name: case-mut-end-trail-pipe
+  template: "{% case x | %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: case-mut-end-trail-question
+  template: "{% case x ? %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: case-mut-end-trail-string
+  template: "{% case x 'hi' %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100
+- name: case-mut-when_end-trail-close_round
+  template: "{% case x %}{% when x ) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round'
+  complexity: 100
+- name: case-mut-when_end-trail-close_square
+  template: "{% case x %}{% when x ] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square'
+  complexity: 100
+- name: case-mut-when_end-trail-colon
+  template: "{% case x %}{% when x : %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon'
+  complexity: 100
+- name: case-mut-when_end-trail-comma
+  template: "{% case x %}{% when x , %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_end-trail-comparison
+  template: "{% case x %}{% when x == %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison'
+  complexity: 100
+- name: case-mut-when_end-trail-dash
+  template: "{% case x %}{% when x - %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash'
+  complexity: 100
+- name: case-mut-when_end-trail-dot
+  template: "{% case x %}{% when x . %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string'
+  complexity: 100
+- name: case-mut-when_end-trail-id
+  template: "{% case x %}{% when x extra %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id'
+  complexity: 100
+- name: case-mut-when_end-trail-number
+  template: "{% case x %}{% when x 42 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number'
+  complexity: 100
+- name: case-mut-when_end-trail-open_round
+  template: "{% case x %}{% when x ( %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round'
+  complexity: 100
+- name: case-mut-when_end-trail-open_square
+  template: "{% case x %}{% when x [ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_end-trail-pipe
+  template: "{% case x %}{% when x | %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe'
+  complexity: 100
+- name: case-mut-when_end-trail-question
+  template: "{% case x %}{% when x ? %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question'
+  complexity: 100
+- name: case-mut-when_end-trail-string
+  template: "{% case x %}{% when x 'hi' %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string'
+  complexity: 100
+- name: case-mut-when_next_value-bare_bracket
+  template: "{% case x %}{% when x , , [0] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-close_round-004
+  template: "{% case x %}{% when x , , ) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-close_square-003
+  template: "{% case x %}{% when x , , ] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-colon-002
+  template: "{% case x %}{% when x , , : %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comma-001
+  template: "{% case x %}{% when x , , , %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comparison-009
+  template: "{% case x %}{% when x , , == %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comparison-010
+  template: "{% case x %}{% when x , , != %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comparison-011
+  template: "{% case x %}{% when x , , < %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comparison-012
+  template: "{% case x %}{% when x , , > %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comparison-013
+  template: "{% case x %}{% when x , , <= %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comparison-014
+  template: "{% case x %}{% when x , , >= %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-comparison-015
+  template: "{% case x %}{% when x , , contains %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-dash-006
+  template: "{% case x %}{% when x , , - %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-dot-007
+  template: "{% case x %}{% when x , , . %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-dotdot-008
+  template: "{% case x %}{% when x , , .. %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-eos-016
+  template: "{% case x %}{% when x , , %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-ampersand
+  template: "{% case x %}{% when x , , & %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character &'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-asterisk
+  template: "{% case x %}{% when x , , * %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character *'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-at
+  template: "{% case x %}{% when x , , @ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-backslash
+  template: "{% case x %}{% when x , , \\ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-backtick
+  template: "{% case x %}{% when x , , ` %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character `'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-caret
+  template: "{% case x %}{% when x , , ^ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-dollar
+  template: "{% case x %}{% when x , , $ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-hash
+  template: "{% case x %}{% when x , , # %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character #'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-semicolon
+  template: "{% case x %}{% when x , , ; %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ;'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-tilde
+  template: "{% case x %}{% when x , , ~ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-unclosed_double_quote
+  template: '{% case x %}{% when x , , "hello %}{% endcase %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character "'
+  complexity: 100
+- name: case-mut-when_next_value-lexerr-unclosed_single_quote
+  template: "{% case x %}{% when x , , 'hello %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '''
+  complexity: 100
+- name: case-mut-when_next_value-lookup-bracket_wrong_content
+  template: "{% case x %}{% when x , , x[,] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lookup-dot_number
+  template: "{% case x %}{% when x , , x.123 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lookup-dot_string
+  template: '{% case x %}{% when x , , x."y" %}{% endcase %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lookup-range_bad_separator
+  template: "{% case x %}{% when x , , (1, 5) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lookup-range_missing_end
+  template: "{% case x %}{% when x , , (1..) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lookup-trailing_dot
+  template: "{% case x %}{% when x , , x. %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lookup-unclosed_bracket
+  template: "{% case x %}{% when x , , x[0 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-lookup-unclosed_range
+  template: "{% case x %}{% when x , , (1..5 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-pipe-000
+  template: "{% case x %}{% when x , , | %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_next_value-question-005
+  template: "{% case x %}{% when x , , ? %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-bare_bracket
+  template: "{% case x %}{% when [0] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead'
+  complexity: 100
+- name: case-mut-when_value-close_round-004
+  template: "{% case x %}{% when ) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-close_square-003
+  template: "{% case x %}{% when ] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-colon-002
+  template: "{% case x %}{% when : %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comma-001
+  template: "{% case x %}{% when , %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comparison-009
+  template: "{% case x %}{% when == %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comparison-010
+  template: "{% case x %}{% when != %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comparison-011
+  template: "{% case x %}{% when < %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comparison-012
+  template: "{% case x %}{% when > %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comparison-013
+  template: "{% case x %}{% when <= %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comparison-014
+  template: "{% case x %}{% when >= %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-comparison-015
+  template: "{% case x %}{% when contains %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-dash-006
+  template: "{% case x %}{% when - %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-dot-007
+  template: "{% case x %}{% when . %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-dotdot-008
+  template: "{% case x %}{% when .. %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-eos-016
+  template: "{% case x %}{% when  %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-lexerr-ampersand
+  template: "{% case x %}{% when & %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character &'
+  complexity: 100
+- name: case-mut-when_value-lexerr-asterisk
+  template: "{% case x %}{% when * %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character *'
+  complexity: 100
+- name: case-mut-when_value-lexerr-at
+  template: "{% case x %}{% when @ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @'
+  complexity: 100
+- name: case-mut-when_value-lexerr-backslash
+  template: "{% case x %}{% when \\ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \'
+  complexity: 100
+- name: case-mut-when_value-lexerr-backtick
+  template: "{% case x %}{% when ` %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character `'
+  complexity: 100
+- name: case-mut-when_value-lexerr-caret
+  template: "{% case x %}{% when ^ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^'
+  complexity: 100
+- name: case-mut-when_value-lexerr-dollar
+  template: "{% case x %}{% when $ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $'
+  complexity: 100
+- name: case-mut-when_value-lexerr-hash
+  template: "{% case x %}{% when # %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character #'
+  complexity: 100
+- name: case-mut-when_value-lexerr-semicolon
+  template: "{% case x %}{% when ; %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ;'
+  complexity: 100
+- name: case-mut-when_value-lexerr-tilde
+  template: "{% case x %}{% when ~ %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~'
+  complexity: 100
+- name: case-mut-when_value-lexerr-unclosed_double_quote
+  template: '{% case x %}{% when "hello %}{% endcase %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character "'
+  complexity: 100
+- name: case-mut-when_value-lexerr-unclosed_single_quote
+  template: "{% case x %}{% when 'hello %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '''
+  complexity: 100
+- name: case-mut-when_value-lookup-bracket_wrong_content
+  template: "{% case x %}{% when x[,] %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-lookup-dot_number
+  template: "{% case x %}{% when x.123 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number'
+  complexity: 100
+- name: case-mut-when_value-lookup-dot_string
+  template: '{% case x %}{% when x."y" %}{% endcase %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string'
+  complexity: 100
+- name: case-mut-when_value-lookup-range_bad_separator
+  template: "{% case x %}{% when (1, 5) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma'
+  complexity: 100
+- name: case-mut-when_value-lookup-range_missing_end
+  template: "{% case x %}{% when (1..) %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-lookup-trailing_dot
+  template: "{% case x %}{% when x. %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string'
+  complexity: 100
+- name: case-mut-when_value-lookup-unclosed_bracket
+  template: "{% case x %}{% when x[0 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string'
+  complexity: 100
+- name: case-mut-when_value-lookup-unclosed_range
+  template: "{% case x %}{% when (1..5 %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string'
+  complexity: 100
+- name: case-mut-when_value-pipe-000
+  template: "{% case x %}{% when | %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression'
+  complexity: 100
+- name: case-mut-when_value-question-005
+  template: "{% case x %}{% when ? %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression'
+  complexity: 100
+- name: case-parity-elsif-in-case
+  template: "{% case x %}{% elsif %}{% endcase %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unknown tag ''elsif'''
+  complexity: 100

--- a/specs/parser_errors/comment.yml
+++ b/specs/parser_errors/comment.yml
@@ -1,0 +1,55 @@
+---
+- name: comment-001
+  template: "{% comment %}hello"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''comment'' tag was never closed'
+  complexity: 100
+- name: comment-002
+  template: "{% comment foo %}hello"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''comment'' tag was never closed'
+  complexity: 100
+- name: comment-003
+  template: "{% comment %}{% comment %}inner{% endcomment %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''comment'' tag was never closed'
+  complexity: 100
+- name: comment-004
+  template: "{% comment %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''comment'' tag was never closed'
+  complexity: 100
+- name: comment-005
+  template: "{%- comment -%}hello"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''comment'' tag was never closed'
+  complexity: 100
+- name: comment-020
+  template: "{% comment %}{% raw %}hello{% endcomment %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: comment-021
+  template: "{% comment %}{% raw %}hello"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: comment-121
+  template: "{% comment %}this is {{{ not }}} valid{{ liquid{% endcomment %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''comment'' tag was never closed'
+  complexity: 100
+- name: comment-161
+  template: "{% endcomment %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unknown tag ''endcomment'''
+  complexity: 100

--- a/specs/parser_errors/comment.yml
+++ b/specs/parser_errors/comment.yml
@@ -3,53 +3,53 @@
   template: "{% comment %}hello"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''comment'' tag was never closed'
+    - "'comment' tag was never closed"
   complexity: 100
 - name: comment-002
   template: "{% comment foo %}hello"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''comment'' tag was never closed'
+    - "'comment' tag was never closed"
   complexity: 100
 - name: comment-003
   template: "{% comment %}{% comment %}inner{% endcomment %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''comment'' tag was never closed'
+    - "'comment' tag was never closed"
   complexity: 100
 - name: comment-004
   template: "{% comment %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''comment'' tag was never closed'
+    - "'comment' tag was never closed"
   complexity: 100
 - name: comment-005
   template: "{%- comment -%}hello"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''comment'' tag was never closed'
+    - "'comment' tag was never closed"
   complexity: 100
 - name: comment-020
   template: "{% comment %}{% raw %}hello{% endcomment %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: comment-021
   template: "{% comment %}{% raw %}hello"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: comment-121
   template: "{% comment %}this is {{{ not }}} valid{{ liquid{% endcomment %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''comment'' tag was never closed'
+    - "'comment' tag was never closed"
   complexity: 100
 - name: comment-161
   template: "{% endcomment %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unknown tag ''endcomment'''
+    - Unknown tag 'endcomment'
   complexity: 100

--- a/specs/parser_errors/cycle.yml
+++ b/specs/parser_errors/cycle.yml
@@ -1,0 +1,1037 @@
+---
+- name: cycle-mut-cycle_value-bare_bracket
+  template: "{% cycle x : x , , [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      [0]"'
+  complexity: 100
+- name: cycle-mut-cycle_value-bare_bracket-2
+  template: "{% cycle x , , [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , [0]"'
+  complexity: 100
+- name: cycle-mut-cycle_value-close_round-004
+  template: "{% cycle x : x , , ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      )"'
+  complexity: 100
+- name: cycle-mut-cycle_value-close_round-004-2
+  template: "{% cycle x , , ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , )"'
+  complexity: 100
+- name: cycle-mut-cycle_value-close_square-003
+  template: "{% cycle x : x , , ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      ]"'
+  complexity: 100
+- name: cycle-mut-cycle_value-close_square-003-2
+  template: "{% cycle x , , ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ]"'
+  complexity: 100
+- name: cycle-mut-cycle_value-colon-002
+  template: "{% cycle x : x , , : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      :"'
+  complexity: 100
+- name: cycle-mut-cycle_value-colon-002-2
+  template: "{% cycle x , , : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , :"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comma-001
+  template: "{% cycle x : x , , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      ,"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comma-001-2
+  template: "{% cycle x , , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ,"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-009
+  template: "{% cycle x : x , , == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      =="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-009-2
+  template: "{% cycle x , , == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , =="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-010
+  template: "{% cycle x : x , , != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      !="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-010-2
+  template: "{% cycle x , , != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , !="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-011
+  template: "{% cycle x : x , , < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      <"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-011-2
+  template: "{% cycle x , , < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , <"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-012
+  template: "{% cycle x : x , , > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      >"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-012-2
+  template: "{% cycle x , , > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , >"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-013
+  template: "{% cycle x : x , , <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      <="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-013-2
+  template: "{% cycle x , , <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , <="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-014
+  template: "{% cycle x : x , , >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      >="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-014-2
+  template: "{% cycle x , , >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , >="'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-015
+  template: "{% cycle x : x , , contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      contains"'
+  complexity: 100
+- name: cycle-mut-cycle_value-comparison-015-2
+  template: "{% cycle x , , contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , contains"'
+  complexity: 100
+- name: cycle-mut-cycle_value-dash-006
+  template: "{% cycle x : x , , - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      -"'
+  complexity: 100
+- name: cycle-mut-cycle_value-dash-006-2
+  template: "{% cycle x , , - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , -"'
+  complexity: 100
+- name: cycle-mut-cycle_value-dot-007
+  template: "{% cycle x : x , , . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      ."'
+  complexity: 100
+- name: cycle-mut-cycle_value-dot-007-2
+  template: "{% cycle x , , . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ."'
+  complexity: 100
+- name: cycle-mut-cycle_value-dotdot-008
+  template: "{% cycle x : x , , .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      .."'
+  complexity: 100
+- name: cycle-mut-cycle_value-dotdot-008-2
+  template: "{% cycle x , , .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , .."'
+  complexity: 100
+- name: cycle-mut-cycle_value-eos-016
+  template: "{% cycle x : x , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,"'
+  complexity: 100
+- name: cycle-mut-cycle_value-eos-016-2
+  template: "{% cycle x , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , ,"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-ampersand
+  template: "{% cycle x : x , , & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x : x , , &"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-ampersand-2
+  template: "{% cycle x , , & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x , , &"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-asterisk
+  template: "{% cycle x : x , , * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x : x , , *"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-asterisk-2
+  template: "{% cycle x , , * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x , , *"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-at
+  template: "{% cycle x : x , , @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x : x , , @"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-at-2
+  template: "{% cycle x , , @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x , , @"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-backslash
+  template: "{% cycle x : x , , \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x : x , , \"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-backslash-2
+  template: "{% cycle x , , \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x , , \"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-backtick
+  template: "{% cycle x : x , , ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x : x , , `"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-backtick-2
+  template: "{% cycle x , , ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x , , `"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-caret
+  template: "{% cycle x : x , , ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x : x , , ^"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-caret-2
+  template: "{% cycle x , , ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x , , ^"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-dollar
+  template: "{% cycle x : x , , $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x : x , , $"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-dollar-2
+  template: "{% cycle x , , $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x , , $"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-hash
+  template: "{% cycle x : x , , # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x : x , , #"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-hash-2
+  template: "{% cycle x , , # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x , , #"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-semicolon
+  template: "{% cycle x : x , , ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x : x , , ;"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-semicolon-2
+  template: "{% cycle x , , ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x , , ;"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-tilde
+  template: "{% cycle x : x , , ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x : x , , ~"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-tilde-2
+  template: "{% cycle x , , ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x , , ~"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-unclosed_double_quote
+  template: '{% cycle x : x , , "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x : x , , "hello"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-unclosed_double_quote-2
+  template: '{% cycle x , , "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x , , "hello"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-unclosed_single_quote
+  template: "{% cycle x : x , , 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x : x , , ''hello"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lexerr-unclosed_single_quote-2
+  template: "{% cycle x , , 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x , , ''hello"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-bracket_wrong_content
+  template: "{% cycle x : x , , x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      x[,]"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-bracket_wrong_content-2
+  template: "{% cycle x , , x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x[,]"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-dot_number
+  template: "{% cycle x : x , , x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      x.123"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-dot_number-2
+  template: "{% cycle x , , x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x.123"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-dot_string
+  template: '{% cycle x : x , , x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      x."y""'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-dot_string-2
+  template: '{% cycle x , , x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x."y""'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-range_bad_separator
+  template: "{% cycle x : x , , (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      (1, 5)"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-range_bad_separator-2
+  template: "{% cycle x , , (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1,
+      5)"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-range_missing_end
+  template: "{% cycle x : x , , (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      (1..)"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-range_missing_end-2
+  template: "{% cycle x , , (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1..)"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-trailing_dot
+  template: "{% cycle x : x , , x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      x."'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-trailing_dot-2
+  template: "{% cycle x , , x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x."'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-unclosed_bracket
+  template: "{% cycle x : x , , x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      x[0"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-unclosed_bracket-2
+  template: "{% cycle x , , x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x[0"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-unclosed_range
+  template: "{% cycle x : x , , (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      (1..5"'
+  complexity: 100
+- name: cycle-mut-cycle_value-lookup-unclosed_range-2
+  template: "{% cycle x , , (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1..5"'
+  complexity: 100
+- name: cycle-mut-cycle_value-pipe-000
+  template: "{% cycle x : x , , | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      |"'
+  complexity: 100
+- name: cycle-mut-cycle_value-pipe-000-2
+  template: "{% cycle x , , | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , |"'
+  complexity: 100
+- name: cycle-mut-cycle_value-question-005
+  template: "{% cycle x : x , , ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
+      ?"'
+  complexity: 100
+- name: cycle-mut-cycle_value-question-005-2
+  template: "{% cycle x , , ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ?"'
+  complexity: 100
+- name: cycle-mut-end-trail-close_round
+  template: "{% cycle x ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: cycle-mut-end-trail-close_square
+  template: "{% cycle x ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: cycle-mut-end-trail-colon
+  template: "{% cycle x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x :"'
+  complexity: 100
+- name: cycle-mut-end-trail-comparison
+  template: "{% cycle x == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  complexity: 100
+- name: cycle-mut-end-trail-dash
+  template: "{% cycle x - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: cycle-mut-end-trail-dot
+  template: "{% cycle x . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  complexity: 100
+- name: cycle-mut-end-trail-id
+  template: "{% cycle x extra %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  complexity: 100
+- name: cycle-mut-end-trail-number
+  template: "{% cycle x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: cycle-mut-end-trail-open_round
+  template: "{% cycle x ( %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: cycle-mut-end-trail-open_square
+  template: "{% cycle x [ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  complexity: 100
+- name: cycle-mut-end-trail-pipe
+  template: "{% cycle x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: cycle-mut-end-trail-question
+  template: "{% cycle x ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: cycle-mut-end-trail-string
+  template: "{% cycle x 'hi' %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-bare_bracket
+  template: "{% cycle x : [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x : [0]"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-close_round-004
+  template: "{% cycle x : ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x :
+      )"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-close_square-003
+  template: "{% cycle x : ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x :
+      ]"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-colon-002
+  template: "{% cycle x : : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x : :"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comma-001
+  template: "{% cycle x : , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : ,"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comparison-009
+  template: "{% cycle x : == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x :
+      =="'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comparison-010
+  template: "{% cycle x : != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x :
+      !="'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comparison-011
+  template: "{% cycle x : < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x : <"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comparison-012
+  template: "{% cycle x : > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x : >"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comparison-013
+  template: "{% cycle x : <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x :
+      <="'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comparison-014
+  template: "{% cycle x : >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x :
+      >="'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-comparison-015
+  template: "{% cycle x : contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x : contains"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-dash-006
+  template: "{% cycle x : - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x : -"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-dot-007
+  template: "{% cycle x : . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x : ."'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-dotdot-008
+  template: "{% cycle x : .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x : .."'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-eos-016
+  template: "{% cycle x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x :"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-ampersand
+  template: "{% cycle x : & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x : &"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-asterisk
+  template: "{% cycle x : * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x : *"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-at
+  template: "{% cycle x : @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x : @"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-backslash
+  template: "{% cycle x : \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x : \"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-backtick
+  template: "{% cycle x : ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x : `"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-caret
+  template: "{% cycle x : ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x : ^"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-dollar
+  template: "{% cycle x : $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x : $"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-hash
+  template: "{% cycle x : # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x : #"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-semicolon
+  template: "{% cycle x : ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x : ;"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-tilde
+  template: "{% cycle x : ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x : ~"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-unclosed_double_quote
+  template: '{% cycle x : "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x : "hello"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lexerr-unclosed_single_quote
+  template: "{% cycle x : 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x : ''hello"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-bracket_wrong_content
+  template: "{% cycle x : x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x[,]"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-dot_number
+  template: "{% cycle x : x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x : x.123"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-dot_string
+  template: '{% cycle x : x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x : x."y""'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-range_bad_separator
+  template: "{% cycle x : (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x : (1, 5)"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-range_missing_end
+  template: "{% cycle x : (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x :
+      (1..)"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-trailing_dot
+  template: "{% cycle x : x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x : x."'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-unclosed_bracket
+  template: "{% cycle x : x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x :
+      x[0"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-lookup-unclosed_range
+  template: "{% cycle x : (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x : (1..5"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-pipe-000
+  template: "{% cycle x : | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x : |"'
+  complexity: 100
+- name: cycle-mut-first_cycle_value-question-005
+  template: "{% cycle x : ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x : ?"'
+  complexity: 100
+- name: cycle-mut-first_value-bare_bracket
+  template: "{% cycle [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "[0]"'
+  complexity: 100
+- name: cycle-mut-first_value-close_round-004
+  template: "{% cycle ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  complexity: 100
+- name: cycle-mut-first_value-close_square-003
+  template: "{% cycle ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  complexity: 100
+- name: cycle-mut-first_value-colon-002
+  template: "{% cycle : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  complexity: 100
+- name: cycle-mut-first_value-comma-001
+  template: "{% cycle , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  complexity: 100
+- name: cycle-mut-first_value-comparison-009
+  template: "{% cycle == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  complexity: 100
+- name: cycle-mut-first_value-comparison-010
+  template: "{% cycle != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  complexity: 100
+- name: cycle-mut-first_value-comparison-011
+  template: "{% cycle < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  complexity: 100
+- name: cycle-mut-first_value-comparison-012
+  template: "{% cycle > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  complexity: 100
+- name: cycle-mut-first_value-comparison-013
+  template: "{% cycle <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  complexity: 100
+- name: cycle-mut-first_value-comparison-014
+  template: "{% cycle >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  complexity: 100
+- name: cycle-mut-first_value-comparison-015
+  template: "{% cycle contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "contains"'
+  complexity: 100
+- name: cycle-mut-first_value-dash-006
+  template: "{% cycle - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  complexity: 100
+- name: cycle-mut-first_value-dot-007
+  template: "{% cycle . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  complexity: 100
+- name: cycle-mut-first_value-dotdot-008
+  template: "{% cycle .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  complexity: 100
+- name: cycle-mut-first_value-eos-016
+  template: "{% cycle  %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''cycle'' - Valid syntax: cycle [name
+      :] var [, var2, var3 ...] in ""'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-ampersand
+  template: "{% cycle & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-asterisk
+  template: "{% cycle * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-at
+  template: "{% cycle @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-backslash
+  template: "{% cycle \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-backtick
+  template: "{% cycle ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-caret
+  template: "{% cycle ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-dollar
+  template: "{% cycle $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-hash
+  template: "{% cycle # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-semicolon
+  template: "{% cycle ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-tilde
+  template: "{% cycle ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-unclosed_double_quote
+  template: '{% cycle "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: cycle-mut-first_value-lexerr-unclosed_single_quote
+  template: "{% cycle 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-bracket_wrong_content
+  template: "{% cycle x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-dot_number
+  template: "{% cycle x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x.123"'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-dot_string
+  template: '{% cycle x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x."y""'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-range_bad_separator
+  template: "{% cycle (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-range_missing_end
+  template: "{% cycle (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-trailing_dot
+  template: "{% cycle x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-unclosed_bracket
+  template: "{% cycle x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  complexity: 100
+- name: cycle-mut-first_value-lookup-unclosed_range
+  template: "{% cycle (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  complexity: 100
+- name: cycle-mut-first_value-pipe-000
+  template: "{% cycle | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  complexity: 100
+- name: cycle-mut-first_value-question-005
+  template: "{% cycle ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  complexity: 100
+- name: cycle-mut-pregate-000
+  template: "{% cycle  %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''cycle'' - Valid syntax: cycle [name
+      :] var [, var2, var3 ...] in ""'
+  complexity: 100

--- a/specs/parser_errors/cycle.yml
+++ b/specs/parser_errors/cycle.yml
@@ -3,1035 +3,995 @@
   template: "{% cycle x : x , , [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      [0]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-bare_bracket-2
   template: "{% cycle x , , [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , [0]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-close_round-004
   template: "{% cycle x : x , , ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      )"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-close_round-004-2
   template: "{% cycle x , , ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , )"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-close_square-003
   template: "{% cycle x : x , , ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      ]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-close_square-003-2
   template: "{% cycle x , , ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-colon-002
   template: "{% cycle x : x , , : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      :"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-colon-002-2
   template: "{% cycle x , , : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , :"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comma-001
   template: "{% cycle x : x , , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comma-001-2
   template: "{% cycle x , , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-009
   template: "{% cycle x : x , , == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      =="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-009-2
   template: "{% cycle x , , == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , =="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-010
   template: "{% cycle x : x , , != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      !="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-010-2
   template: "{% cycle x , , != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , !="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-011
   template: "{% cycle x : x , , < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      <"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-011-2
   template: "{% cycle x , , < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , <"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-012
   template: "{% cycle x : x , , > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      >"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-012-2
   template: "{% cycle x , , > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , >"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-013
   template: "{% cycle x : x , , <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      <="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-013-2
   template: "{% cycle x , , <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , <="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-014
   template: "{% cycle x : x , , >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      >="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-014-2
   template: "{% cycle x , , >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , >="'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-015
   template: "{% cycle x : x , , contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      contains"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-comparison-015-2
   template: "{% cycle x , , contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , contains"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-dash-006
   template: "{% cycle x : x , , - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      -"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-dash-006-2
   template: "{% cycle x , , - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , -"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-dot-007
   template: "{% cycle x : x , , . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      ."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-dot-007-2
   template: "{% cycle x , , . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-dotdot-008
   template: "{% cycle x : x , , .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      .."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-dotdot-008-2
   template: "{% cycle x , , .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , .."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-eos-016
   template: "{% cycle x : x , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-eos-016-2
   template: "{% cycle x , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-ampersand
   template: "{% cycle x : x , , & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x : x , , &"'
+    - Unexpected character &
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-ampersand-2
   template: "{% cycle x , , & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x , , &"'
+    - Unexpected character &
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-asterisk
   template: "{% cycle x : x , , * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x : x , , *"'
+    - Unexpected character *
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-asterisk-2
   template: "{% cycle x , , * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x , , *"'
+    - Unexpected character *
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-at
   template: "{% cycle x : x , , @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x : x , , @"'
+    - Unexpected character @
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-at-2
   template: "{% cycle x , , @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x , , @"'
+    - Unexpected character @
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-backslash
   template: "{% cycle x : x , , \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x : x , , \"'
+    - Unexpected character \
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-backslash-2
   template: "{% cycle x , , \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x , , \"'
+    - Unexpected character \
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-backtick
   template: "{% cycle x : x , , ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x : x , , `"'
+    - Unexpected character `
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-backtick-2
   template: "{% cycle x , , ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x , , `"'
+    - Unexpected character `
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-caret
   template: "{% cycle x : x , , ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x : x , , ^"'
+    - Unexpected character ^
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-caret-2
   template: "{% cycle x , , ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x , , ^"'
+    - Unexpected character ^
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-dollar
   template: "{% cycle x : x , , $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x : x , , $"'
+    - Unexpected character $
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-dollar-2
   template: "{% cycle x , , $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x , , $"'
+    - Unexpected character $
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-hash
   template: "{% cycle x : x , , # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x : x , , #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-hash-2
   template: "{% cycle x , , # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x , , #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-semicolon
   template: "{% cycle x : x , , ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x : x , , ;"'
+    - Unexpected character ;
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-semicolon-2
   template: "{% cycle x , , ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x , , ;"'
+    - Unexpected character ;
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-tilde
   template: "{% cycle x : x , , ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x : x , , ~"'
+    - Unexpected character ~
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-tilde-2
   template: "{% cycle x , , ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x , , ~"'
+    - Unexpected character ~
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-unclosed_double_quote
   template: '{% cycle x : x , , "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x : x , , "hello"'
+    - Unexpected character "
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-unclosed_double_quote-2
   template: '{% cycle x , , "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x , , "hello"'
+    - Unexpected character "
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-unclosed_single_quote
   template: "{% cycle x : x , , 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x : x , , ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: cycle-mut-cycle_value-lexerr-unclosed_single_quote-2
   template: "{% cycle x , , 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x , , ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-bracket_wrong_content
   template: "{% cycle x : x , , x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-bracket_wrong_content-2
   template: "{% cycle x , , x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-dot_number
   template: "{% cycle x : x , , x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      x.123"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-dot_number-2
   template: "{% cycle x , , x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x.123"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-dot_string
   template: '{% cycle x : x , , x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      x."y""'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-dot_string-2
   template: '{% cycle x , , x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x."y""'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-range_bad_separator
   template: "{% cycle x : x , , (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      (1, 5)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-range_bad_separator-2
   template: "{% cycle x , , (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1,
-      5)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-range_missing_end
   template: "{% cycle x : x , , (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      (1..)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-range_missing_end-2
   template: "{% cycle x , , (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1..)"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-trailing_dot
   template: "{% cycle x : x , , x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      x."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-trailing_dot-2
   template: "{% cycle x , , x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x."'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-unclosed_bracket
   template: "{% cycle x : x , , x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      x[0"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-unclosed_bracket-2
   template: "{% cycle x , , x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , x[0"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-unclosed_range
   template: "{% cycle x : x , , (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      (1..5"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-lookup-unclosed_range-2
   template: "{% cycle x , , (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , (1..5"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-pipe-000
   template: "{% cycle x : x , , | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      |"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-pipe-000-2
   template: "{% cycle x , , | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , |"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-question-005
   template: "{% cycle x : x , , ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x , ,
-      ?"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-cycle_value-question-005-2
   template: "{% cycle x , , ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x , , ?"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-end-trail-close_round
   template: "{% cycle x ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: cycle-mut-end-trail-close_square
   template: "{% cycle x ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: cycle-mut-end-trail-colon
   template: "{% cycle x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x :"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: cycle-mut-end-trail-comparison
   template: "{% cycle x == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: cycle-mut-end-trail-dash
   template: "{% cycle x - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: cycle-mut-end-trail-dot
   template: "{% cycle x . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: cycle-mut-end-trail-id
   template: "{% cycle x extra %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: cycle-mut-end-trail-number
   template: "{% cycle x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: cycle-mut-end-trail-open_round
   template: "{% cycle x ( %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: cycle-mut-end-trail-open_square
   template: "{% cycle x [ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: cycle-mut-end-trail-pipe
   template: "{% cycle x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: cycle-mut-end-trail-question
   template: "{% cycle x ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: cycle-mut-end-trail-string
   template: "{% cycle x 'hi' %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: cycle-mut-first_cycle_value-bare_bracket
   template: "{% cycle x : [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x : [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: cycle-mut-first_cycle_value-close_round-004
   template: "{% cycle x : ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x :
-      )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-close_square-003
   template: "{% cycle x : ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x :
-      ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-colon-002
   template: "{% cycle x : : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x : :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comma-001
   template: "{% cycle x : , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comparison-009
   template: "{% cycle x : == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x :
-      =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comparison-010
   template: "{% cycle x : != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x :
-      !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comparison-011
   template: "{% cycle x : < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x : <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comparison-012
   template: "{% cycle x : > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x : >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comparison-013
   template: "{% cycle x : <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x :
-      <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comparison-014
   template: "{% cycle x : >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x :
-      >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-comparison-015
   template: "{% cycle x : contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x : contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-dash-006
   template: "{% cycle x : - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x : -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-dot-007
   template: "{% cycle x : . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x : ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-dotdot-008
   template: "{% cycle x : .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x : .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-eos-016
   template: "{% cycle x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x :"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-ampersand
   template: "{% cycle x : & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x : &"'
+    - Unexpected character &
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-asterisk
   template: "{% cycle x : * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x : *"'
+    - Unexpected character *
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-at
   template: "{% cycle x : @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x : @"'
+    - Unexpected character @
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-backslash
   template: "{% cycle x : \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x : \"'
+    - Unexpected character \
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-backtick
   template: "{% cycle x : ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x : `"'
+    - Unexpected character `
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-caret
   template: "{% cycle x : ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x : ^"'
+    - Unexpected character ^
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-dollar
   template: "{% cycle x : $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x : $"'
+    - Unexpected character $
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-hash
   template: "{% cycle x : # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x : #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-semicolon
   template: "{% cycle x : ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x : ;"'
+    - Unexpected character ;
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-tilde
   template: "{% cycle x : ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x : ~"'
+    - Unexpected character ~
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-unclosed_double_quote
   template: '{% cycle x : "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x : "hello"'
+    - Unexpected character "
   complexity: 100
 - name: cycle-mut-first_cycle_value-lexerr-unclosed_single_quote
   template: "{% cycle x : 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x : ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-bracket_wrong_content
   template: "{% cycle x : x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x : x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-dot_number
   template: "{% cycle x : x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x : x.123"'
+    - Expected id but found number
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-dot_string
   template: '{% cycle x : x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x : x."y""'
+    - Expected id but found string
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-range_bad_separator
   template: "{% cycle x : (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x : (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-range_missing_end
   template: "{% cycle x : (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x :
-      (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-trailing_dot
   template: "{% cycle x : x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x : x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-unclosed_bracket
   template: "{% cycle x : x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x :
-      x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: cycle-mut-first_cycle_value-lookup-unclosed_range
   template: "{% cycle x : (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x : (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: cycle-mut-first_cycle_value-pipe-000
   template: "{% cycle x : | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x : |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_cycle_value-question-005
   template: "{% cycle x : ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x : ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-bare_bracket
   template: "{% cycle [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "[0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: cycle-mut-first_value-close_round-004
   template: "{% cycle ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-close_square-003
   template: "{% cycle ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-colon-002
   template: "{% cycle : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comma-001
   template: "{% cycle , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comparison-009
   template: "{% cycle == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comparison-010
   template: "{% cycle != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comparison-011
   template: "{% cycle < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comparison-012
   template: "{% cycle > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comparison-013
   template: "{% cycle <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comparison-014
   template: "{% cycle >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-comparison-015
   template: "{% cycle contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-dash-006
   template: "{% cycle - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-dot-007
   template: "{% cycle . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-dotdot-008
   template: "{% cycle .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-eos-016
   template: "{% cycle  %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''cycle'' - Valid syntax: cycle [name
-      :] var [, var2, var3 ...] in ""'
+    - Syntax Error in 'cycle'
   complexity: 100
 - name: cycle-mut-first_value-lexerr-ampersand
   template: "{% cycle & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: cycle-mut-first_value-lexerr-asterisk
   template: "{% cycle * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: cycle-mut-first_value-lexerr-at
   template: "{% cycle @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: cycle-mut-first_value-lexerr-backslash
   template: "{% cycle \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: cycle-mut-first_value-lexerr-backtick
   template: "{% cycle ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: cycle-mut-first_value-lexerr-caret
   template: "{% cycle ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: cycle-mut-first_value-lexerr-dollar
   template: "{% cycle $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: cycle-mut-first_value-lexerr-hash
   template: "{% cycle # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: cycle-mut-first_value-lexerr-semicolon
   template: "{% cycle ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: cycle-mut-first_value-lexerr-tilde
   template: "{% cycle ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: cycle-mut-first_value-lexerr-unclosed_double_quote
   template: '{% cycle "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: cycle-mut-first_value-lexerr-unclosed_single_quote
   template: "{% cycle 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: cycle-mut-first_value-lookup-bracket_wrong_content
   template: "{% cycle x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-lookup-dot_number
   template: "{% cycle x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x.123"'
+    - Expected id but found number
   complexity: 100
 - name: cycle-mut-first_value-lookup-dot_string
   template: '{% cycle x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x."y""'
+    - Expected id but found string
   complexity: 100
 - name: cycle-mut-first_value-lookup-range_bad_separator
   template: "{% cycle (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: cycle-mut-first_value-lookup-range_missing_end
   template: "{% cycle (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-lookup-trailing_dot
   template: "{% cycle x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: cycle-mut-first_value-lookup-unclosed_bracket
   template: "{% cycle x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: cycle-mut-first_value-lookup-unclosed_range
   template: "{% cycle (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: cycle-mut-first_value-pipe-000
   template: "{% cycle | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-first_value-question-005
   template: "{% cycle ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: cycle-mut-pregate-000
   template: "{% cycle  %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''cycle'' - Valid syntax: cycle [name
-      :] var [, var2, var3 ...] in ""'
+    - Syntax Error in 'cycle'
   complexity: 100

--- a/specs/parser_errors/decrement.yml
+++ b/specs/parser_errors/decrement.yml
@@ -1,0 +1,169 @@
+---
+- name: decrement-mut-end-trail-close_round
+  template: "{% decrement x ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: decrement-mut-end-trail-close_square
+  template: "{% decrement x ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: decrement-mut-end-trail-colon
+  template: "{% decrement x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  complexity: 100
+- name: decrement-mut-end-trail-comma
+  template: "{% decrement x , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  complexity: 100
+- name: decrement-mut-end-trail-comparison
+  template: "{% decrement x == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  complexity: 100
+- name: decrement-mut-end-trail-dash
+  template: "{% decrement x - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: decrement-mut-end-trail-dot
+  template: "{% decrement x . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+  complexity: 100
+- name: decrement-mut-end-trail-id
+  template: "{% decrement x extra %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  complexity: 100
+- name: decrement-mut-end-trail-number
+  template: "{% decrement x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: decrement-mut-end-trail-open_round
+  template: "{% decrement x ( %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: decrement-mut-end-trail-open_square
+  template: "{% decrement x [ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_square in "x ["'
+  complexity: 100
+- name: decrement-mut-end-trail-pipe
+  template: "{% decrement x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: decrement-mut-end-trail-question
+  template: "{% decrement x ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: decrement-mut-end-trail-string
+  template: "{% decrement x 'hi' %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100
+- name: decrement-mut-variable_name-eos
+  template: "{% decrement  %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-ampersand
+  template: "{% decrement & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-asterisk
+  template: "{% decrement * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-at
+  template: "{% decrement @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-backslash
+  template: "{% decrement \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-backtick
+  template: "{% decrement ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-caret
+  template: "{% decrement ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-dollar
+  template: "{% decrement $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-hash
+  template: "{% decrement # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-semicolon
+  template: "{% decrement ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-tilde
+  template: "{% decrement ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% decrement "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: decrement-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% decrement 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: decrement-mut-variable_name-number
+  template: "{% decrement 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "42"'
+  complexity: 100

--- a/specs/parser_errors/decrement.yml
+++ b/specs/parser_errors/decrement.yml
@@ -3,167 +3,167 @@
   template: "{% decrement x ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: decrement-mut-end-trail-close_square
   template: "{% decrement x ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: decrement-mut-end-trail-colon
   template: "{% decrement x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: decrement-mut-end-trail-comma
   template: "{% decrement x , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: decrement-mut-end-trail-comparison
   template: "{% decrement x == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: decrement-mut-end-trail-dash
   template: "{% decrement x - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: decrement-mut-end-trail-dot
   template: "{% decrement x . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+    - Expected end_of_string but found dot
   complexity: 100
 - name: decrement-mut-end-trail-id
   template: "{% decrement x extra %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: decrement-mut-end-trail-number
   template: "{% decrement x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: decrement-mut-end-trail-open_round
   template: "{% decrement x ( %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: decrement-mut-end-trail-open_square
   template: "{% decrement x [ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_square in "x ["'
+    - Expected end_of_string but found open_square
   complexity: 100
 - name: decrement-mut-end-trail-pipe
   template: "{% decrement x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: decrement-mut-end-trail-question
   template: "{% decrement x ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: decrement-mut-end-trail-string
   template: "{% decrement x 'hi' %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: decrement-mut-variable_name-eos
   template: "{% decrement  %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+    - Expected id but found end_of_string
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-ampersand
   template: "{% decrement & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-asterisk
   template: "{% decrement * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-at
   template: "{% decrement @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-backslash
   template: "{% decrement \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-backtick
   template: "{% decrement ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-caret
   template: "{% decrement ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-dollar
   template: "{% decrement $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-hash
   template: "{% decrement # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-semicolon
   template: "{% decrement ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-tilde
   template: "{% decrement ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-unclosed_double_quote
   template: '{% decrement "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: decrement-mut-variable_name-lexerr-unclosed_single_quote
   template: "{% decrement 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: decrement-mut-variable_name-number
   template: "{% decrement 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "42"'
+    - Expected id but found number
   complexity: 100

--- a/specs/parser_errors/doc.yml
+++ b/specs/parser_errors/doc.yml
@@ -3,131 +3,121 @@
   template: "{% doc foo %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-002
   template: "{% doc foo bar %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-003
   template: "{% doc 123 %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-004
   template: "{% doc 'hello' %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-005
   template: "{% doc == %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-006
   template: "{% doc | %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-007
   template: "{% doc @#$ %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-008
   template: "{%- doc foo -%}{%- enddoc -%}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-009
   template: "{% doc foo %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-010
   template: "{% doc foo %}some content"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
-      %}'
+    - Syntax Error in 'doc'
   complexity: 100
 - name: doc-020
   template: "{% doc %}{% doc %}{% enddoc %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+    - Syntax Error in 'doc' - Nested doc tags are not allowed
   complexity: 100
 - name: doc-021
   template: "{% doc %}hello{% doc %}world{% enddoc %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+    - Syntax Error in 'doc' - Nested doc tags are not allowed
   complexity: 100
 - name: doc-022
   template: "{% doc %}{% doc %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+    - Syntax Error in 'doc' - Nested doc tags are not allowed
   complexity: 100
 - name: doc-023
   template: "{% doc %}{% doc %}content"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+    - Syntax Error in 'doc' - Nested doc tags are not allowed
   complexity: 100
 - name: doc-024
   template: "{% doc %}{% doc %}{% doc %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+    - Syntax Error in 'doc' - Nested doc tags are not allowed
   complexity: 100
 - name: doc-025
   template: "{% doc %}{% doc foo %}{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+    - Syntax Error in 'doc' - Nested doc tags are not allowed
   complexity: 100
 - name: doc-040
   template: "{% doc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''doc'' tag was never closed'
+    - "'doc' tag was never closed"
   complexity: 100
 - name: doc-041
   template: "{% doc %}some content here"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''doc'' tag was never closed'
+    - "'doc' tag was never closed"
   complexity: 100
 - name: doc-042
   template: "{% doc %}{% if true %}hello{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''doc'' tag was never closed'
+    - "'doc' tag was never closed"
   complexity: 100
 - name: doc-043
   template: "{%- doc -%}content"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''doc'' tag was never closed'
+    - "'doc' tag was never closed"
   complexity: 100
 - name: doc-044
   template: |-
@@ -136,17 +126,17 @@
     {% doc %}content
   errors:
     parse_error:
-    - 'Liquid syntax error: ''doc'' tag was never closed'
+    - "'doc' tag was never closed"
   complexity: 100
 - name: doc-045
   template: "{% doc %}a{% enddoc %}{% doc %}b"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''doc'' tag was never closed'
+    - "'doc' tag was never closed"
   complexity: 100
 - name: doc-114
   template: "{% enddoc %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unknown tag ''enddoc'''
+    - Unknown tag 'enddoc'
   complexity: 100

--- a/specs/parser_errors/doc.yml
+++ b/specs/parser_errors/doc.yml
@@ -1,0 +1,152 @@
+---
+- name: doc-001
+  template: "{% doc foo %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-002
+  template: "{% doc foo bar %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-003
+  template: "{% doc 123 %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-004
+  template: "{% doc 'hello' %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-005
+  template: "{% doc == %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-006
+  template: "{% doc | %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-007
+  template: "{% doc @#$ %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-008
+  template: "{%- doc foo -%}{%- enddoc -%}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-009
+  template: "{% doc foo %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-010
+  template: "{% doc foo %}some content"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Valid syntax: {% doc %}{% enddoc
+      %}'
+  complexity: 100
+- name: doc-020
+  template: "{% doc %}{% doc %}{% enddoc %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  complexity: 100
+- name: doc-021
+  template: "{% doc %}hello{% doc %}world{% enddoc %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  complexity: 100
+- name: doc-022
+  template: "{% doc %}{% doc %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  complexity: 100
+- name: doc-023
+  template: "{% doc %}{% doc %}content"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  complexity: 100
+- name: doc-024
+  template: "{% doc %}{% doc %}{% doc %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  complexity: 100
+- name: doc-025
+  template: "{% doc %}{% doc foo %}{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''doc'' - Nested doc tags are not allowed'
+  complexity: 100
+- name: doc-040
+  template: "{% doc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''doc'' tag was never closed'
+  complexity: 100
+- name: doc-041
+  template: "{% doc %}some content here"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''doc'' tag was never closed'
+  complexity: 100
+- name: doc-042
+  template: "{% doc %}{% if true %}hello{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''doc'' tag was never closed'
+  complexity: 100
+- name: doc-043
+  template: "{%- doc -%}content"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''doc'' tag was never closed'
+  complexity: 100
+- name: doc-044
+  template: |-
+    hello
+
+    {% doc %}content
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''doc'' tag was never closed'
+  complexity: 100
+- name: doc-045
+  template: "{% doc %}a{% enddoc %}{% doc %}b"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''doc'' tag was never closed'
+  complexity: 100
+- name: doc-114
+  template: "{% enddoc %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unknown tag ''enddoc'''
+  complexity: 100

--- a/specs/parser_errors/echo.yml
+++ b/specs/parser_errors/echo.yml
@@ -1,0 +1,1173 @@
+---
+- name: echo-mut-end-trail-close_round
+  template: "{% echo x ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "{{x )
+      }}"'
+  complexity: 100
+- name: echo-mut-end-trail-close_square
+  template: "{% echo x ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "{{x
+      ] }}"'
+  complexity: 100
+- name: echo-mut-end-trail-colon
+  template: "{% echo x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "{{x : }}"'
+  complexity: 100
+- name: echo-mut-end-trail-comma
+  template: "{% echo x , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "{{x , }}"'
+  complexity: 100
+- name: echo-mut-end-trail-comparison
+  template: "{% echo x == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "{{x ==
+      }}"'
+  complexity: 100
+- name: echo-mut-end-trail-dash
+  template: "{% echo x - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "{{x - }}"'
+  complexity: 100
+- name: echo-mut-end-trail-dot
+  template: "{% echo x . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{x . }}"'
+  complexity: 100
+- name: echo-mut-end-trail-id
+  template: "{% echo x extra %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "{{x extra }}"'
+  complexity: 100
+- name: echo-mut-end-trail-number
+  template: "{% echo x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "{{x 42 }}"'
+  complexity: 100
+- name: echo-mut-end-trail-open_round
+  template: "{% echo x ( %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "{{x (
+      }}"'
+  complexity: 100
+- name: echo-mut-end-trail-open_square
+  template: "{% echo x [ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "{{x [ }}"'
+  complexity: 100
+- name: echo-mut-end-trail-pipe
+  template: "{% echo x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | }}"'
+  complexity: 100
+- name: echo-mut-end-trail-question
+  template: "{% echo x ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "{{x ? }}"'
+  complexity: 100
+- name: echo-mut-end-trail-string
+  template: "{% echo x 'hi' %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "{{x ''hi''
+      }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-bare_bracket
+  template: "{% echo x | x : x , , [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , [0] }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-close_round-004
+  template: "{% echo x | x : x , , ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , ) }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-close_square-003
+  template: "{% echo x | x : x , , ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , ] }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-colon-002
+  template: "{% echo x | x : x , , : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , : }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comma-001
+  template: "{% echo x | x : x , , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , , }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comparison-009
+  template: "{% echo x | x : x , , == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , == }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comparison-010
+  template: "{% echo x | x : x , , != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , != }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comparison-011
+  template: "{% echo x | x : x , , < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , < }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comparison-012
+  template: "{% echo x | x : x , , > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , > }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comparison-013
+  template: "{% echo x | x : x , , <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , <= }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comparison-014
+  template: "{% echo x | x : x , , >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , >= }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-comparison-015
+  template: "{% echo x | x : x , , contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , contains }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-dash-006
+  template: "{% echo x | x : x , , - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , - }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-dot-007
+  template: "{% echo x | x : x , , . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , . }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-dotdot-008
+  template: "{% echo x | x : x , , .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , .. }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-eos-016
+  template: "{% echo x | x : x , , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-ampersand
+  template: "{% echo x | x : x , , & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{x | x : x , , & }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-asterisk
+  template: "{% echo x | x : x , , * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{x | x : x , , * }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-at
+  template: "{% echo x | x : x , , @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{x | x : x , , @ }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-backslash
+  template: "{% echo x | x : x , , \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{x | x : x , , \ }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-backtick
+  template: "{% echo x | x : x , , ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{x | x : x , , ` }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-caret
+  template: "{% echo x | x : x , , ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{x | x : x , , ^ }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-dollar
+  template: "{% echo x | x : x , , $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{x | x : x , , $ }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-hash
+  template: "{% echo x | x : x , , # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{x | x : x , , # }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-semicolon
+  template: "{% echo x | x : x , , ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{x | x : x , , ; }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-tilde
+  template: "{% echo x | x : x , , ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{x | x : x , , ~ }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-unclosed_double_quote
+  template: '{% echo x | x : x , , "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{x | x : x , , "hello }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lexerr-unclosed_single_quote
+  template: "{% echo x | x : x , , 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{x | x : x , , ''hello }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-bracket_wrong_content
+  template: "{% echo x | x : x , , x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x[,] }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-dot_number
+  template: "{% echo x | x : x , , x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x.123 }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-dot_string
+  template: '{% echo x | x : x , , x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x."y" }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-range_bad_separator
+  template: "{% echo x | x : x , , (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , (1, 5) }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-range_missing_end
+  template: "{% echo x | x : x , , (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , (1..) }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-trailing_dot
+  template: "{% echo x | x : x , , x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x. }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-unclosed_bracket
+  template: "{% echo x | x : x , , x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x[0 }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-lookup-unclosed_range
+  template: "{% echo x | x : x , , (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , (1..5 }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-pipe-000
+  template: "{% echo x | x : x , , | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , | }}"'
+  complexity: 100
+- name: echo-mut-filter_arg_value-question-005
+  template: "{% echo x | x : x , , ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , ? }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-bare_bracket
+  template: "{% echo x | x : [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "{{x | x : [0] }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-close_round-004
+  template: "{% echo x | x : ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{x
+      | x : ) }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-close_square-003
+  template: "{% echo x | x : ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{x
+      | x : ] }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-colon-002
+  template: "{% echo x | x : : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{x | x :
+      : }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comma-001
+  template: "{% echo x | x : , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      , }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comparison-009
+  template: "{% echo x | x : == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{x
+      | x : == }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comparison-010
+  template: "{% echo x | x : != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{x
+      | x : != }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comparison-011
+  template: "{% echo x | x : < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{x |
+      x : < }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comparison-012
+  template: "{% echo x | x : > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{x |
+      x : > }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comparison-013
+  template: "{% echo x | x : <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{x
+      | x : <= }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comparison-014
+  template: "{% echo x | x : >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{x
+      | x : >= }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-comparison-015
+  template: "{% echo x | x : contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "{{x | x : contains }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-dash-006
+  template: "{% echo x | x : - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{x | x : -
+      }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-dot-007
+  template: "{% echo x | x : . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{x | x : .
+      }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-dotdot-008
+  template: "{% echo x | x : .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{x | x
+      : .. }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-ampersand
+  template: "{% echo x | x : & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{x | x : & }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-asterisk
+  template: "{% echo x | x : * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{x | x : * }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-at
+  template: "{% echo x | x : @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{x | x : @ }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-backslash
+  template: "{% echo x | x : \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{x | x : \ }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-backtick
+  template: "{% echo x | x : ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{x | x : ` }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-caret
+  template: "{% echo x | x : ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{x | x : ^ }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-dollar
+  template: "{% echo x | x : $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{x | x : $ }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-hash
+  template: "{% echo x | x : # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{x | x : # }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-semicolon
+  template: "{% echo x | x : ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{x | x : ; }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-tilde
+  template: "{% echo x | x : ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{x | x : ~ }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-unclosed_double_quote
+  template: '{% echo x | x : "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{x | x : "hello }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lexerr-unclosed_single_quote
+  template: "{% echo x | x : 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{x | x : ''hello }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-bracket_wrong_content
+  template: "{% echo x | x : x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x[,] }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-dot_number
+  template: "{% echo x | x : x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "{{x | x : x.123 }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-dot_string
+  template: '{% echo x | x : x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "{{x | x : x."y" }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-range_bad_separator
+  template: "{% echo x | x : (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "{{x | x : (1, 5) }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-range_missing_end
+  template: "{% echo x | x : (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{x
+      | x : (1..) }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-trailing_dot
+  template: "{% echo x | x : x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | x : x. }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-unclosed_bracket
+  template: "{% echo x | x : x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{x
+      | x : x[0 }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-lookup-unclosed_range
+  template: "{% echo x | x : (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{x |
+      x : (1..5 }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-pipe-000
+  template: "{% echo x | x : | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | x : | }}"'
+  complexity: 100
+- name: echo-mut-filter_first_arg-question-005
+  template: "{% echo x | x : ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{x | x
+      : ? }}"'
+  complexity: 100
+- name: echo-mut-filter_name-eos
+  template: "{% echo x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-ampersand
+  template: "{% echo x | & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{x | & }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-asterisk
+  template: "{% echo x | * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{x | * }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-at
+  template: "{% echo x | @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{x | @ }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-backslash
+  template: "{% echo x | \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{x | \ }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-backtick
+  template: "{% echo x | ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{x | ` }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-caret
+  template: "{% echo x | ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{x | ^ }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-dollar
+  template: "{% echo x | $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{x | $ }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-hash
+  template: "{% echo x | # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{x | # }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-semicolon
+  template: "{% echo x | ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{x | ; }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-tilde
+  template: "{% echo x | ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{x | ~ }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-unclosed_double_quote
+  template: '{% echo x | "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{x | "hello }}"'
+  complexity: 100
+- name: echo-mut-filter_name-lexerr-unclosed_single_quote
+  template: "{% echo x | 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{x | ''hello }}"'
+  complexity: 100
+- name: echo-mut-filter_name-number
+  template: "{% echo x | 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "{{x | 42 }}"'
+  complexity: 100
+- name: echo-mut-kwarg_colon-eos
+  template: "{% echo x | x : x , , x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x }}"'
+  complexity: 100
+- name: echo-mut-kwarg_colon-number
+  template: "{% echo x | x : x , , x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x 42 }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-bare_bracket
+  template: "{% echo x | x : x , , x : [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : [0] }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-close_round-004
+  template: "{% echo x | x : x , , x : ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : ) }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-close_square-003
+  template: "{% echo x | x : x , , x : ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : ] }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-colon-002
+  template: "{% echo x | x : x , , x : : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : : }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comma-001
+  template: "{% echo x | x : x , , x : , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : , }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comparison-009
+  template: "{% echo x | x : x , , x : == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : == }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comparison-010
+  template: "{% echo x | x : x , , x : != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : != }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comparison-011
+  template: "{% echo x | x : x , , x : < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : < }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comparison-012
+  template: "{% echo x | x : x , , x : > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : > }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comparison-013
+  template: "{% echo x | x : x , , x : <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : <= }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comparison-014
+  template: "{% echo x | x : x , , x : >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : >= }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-comparison-015
+  template: "{% echo x | x : x , , x : contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : contains }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-dash-006
+  template: "{% echo x | x : x , , x : - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : - }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-dot-007
+  template: "{% echo x | x : x , , x : . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : . }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-dotdot-008
+  template: "{% echo x | x : x , , x : .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : .. }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-eos-016
+  template: "{% echo x | x : x , , x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-ampersand
+  template: "{% echo x | x : x , , x : & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{x | x : x , , x : & }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-asterisk
+  template: "{% echo x | x : x , , x : * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{x | x : x , , x : * }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-at
+  template: "{% echo x | x : x , , x : @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{x | x : x , , x : @ }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-backslash
+  template: "{% echo x | x : x , , x : \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{x | x : x , , x : \ }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-backtick
+  template: "{% echo x | x : x , , x : ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{x | x : x , , x : ` }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-caret
+  template: "{% echo x | x : x , , x : ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{x | x : x , , x : ^ }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-dollar
+  template: "{% echo x | x : x , , x : $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{x | x : x , , x : $ }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-hash
+  template: "{% echo x | x : x , , x : # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{x | x : x , , x : # }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-semicolon
+  template: "{% echo x | x : x , , x : ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{x | x : x , , x : ; }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-tilde
+  template: "{% echo x | x : x , , x : ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{x | x : x , , x : ~ }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% echo x | x : x , , x : "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{x | x : x , , x : "hello
+      }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% echo x | x : x , , x : 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{x | x : x , , x : ''hello
+      }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% echo x | x : x , , x : x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : x[,] }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-dot_number
+  template: "{% echo x | x : x , , x : x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : x.123 }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-dot_string
+  template: '{% echo x | x : x , , x : x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : x."y" }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% echo x | x : x , , x : (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : (1, 5) }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-range_missing_end
+  template: "{% echo x | x : x , , x : (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : (1..) }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-trailing_dot
+  template: "{% echo x | x : x , , x : x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : x. }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% echo x | x : x , , x : x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : x[0 }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-lookup-unclosed_range
+  template: "{% echo x | x : x , , x : (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : (1..5 }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-pipe-000
+  template: "{% echo x | x : x , , x : | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : | }}"'
+  complexity: 100
+- name: echo-mut-kwarg_value-question-005
+  template: "{% echo x | x : x , , x : ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
+      x , , x : ? }}"'
+  complexity: 100
+- name: echo-mut-value-bare_bracket
+  template: "{% echo [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "{{[0] }}"'
+  complexity: 100
+- name: echo-mut-value-close_round-004
+  template: "{% echo ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{)
+      }}"'
+  complexity: 100
+- name: echo-mut-value-close_square-003
+  template: "{% echo ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{]
+      }}"'
+  complexity: 100
+- name: echo-mut-value-colon-002
+  template: "{% echo : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{: }}"'
+  complexity: 100
+- name: echo-mut-value-comma-001
+  template: "{% echo , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{, }}"'
+  complexity: 100
+- name: echo-mut-value-comparison-009
+  template: "{% echo == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{==
+      }}"'
+  complexity: 100
+- name: echo-mut-value-comparison-010
+  template: "{% echo != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{!=
+      }}"'
+  complexity: 100
+- name: echo-mut-value-comparison-011
+  template: "{% echo < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{< }}"'
+  complexity: 100
+- name: echo-mut-value-comparison-012
+  template: "{% echo > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{> }}"'
+  complexity: 100
+- name: echo-mut-value-comparison-013
+  template: "{% echo <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{<=
+      }}"'
+  complexity: 100
+- name: echo-mut-value-comparison-014
+  template: "{% echo >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{>=
+      }}"'
+  complexity: 100
+- name: echo-mut-value-comparison-015
+  template: "{% echo contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "{{contains }}"'
+  complexity: 100
+- name: echo-mut-value-dash-006
+  template: "{% echo - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{- }}"'
+  complexity: 100
+- name: echo-mut-value-dot-007
+  template: "{% echo . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{. }}"'
+  complexity: 100
+- name: echo-mut-value-dotdot-008
+  template: "{% echo .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{.. }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-ampersand
+  template: "{% echo & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{& }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-asterisk
+  template: "{% echo * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{* }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-at
+  template: "{% echo @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{@ }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-backslash
+  template: "{% echo \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{\ }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-backtick
+  template: "{% echo ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{` }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-caret
+  template: "{% echo ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{^ }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-dollar
+  template: "{% echo $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{$ }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-hash
+  template: "{% echo # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{# }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-semicolon
+  template: "{% echo ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{; }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-tilde
+  template: "{% echo ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{~ }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-unclosed_double_quote
+  template: '{% echo "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{"hello }}"'
+  complexity: 100
+- name: echo-mut-value-lexerr-unclosed_single_quote
+  template: "{% echo 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{''hello }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-bracket_wrong_content
+  template: "{% echo x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x[,] }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-dot_number
+  template: "{% echo x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "{{x.123 }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-dot_string
+  template: '{% echo x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "{{x."y" }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-range_bad_separator
+  template: "{% echo (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "{{(1, 5) }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-range_missing_end
+  template: "{% echo (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{(1..)
+      }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-trailing_dot
+  template: "{% echo x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{x. }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-unclosed_bracket
+  template: "{% echo x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{x[0
+      }}"'
+  complexity: 100
+- name: echo-mut-value-lookup-unclosed_range
+  template: "{% echo (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{(1..5
+      }}"'
+  complexity: 100
+- name: echo-mut-value-pipe-000
+  template: "{% echo | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "{{| }}"'
+  complexity: 100
+- name: echo-mut-value-question-005
+  template: "{% echo ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{? }}"'
+  complexity: 100

--- a/specs/parser_errors/echo.yml
+++ b/specs/parser_errors/echo.yml
@@ -3,1171 +3,1079 @@
   template: "{% echo x ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "{{x )
-      }}"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: echo-mut-end-trail-close_square
   template: "{% echo x ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "{{x
-      ] }}"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: echo-mut-end-trail-colon
   template: "{% echo x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "{{x : }}"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: echo-mut-end-trail-comma
   template: "{% echo x , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "{{x , }}"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: echo-mut-end-trail-comparison
   template: "{% echo x == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "{{x ==
-      }}"'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: echo-mut-end-trail-dash
   template: "{% echo x - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "{{x - }}"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: echo-mut-end-trail-dot
   template: "{% echo x . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{x . }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: echo-mut-end-trail-id
   template: "{% echo x extra %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "{{x extra }}"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: echo-mut-end-trail-number
   template: "{% echo x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "{{x 42 }}"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: echo-mut-end-trail-open_round
   template: "{% echo x ( %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "{{x (
-      }}"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: echo-mut-end-trail-open_square
   template: "{% echo x [ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "{{x [ }}"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: echo-mut-end-trail-pipe
   template: "{% echo x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: echo-mut-end-trail-question
   template: "{% echo x ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "{{x ? }}"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: echo-mut-end-trail-string
   template: "{% echo x 'hi' %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "{{x ''hi''
-      }}"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: echo-mut-filter_arg_value-bare_bracket
   template: "{% echo x | x : x , , [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , [0] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-close_round-004
   template: "{% echo x | x : x , , ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , ) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-close_square-003
   template: "{% echo x | x : x , , ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , ] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-colon-002
   template: "{% echo x | x : x , , : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , : }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comma-001
   template: "{% echo x | x : x , , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comparison-009
   template: "{% echo x | x : x , , == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , == }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comparison-010
   template: "{% echo x | x : x , , != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , != }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comparison-011
   template: "{% echo x | x : x , , < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , < }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comparison-012
   template: "{% echo x | x : x , , > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , > }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comparison-013
   template: "{% echo x | x : x , , <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , <= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comparison-014
   template: "{% echo x | x : x , , >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , >= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-comparison-015
   template: "{% echo x | x : x , , contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , contains }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-dash-006
   template: "{% echo x | x : x , , - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , - }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-dot-007
   template: "{% echo x | x : x , , . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , . }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-dotdot-008
   template: "{% echo x | x : x , , .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , .. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-eos-016
   template: "{% echo x | x : x , , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-ampersand
   template: "{% echo x | x : x , , & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{x | x : x , , & }}"'
+    - Unexpected character &
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-asterisk
   template: "{% echo x | x : x , , * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{x | x : x , , * }}"'
+    - Unexpected character *
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-at
   template: "{% echo x | x : x , , @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{x | x : x , , @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-backslash
   template: "{% echo x | x : x , , \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{x | x : x , , \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-backtick
   template: "{% echo x | x : x , , ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{x | x : x , , ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-caret
   template: "{% echo x | x : x , , ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{x | x : x , , ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-dollar
   template: "{% echo x | x : x , , $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{x | x : x , , $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-hash
   template: "{% echo x | x : x , , # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{x | x : x , , # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-semicolon
   template: "{% echo x | x : x , , ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{x | x : x , , ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-tilde
   template: "{% echo x | x : x , , ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{x | x : x , , ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-unclosed_double_quote
   template: '{% echo x | x : x , , "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{x | x : x , , "hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: echo-mut-filter_arg_value-lexerr-unclosed_single_quote
   template: "{% echo x | x : x , , 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{x | x : x , , ''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-bracket_wrong_content
   template: "{% echo x | x : x , , x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-dot_number
   template: "{% echo x | x : x , , x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x.123 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-dot_string
   template: '{% echo x | x : x , , x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x."y" }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-range_bad_separator
   template: "{% echo x | x : x , , (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , (1, 5) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-range_missing_end
   template: "{% echo x | x : x , , (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , (1..) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-trailing_dot
   template: "{% echo x | x : x , , x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-unclosed_bracket
   template: "{% echo x | x : x , , x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x[0 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-lookup-unclosed_range
   template: "{% echo x | x : x , , (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , (1..5 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-pipe-000
   template: "{% echo x | x : x , , | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , | }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_arg_value-question-005
   template: "{% echo x | x : x , , ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , ? }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-bare_bracket
   template: "{% echo x | x : [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "{{x | x : [0] }}"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: echo-mut-filter_first_arg-close_round-004
   template: "{% echo x | x : ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{x
-      | x : ) }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-close_square-003
   template: "{% echo x | x : ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{x
-      | x : ] }}"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-colon-002
   template: "{% echo x | x : : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{x | x :
-      : }}"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comma-001
   template: "{% echo x | x : , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comparison-009
   template: "{% echo x | x : == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{x
-      | x : == }}"'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comparison-010
   template: "{% echo x | x : != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{x
-      | x : != }}"'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comparison-011
   template: "{% echo x | x : < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{x |
-      x : < }}"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comparison-012
   template: "{% echo x | x : > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{x |
-      x : > }}"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comparison-013
   template: "{% echo x | x : <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{x
-      | x : <= }}"'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comparison-014
   template: "{% echo x | x : >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{x
-      | x : >= }}"'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-comparison-015
   template: "{% echo x | x : contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "{{x | x : contains }}"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-dash-006
   template: "{% echo x | x : - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{x | x : -
-      }}"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-dot-007
   template: "{% echo x | x : . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{x | x : .
-      }}"'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-dotdot-008
   template: "{% echo x | x : .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{x | x
-      : .. }}"'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-ampersand
   template: "{% echo x | x : & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{x | x : & }}"'
+    - Unexpected character &
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-asterisk
   template: "{% echo x | x : * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{x | x : * }}"'
+    - Unexpected character *
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-at
   template: "{% echo x | x : @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{x | x : @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-backslash
   template: "{% echo x | x : \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{x | x : \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-backtick
   template: "{% echo x | x : ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{x | x : ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-caret
   template: "{% echo x | x : ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{x | x : ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-dollar
   template: "{% echo x | x : $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{x | x : $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-hash
   template: "{% echo x | x : # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{x | x : # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-semicolon
   template: "{% echo x | x : ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{x | x : ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-tilde
   template: "{% echo x | x : ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{x | x : ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-unclosed_double_quote
   template: '{% echo x | x : "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{x | x : "hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: echo-mut-filter_first_arg-lexerr-unclosed_single_quote
   template: "{% echo x | x : 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{x | x : ''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-bracket_wrong_content
   template: "{% echo x | x : x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-dot_number
   template: "{% echo x | x : x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "{{x | x : x.123 }}"'
+    - Expected id but found number
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-dot_string
   template: '{% echo x | x : x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "{{x | x : x."y" }}"'
+    - Expected id but found string
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-range_bad_separator
   template: "{% echo x | x : (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "{{x | x : (1, 5) }}"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-range_missing_end
   template: "{% echo x | x : (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{x
-      | x : (1..) }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-trailing_dot
   template: "{% echo x | x : x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | x : x. }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-unclosed_bracket
   template: "{% echo x | x : x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{x
-      | x : x[0 }}"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: echo-mut-filter_first_arg-lookup-unclosed_range
   template: "{% echo x | x : (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{x |
-      x : (1..5 }}"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: echo-mut-filter_first_arg-pipe-000
   template: "{% echo x | x : | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | x : | }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: echo-mut-filter_first_arg-question-005
   template: "{% echo x | x : ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{x | x
-      : ? }}"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: echo-mut-filter_name-eos
   template: "{% echo x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{x | }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: echo-mut-filter_name-lexerr-ampersand
   template: "{% echo x | & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{x | & }}"'
+    - Unexpected character &
   complexity: 100
 - name: echo-mut-filter_name-lexerr-asterisk
   template: "{% echo x | * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{x | * }}"'
+    - Unexpected character *
   complexity: 100
 - name: echo-mut-filter_name-lexerr-at
   template: "{% echo x | @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{x | @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: echo-mut-filter_name-lexerr-backslash
   template: "{% echo x | \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{x | \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: echo-mut-filter_name-lexerr-backtick
   template: "{% echo x | ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{x | ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: echo-mut-filter_name-lexerr-caret
   template: "{% echo x | ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{x | ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: echo-mut-filter_name-lexerr-dollar
   template: "{% echo x | $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{x | $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: echo-mut-filter_name-lexerr-hash
   template: "{% echo x | # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{x | # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: echo-mut-filter_name-lexerr-semicolon
   template: "{% echo x | ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{x | ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: echo-mut-filter_name-lexerr-tilde
   template: "{% echo x | ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{x | ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: echo-mut-filter_name-lexerr-unclosed_double_quote
   template: '{% echo x | "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{x | "hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: echo-mut-filter_name-lexerr-unclosed_single_quote
   template: "{% echo x | 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{x | ''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: echo-mut-filter_name-number
   template: "{% echo x | 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "{{x | 42 }}"'
+    - Expected id but found number
   complexity: 100
 - name: echo-mut-kwarg_colon-eos
   template: "{% echo x | x : x , , x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_colon-number
   template: "{% echo x | x : x , , x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x 42 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-bare_bracket
   template: "{% echo x | x : x , , x : [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : [0] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-close_round-004
   template: "{% echo x | x : x , , x : ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : ) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-close_square-003
   template: "{% echo x | x : x , , x : ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : ] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-colon-002
   template: "{% echo x | x : x , , x : : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : : }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comma-001
   template: "{% echo x | x : x , , x : , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comparison-009
   template: "{% echo x | x : x , , x : == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : == }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comparison-010
   template: "{% echo x | x : x , , x : != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : != }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comparison-011
   template: "{% echo x | x : x , , x : < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : < }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comparison-012
   template: "{% echo x | x : x , , x : > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : > }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comparison-013
   template: "{% echo x | x : x , , x : <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : <= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comparison-014
   template: "{% echo x | x : x , , x : >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : >= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-comparison-015
   template: "{% echo x | x : x , , x : contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : contains }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-dash-006
   template: "{% echo x | x : x , , x : - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : - }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-dot-007
   template: "{% echo x | x : x , , x : . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : . }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-dotdot-008
   template: "{% echo x | x : x , , x : .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : .. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-eos-016
   template: "{% echo x | x : x , , x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-ampersand
   template: "{% echo x | x : x , , x : & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{x | x : x , , x : & }}"'
+    - Unexpected character &
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-asterisk
   template: "{% echo x | x : x , , x : * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{x | x : x , , x : * }}"'
+    - Unexpected character *
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-at
   template: "{% echo x | x : x , , x : @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{x | x : x , , x : @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-backslash
   template: "{% echo x | x : x , , x : \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{x | x : x , , x : \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-backtick
   template: "{% echo x | x : x , , x : ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{x | x : x , , x : ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-caret
   template: "{% echo x | x : x , , x : ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{x | x : x , , x : ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-dollar
   template: "{% echo x | x : x , , x : $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{x | x : x , , x : $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-hash
   template: "{% echo x | x : x , , x : # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{x | x : x , , x : # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-semicolon
   template: "{% echo x | x : x , , x : ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{x | x : x , , x : ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-tilde
   template: "{% echo x | x : x , , x : ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{x | x : x , , x : ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-unclosed_double_quote
   template: '{% echo x | x : x , , x : "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{x | x : x , , x : "hello
-      }}"'
+    - Unexpected character "
   complexity: 100
 - name: echo-mut-kwarg_value-lexerr-unclosed_single_quote
   template: "{% echo x | x : x , , x : 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{x | x : x , , x : ''hello
-      }}"'
+    - Unexpected character '
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-bracket_wrong_content
   template: "{% echo x | x : x , , x : x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-dot_number
   template: "{% echo x | x : x , , x : x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : x.123 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-dot_string
   template: '{% echo x | x : x , , x : x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : x."y" }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-range_bad_separator
   template: "{% echo x | x : x , , x : (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : (1, 5) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-range_missing_end
   template: "{% echo x | x : x , , x : (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : (1..) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-trailing_dot
   template: "{% echo x | x : x , , x : x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : x. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-unclosed_bracket
   template: "{% echo x | x : x , , x : x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : x[0 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-lookup-unclosed_range
   template: "{% echo x | x : x , , x : (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : (1..5 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-pipe-000
   template: "{% echo x | x : x , , x : | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : | }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-kwarg_value-question-005
   template: "{% echo x | x : x , , x : ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x | x :
-      x , , x : ? }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-bare_bracket
   template: "{% echo [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "{{[0] }}"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: echo-mut-value-close_round-004
   template: "{% echo ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{)
-      }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-close_square-003
   template: "{% echo ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{]
-      }}"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-colon-002
   template: "{% echo : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{: }}"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comma-001
   template: "{% echo , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{, }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comparison-009
   template: "{% echo == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{==
-      }}"'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comparison-010
   template: "{% echo != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{!=
-      }}"'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comparison-011
   template: "{% echo < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{< }}"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comparison-012
   template: "{% echo > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{> }}"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comparison-013
   template: "{% echo <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{<=
-      }}"'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comparison-014
   template: "{% echo >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{>=
-      }}"'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-comparison-015
   template: "{% echo contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "{{contains }}"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-dash-006
   template: "{% echo - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{- }}"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-dot-007
   template: "{% echo . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{. }}"'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-dotdot-008
   template: "{% echo .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{.. }}"'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-lexerr-ampersand
   template: "{% echo & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{& }}"'
+    - Unexpected character &
   complexity: 100
 - name: echo-mut-value-lexerr-asterisk
   template: "{% echo * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{* }}"'
+    - Unexpected character *
   complexity: 100
 - name: echo-mut-value-lexerr-at
   template: "{% echo @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{@ }}"'
+    - Unexpected character @
   complexity: 100
 - name: echo-mut-value-lexerr-backslash
   template: "{% echo \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{\ }}"'
+    - Unexpected character \
   complexity: 100
 - name: echo-mut-value-lexerr-backtick
   template: "{% echo ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{` }}"'
+    - Unexpected character `
   complexity: 100
 - name: echo-mut-value-lexerr-caret
   template: "{% echo ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: echo-mut-value-lexerr-dollar
   template: "{% echo $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{$ }}"'
+    - Unexpected character $
   complexity: 100
 - name: echo-mut-value-lexerr-hash
   template: "{% echo # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{# }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: echo-mut-value-lexerr-semicolon
   template: "{% echo ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: echo-mut-value-lexerr-tilde
   template: "{% echo ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: echo-mut-value-lexerr-unclosed_double_quote
   template: '{% echo "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{"hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: echo-mut-value-lexerr-unclosed_single_quote
   template: "{% echo 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: echo-mut-value-lookup-bracket_wrong_content
   template: "{% echo x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-lookup-dot_number
   template: "{% echo x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "{{x.123 }}"'
+    - Expected id but found number
   complexity: 100
 - name: echo-mut-value-lookup-dot_string
   template: '{% echo x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "{{x."y" }}"'
+    - Expected id but found string
   complexity: 100
 - name: echo-mut-value-lookup-range_bad_separator
   template: "{% echo (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "{{(1, 5) }}"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: echo-mut-value-lookup-range_missing_end
   template: "{% echo (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{(1..)
-      }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-lookup-trailing_dot
   template: "{% echo x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{x. }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: echo-mut-value-lookup-unclosed_bracket
   template: "{% echo x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{x[0
-      }}"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: echo-mut-value-lookup-unclosed_range
   template: "{% echo (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{(1..5
-      }}"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: echo-mut-value-pipe-000
   template: "{% echo | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "{{| }}"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: echo-mut-value-question-005
   template: "{% echo ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{? }}"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100

--- a/specs/parser_errors/for.yml
+++ b/specs/parser_errors/for.yml
@@ -1,0 +1,710 @@
+---
+- name: for-mut-attr_colon-eos
+  template: "{% for x in x step , %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step ,"'
+  complexity: 100
+- name: for-mut-attr_colon-number
+  template: "{% for x in x step , 42 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , 42"'
+  complexity: 100
+- name: for-mut-attr_value-bare_bracket
+  template: "{% for x in x step , : [0] %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : [0]"'
+  complexity: 100
+- name: for-mut-attr_value-close_round-004
+  template: "{% for x in x step , : ) %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : )"'
+  complexity: 100
+- name: for-mut-attr_value-close_square-003
+  template: "{% for x in x step , : ] %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : ]"'
+  complexity: 100
+- name: for-mut-attr_value-colon-002
+  template: "{% for x in x step , : : %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : :"'
+  complexity: 100
+- name: for-mut-attr_value-comma-001
+  template: "{% for x in x step , : , %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : ,"'
+  complexity: 100
+- name: for-mut-attr_value-comparison-009
+  template: "{% for x in x step , : == %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : =="'
+  complexity: 100
+- name: for-mut-attr_value-comparison-010
+  template: "{% for x in x step , : != %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : !="'
+  complexity: 100
+- name: for-mut-attr_value-comparison-011
+  template: "{% for x in x step , : < %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : <"'
+  complexity: 100
+- name: for-mut-attr_value-comparison-012
+  template: "{% for x in x step , : > %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : >"'
+  complexity: 100
+- name: for-mut-attr_value-comparison-013
+  template: "{% for x in x step , : <= %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : <="'
+  complexity: 100
+- name: for-mut-attr_value-comparison-014
+  template: "{% for x in x step , : >= %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : >="'
+  complexity: 100
+- name: for-mut-attr_value-comparison-015
+  template: "{% for x in x step , : contains %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : contains"'
+  complexity: 100
+- name: for-mut-attr_value-dash-006
+  template: "{% for x in x step , : - %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : -"'
+  complexity: 100
+- name: for-mut-attr_value-dot-007
+  template: "{% for x in x step , : . %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : ."'
+  complexity: 100
+- name: for-mut-attr_value-dotdot-008
+  template: "{% for x in x step , : .. %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : .."'
+  complexity: 100
+- name: for-mut-attr_value-eos-016
+  template: "{% for x in x step , : %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , :"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-ampersand
+  template: "{% for x in x step , : & %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x in x step , : &"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-asterisk
+  template: "{% for x in x step , : * %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x in x step , : *"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-at
+  template: "{% for x in x step , : @ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x in x step , : @"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-backslash
+  template: "{% for x in x step , : \\ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x in x step , : \"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-backtick
+  template: "{% for x in x step , : ` %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x in x step , : `"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-caret
+  template: "{% for x in x step , : ^ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x in x step , : ^"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-dollar
+  template: "{% for x in x step , : $ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x in x step , : $"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-hash
+  template: "{% for x in x step , : # %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x in x step , : #"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-semicolon
+  template: "{% for x in x step , : ; %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x in x step , : ;"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-tilde
+  template: "{% for x in x step , : ~ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x in x step , : ~"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-unclosed_double_quote
+  template: '{% for x in x step , : "hello %}{% endfor %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x in x step , : "hello"'
+  complexity: 100
+- name: for-mut-attr_value-lexerr-unclosed_single_quote
+  template: "{% for x in x step , : 'hello %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x in x step , : ''hello"'
+  complexity: 100
+- name: for-mut-attr_value-lookup-bracket_wrong_content
+  template: "{% for x in x step , : x[,] %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : x[,]"'
+  complexity: 100
+- name: for-mut-attr_value-lookup-dot_number
+  template: "{% for x in x step , : x.123 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : x.123"'
+  complexity: 100
+- name: for-mut-attr_value-lookup-dot_string
+  template: '{% for x in x step , : x."y" %}{% endfor %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : x."y""'
+  complexity: 100
+- name: for-mut-attr_value-lookup-range_bad_separator
+  template: "{% for x in x step , : (1, 5) %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : (1, 5)"'
+  complexity: 100
+- name: for-mut-attr_value-lookup-range_missing_end
+  template: "{% for x in x step , : (1..) %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : (1..)"'
+  complexity: 100
+- name: for-mut-attr_value-lookup-trailing_dot
+  template: "{% for x in x step , : x. %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : x."'
+  complexity: 100
+- name: for-mut-attr_value-lookup-unclosed_bracket
+  template: "{% for x in x step , : x[0 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : x[0"'
+  complexity: 100
+- name: for-mut-attr_value-lookup-unclosed_range
+  template: "{% for x in x step , : (1..5 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : (1..5"'
+  complexity: 100
+- name: for-mut-attr_value-pipe-000
+  template: "{% for x in x step , : | %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : |"'
+  complexity: 100
+- name: for-mut-attr_value-question-005
+  template: "{% for x in x step , : ? %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step , : ?"'
+  complexity: 100
+- name: for-mut-collection-bare_bracket
+  template: "{% for x in [0] %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x in [0]"'
+  complexity: 100
+- name: for-mut-collection-close_round-004
+  template: "{% for x in ) %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
+      )"'
+  complexity: 100
+- name: for-mut-collection-close_square-003
+  template: "{% for x in ] %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x in
+      ]"'
+  complexity: 100
+- name: for-mut-collection-colon-002
+  template: "{% for x in : %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x in :"'
+  complexity: 100
+- name: for-mut-collection-comma-001
+  template: "{% for x in , %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in ,"'
+  complexity: 100
+- name: for-mut-collection-comparison-009
+  template: "{% for x in == %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x in
+      =="'
+  complexity: 100
+- name: for-mut-collection-comparison-010
+  template: "{% for x in != %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x in
+      !="'
+  complexity: 100
+- name: for-mut-collection-comparison-011
+  template: "{% for x in < %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x in
+      <"'
+  complexity: 100
+- name: for-mut-collection-comparison-012
+  template: "{% for x in > %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x in
+      >"'
+  complexity: 100
+- name: for-mut-collection-comparison-013
+  template: "{% for x in <= %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x in
+      <="'
+  complexity: 100
+- name: for-mut-collection-comparison-014
+  template: "{% for x in >= %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x in
+      >="'
+  complexity: 100
+- name: for-mut-collection-comparison-015
+  template: "{% for x in contains %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x in contains"'
+  complexity: 100
+- name: for-mut-collection-dash-006
+  template: "{% for x in - %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x in -"'
+  complexity: 100
+- name: for-mut-collection-dot-007
+  template: "{% for x in . %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x in ."'
+  complexity: 100
+- name: for-mut-collection-dotdot-008
+  template: "{% for x in .. %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x in .."'
+  complexity: 100
+- name: for-mut-collection-eos-016
+  template: "{% for x in %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in"'
+  complexity: 100
+- name: for-mut-collection-lexerr-ampersand
+  template: "{% for x in & %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x in &"'
+  complexity: 100
+- name: for-mut-collection-lexerr-asterisk
+  template: "{% for x in * %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x in *"'
+  complexity: 100
+- name: for-mut-collection-lexerr-at
+  template: "{% for x in @ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x in @"'
+  complexity: 100
+- name: for-mut-collection-lexerr-backslash
+  template: "{% for x in \\ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x in \"'
+  complexity: 100
+- name: for-mut-collection-lexerr-backtick
+  template: "{% for x in ` %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x in `"'
+  complexity: 100
+- name: for-mut-collection-lexerr-caret
+  template: "{% for x in ^ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x in ^"'
+  complexity: 100
+- name: for-mut-collection-lexerr-dollar
+  template: "{% for x in $ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x in $"'
+  complexity: 100
+- name: for-mut-collection-lexerr-hash
+  template: "{% for x in # %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x in #"'
+  complexity: 100
+- name: for-mut-collection-lexerr-semicolon
+  template: "{% for x in ; %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x in ;"'
+  complexity: 100
+- name: for-mut-collection-lexerr-tilde
+  template: "{% for x in ~ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x in ~"'
+  complexity: 100
+- name: for-mut-collection-lexerr-unclosed_double_quote
+  template: '{% for x in "hello %}{% endfor %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x in "hello"'
+  complexity: 100
+- name: for-mut-collection-lexerr-unclosed_single_quote
+  template: "{% for x in 'hello %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x in ''hello"'
+  complexity: 100
+- name: for-mut-collection-lookup-bracket_wrong_content
+  template: "{% for x in x[,] %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in x[,]"'
+  complexity: 100
+- name: for-mut-collection-lookup-dot_number
+  template: "{% for x in x.123 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x in x.123"'
+  complexity: 100
+- name: for-mut-collection-lookup-dot_string
+  template: '{% for x in x."y" %}{% endfor %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x in x."y""'
+  complexity: 100
+- name: for-mut-collection-lookup-range_bad_separator
+  template: "{% for x in (1, 5) %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x in (1, 5)"'
+  complexity: 100
+- name: for-mut-collection-lookup-range_missing_end
+  template: "{% for x in (1..) %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
+      (1..)"'
+  complexity: 100
+- name: for-mut-collection-lookup-trailing_dot
+  template: "{% for x in x. %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x in x."'
+  complexity: 100
+- name: for-mut-collection-lookup-unclosed_bracket
+  template: "{% for x in x[0 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x in
+      x[0"'
+  complexity: 100
+- name: for-mut-collection-lookup-unclosed_range
+  template: "{% for x in (1..5 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x in
+      (1..5"'
+  complexity: 100
+- name: for-mut-collection-pipe-000
+  template: "{% for x in | %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x in |"'
+  complexity: 100
+- name: for-mut-collection-question-005
+  template: "{% for x in ? %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x in ?"'
+  complexity: 100
+- name: for-mut-end-trail-close_round
+  template: "{% for x in x ) %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x in
+      x )"'
+  complexity: 100
+- name: for-mut-end-trail-close_square
+  template: "{% for x in x ] %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x in
+      x ]"'
+  complexity: 100
+- name: for-mut-end-trail-colon
+  template: "{% for x in x : %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x in x :"'
+  complexity: 100
+- name: for-mut-end-trail-comma
+  template: "{% for x in x , %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x ,"'
+  complexity: 100
+- name: for-mut-end-trail-comparison
+  template: "{% for x in x == %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x in x
+      =="'
+  complexity: 100
+- name: for-mut-end-trail-dash
+  template: "{% for x in x - %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x in x -"'
+  complexity: 100
+- name: for-mut-end-trail-dot
+  template: "{% for x in x . %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x in x ."'
+  complexity: 100
+- name: for-mut-end-trail-id
+  template: "{% for x in x extra %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x extra"'
+  complexity: 100
+- name: for-mut-end-trail-number
+  template: "{% for x in x 42 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x in x 42"'
+  complexity: 100
+- name: for-mut-end-trail-open_round
+  template: "{% for x in x ( %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x in x
+      ("'
+  complexity: 100
+- name: for-mut-end-trail-open_square
+  template: "{% for x in x [ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in x
+      ["'
+  complexity: 100
+- name: for-mut-end-trail-pipe
+  template: "{% for x in x | %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x in x |"'
+  complexity: 100
+- name: for-mut-end-trail-question
+  template: "{% for x in x ? %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x in x ?"'
+  complexity: 100
+- name: for-mut-end-trail-string
+  template: "{% for x in x 'hi' %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x in x ''hi''"'
+  complexity: 100
+- name: for-mut-in_keyword-eos
+  template: "{% for x %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: For loops require an ''in'' clause in "x"'
+  complexity: 100
+- name: for-mut-in_keyword-id
+  template: "{% for x of %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: For loops require an ''in'' clause in "x of"'
+  complexity: 100
+- name: for-mut-invalid_attribute-invalid
+  template: "{% for x in x step , %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
+      and offset in "x in x step ,"'
+  complexity: 100
+- name: for-mut-variable_name-eos
+  template: "{% for  %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-ampersand
+  template: "{% for & %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-asterisk
+  template: "{% for * %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-at
+  template: "{% for @ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-backslash
+  template: "{% for \\ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-backtick
+  template: "{% for ` %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-caret
+  template: "{% for ^ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-dollar
+  template: "{% for $ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-hash
+  template: "{% for # %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-semicolon
+  template: "{% for ; %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-tilde
+  template: "{% for ~ %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% for "hello %}{% endfor %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: for-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% for 'hello %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: for-mut-variable_name-number
+  template: "{% for 42 %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "42"'
+  complexity: 100
+- name: for-parity-elsif-in-for
+  template: "{% for i in (1..3) %}{% elsif %}{% endfor %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unknown tag ''elsif'''
+  complexity: 100

--- a/specs/parser_errors/for.yml
+++ b/specs/parser_errors/for.yml
@@ -3,708 +3,659 @@
   template: "{% for x in x step , %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step ,"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_colon-number
   template: "{% for x in x step , 42 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , 42"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-bare_bracket
   template: "{% for x in x step , : [0] %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : [0]"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-close_round-004
   template: "{% for x in x step , : ) %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : )"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-close_square-003
   template: "{% for x in x step , : ] %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : ]"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-colon-002
   template: "{% for x in x step , : : %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : :"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comma-001
   template: "{% for x in x step , : , %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : ,"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comparison-009
   template: "{% for x in x step , : == %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : =="'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comparison-010
   template: "{% for x in x step , : != %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : !="'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comparison-011
   template: "{% for x in x step , : < %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : <"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comparison-012
   template: "{% for x in x step , : > %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : >"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comparison-013
   template: "{% for x in x step , : <= %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : <="'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comparison-014
   template: "{% for x in x step , : >= %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : >="'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-comparison-015
   template: "{% for x in x step , : contains %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : contains"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-dash-006
   template: "{% for x in x step , : - %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : -"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-dot-007
   template: "{% for x in x step , : . %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : ."'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-dotdot-008
   template: "{% for x in x step , : .. %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : .."'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-eos-016
   template: "{% for x in x step , : %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , :"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lexerr-ampersand
   template: "{% for x in x step , : & %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x in x step , : &"'
+    - Unexpected character &
   complexity: 100
 - name: for-mut-attr_value-lexerr-asterisk
   template: "{% for x in x step , : * %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x in x step , : *"'
+    - Unexpected character *
   complexity: 100
 - name: for-mut-attr_value-lexerr-at
   template: "{% for x in x step , : @ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x in x step , : @"'
+    - Unexpected character @
   complexity: 100
 - name: for-mut-attr_value-lexerr-backslash
   template: "{% for x in x step , : \\ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x in x step , : \"'
+    - Unexpected character \
   complexity: 100
 - name: for-mut-attr_value-lexerr-backtick
   template: "{% for x in x step , : ` %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x in x step , : `"'
+    - Unexpected character `
   complexity: 100
 - name: for-mut-attr_value-lexerr-caret
   template: "{% for x in x step , : ^ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x in x step , : ^"'
+    - Unexpected character ^
   complexity: 100
 - name: for-mut-attr_value-lexerr-dollar
   template: "{% for x in x step , : $ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x in x step , : $"'
+    - Unexpected character $
   complexity: 100
 - name: for-mut-attr_value-lexerr-hash
   template: "{% for x in x step , : # %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x in x step , : #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: for-mut-attr_value-lexerr-semicolon
   template: "{% for x in x step , : ; %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x in x step , : ;"'
+    - Unexpected character ;
   complexity: 100
 - name: for-mut-attr_value-lexerr-tilde
   template: "{% for x in x step , : ~ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x in x step , : ~"'
+    - Unexpected character ~
   complexity: 100
 - name: for-mut-attr_value-lexerr-unclosed_double_quote
   template: '{% for x in x step , : "hello %}{% endfor %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x in x step , : "hello"'
+    - Unexpected character "
   complexity: 100
 - name: for-mut-attr_value-lexerr-unclosed_single_quote
   template: "{% for x in x step , : 'hello %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x in x step , : ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: for-mut-attr_value-lookup-bracket_wrong_content
   template: "{% for x in x step , : x[,] %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : x[,]"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lookup-dot_number
   template: "{% for x in x step , : x.123 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : x.123"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lookup-dot_string
   template: '{% for x in x step , : x."y" %}{% endfor %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : x."y""'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lookup-range_bad_separator
   template: "{% for x in x step , : (1, 5) %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : (1, 5)"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lookup-range_missing_end
   template: "{% for x in x step , : (1..) %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : (1..)"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lookup-trailing_dot
   template: "{% for x in x step , : x. %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : x."'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lookup-unclosed_bracket
   template: "{% for x in x step , : x[0 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : x[0"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-lookup-unclosed_range
   template: "{% for x in x step , : (1..5 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : (1..5"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-pipe-000
   template: "{% for x in x step , : | %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : |"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-attr_value-question-005
   template: "{% for x in x step , : ? %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step , : ?"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-collection-bare_bracket
   template: "{% for x in [0] %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x in [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: for-mut-collection-close_round-004
   template: "{% for x in ) %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
-      )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-close_square-003
   template: "{% for x in ] %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x in
-      ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-colon-002
   template: "{% for x in : %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x in :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comma-001
   template: "{% for x in , %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comparison-009
   template: "{% for x in == %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x in
-      =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comparison-010
   template: "{% for x in != %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x in
-      !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comparison-011
   template: "{% for x in < %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x in
-      <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comparison-012
   template: "{% for x in > %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x in
-      >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comparison-013
   template: "{% for x in <= %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x in
-      <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comparison-014
   template: "{% for x in >= %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x in
-      >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-comparison-015
   template: "{% for x in contains %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x in contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-dash-006
   template: "{% for x in - %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x in -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-dot-007
   template: "{% for x in . %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x in ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-dotdot-008
   template: "{% for x in .. %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x in .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-eos-016
   template: "{% for x in %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: for-mut-collection-lexerr-ampersand
   template: "{% for x in & %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x in &"'
+    - Unexpected character &
   complexity: 100
 - name: for-mut-collection-lexerr-asterisk
   template: "{% for x in * %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x in *"'
+    - Unexpected character *
   complexity: 100
 - name: for-mut-collection-lexerr-at
   template: "{% for x in @ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x in @"'
+    - Unexpected character @
   complexity: 100
 - name: for-mut-collection-lexerr-backslash
   template: "{% for x in \\ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x in \"'
+    - Unexpected character \
   complexity: 100
 - name: for-mut-collection-lexerr-backtick
   template: "{% for x in ` %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x in `"'
+    - Unexpected character `
   complexity: 100
 - name: for-mut-collection-lexerr-caret
   template: "{% for x in ^ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x in ^"'
+    - Unexpected character ^
   complexity: 100
 - name: for-mut-collection-lexerr-dollar
   template: "{% for x in $ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x in $"'
+    - Unexpected character $
   complexity: 100
 - name: for-mut-collection-lexerr-hash
   template: "{% for x in # %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x in #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: for-mut-collection-lexerr-semicolon
   template: "{% for x in ; %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x in ;"'
+    - Unexpected character ;
   complexity: 100
 - name: for-mut-collection-lexerr-tilde
   template: "{% for x in ~ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x in ~"'
+    - Unexpected character ~
   complexity: 100
 - name: for-mut-collection-lexerr-unclosed_double_quote
   template: '{% for x in "hello %}{% endfor %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x in "hello"'
+    - Unexpected character "
   complexity: 100
 - name: for-mut-collection-lexerr-unclosed_single_quote
   template: "{% for x in 'hello %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x in ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: for-mut-collection-lookup-bracket_wrong_content
   template: "{% for x in x[,] %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-lookup-dot_number
   template: "{% for x in x.123 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x in x.123"'
+    - Expected id but found number
   complexity: 100
 - name: for-mut-collection-lookup-dot_string
   template: '{% for x in x."y" %}{% endfor %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x in x."y""'
+    - Expected id but found string
   complexity: 100
 - name: for-mut-collection-lookup-range_bad_separator
   template: "{% for x in (1, 5) %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x in (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: for-mut-collection-lookup-range_missing_end
   template: "{% for x in (1..) %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
-      (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-lookup-trailing_dot
   template: "{% for x in x. %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x in x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: for-mut-collection-lookup-unclosed_bracket
   template: "{% for x in x[0 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x in
-      x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: for-mut-collection-lookup-unclosed_range
   template: "{% for x in (1..5 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x in
-      (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: for-mut-collection-pipe-000
   template: "{% for x in | %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x in |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: for-mut-collection-question-005
   template: "{% for x in ? %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x in ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: for-mut-end-trail-close_round
   template: "{% for x in x ) %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x in
-      x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: for-mut-end-trail-close_square
   template: "{% for x in x ] %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x in
-      x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: for-mut-end-trail-colon
   template: "{% for x in x : %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x in x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: for-mut-end-trail-comma
   template: "{% for x in x , %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x ,"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-end-trail-comparison
   template: "{% for x in x == %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x in x
-      =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: for-mut-end-trail-dash
   template: "{% for x in x - %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x in x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: for-mut-end-trail-dot
   template: "{% for x in x . %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x in x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: for-mut-end-trail-id
   template: "{% for x in x extra %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x extra"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-end-trail-number
   template: "{% for x in x 42 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x in x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: for-mut-end-trail-open_round
   template: "{% for x in x ( %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x in x
-      ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: for-mut-end-trail-open_square
   template: "{% for x in x [ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in x
-      ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: for-mut-end-trail-pipe
   template: "{% for x in x | %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x in x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: for-mut-end-trail-question
   template: "{% for x in x ? %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x in x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: for-mut-end-trail-string
   template: "{% for x in x 'hi' %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x in x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: for-mut-in_keyword-eos
   template: "{% for x %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: For loops require an ''in'' clause in "x"'
+    - For loops require an 'in' clause
   complexity: 100
 - name: for-mut-in_keyword-id
   template: "{% for x of %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: For loops require an ''in'' clause in "x of"'
+    - For loops require an 'in' clause
   complexity: 100
 - name: for-mut-invalid_attribute-invalid
   template: "{% for x in x step , %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute in for loop. Valid attributes are limit
-      and offset in "x in x step ,"'
+    - Invalid attribute in for loop. Valid attributes are limit and offset
   complexity: 100
 - name: for-mut-variable_name-eos
   template: "{% for  %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+    - Expected id but found end_of_string
   complexity: 100
 - name: for-mut-variable_name-lexerr-ampersand
   template: "{% for & %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: for-mut-variable_name-lexerr-asterisk
   template: "{% for * %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: for-mut-variable_name-lexerr-at
   template: "{% for @ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: for-mut-variable_name-lexerr-backslash
   template: "{% for \\ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: for-mut-variable_name-lexerr-backtick
   template: "{% for ` %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: for-mut-variable_name-lexerr-caret
   template: "{% for ^ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: for-mut-variable_name-lexerr-dollar
   template: "{% for $ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: for-mut-variable_name-lexerr-hash
   template: "{% for # %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: for-mut-variable_name-lexerr-semicolon
   template: "{% for ; %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: for-mut-variable_name-lexerr-tilde
   template: "{% for ~ %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: for-mut-variable_name-lexerr-unclosed_double_quote
   template: '{% for "hello %}{% endfor %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: for-mut-variable_name-lexerr-unclosed_single_quote
   template: "{% for 'hello %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: for-mut-variable_name-number
   template: "{% for 42 %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "42"'
+    - Expected id but found number
   complexity: 100
 - name: for-parity-elsif-in-for
   template: "{% for i in (1..3) %}{% elsif %}{% endfor %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unknown tag ''elsif'''
+    - Unknown tag 'elsif'
   complexity: 100

--- a/specs/parser_errors/if.yml
+++ b/specs/parser_errors/if.yml
@@ -1,0 +1,1092 @@
+---
+- name: if-mut-boolean_comparison_rhs-bare_bracket
+  template: "{% if x and x x == [0] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == [0]"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-close_round-004
+  template: "{% if x and x x == ) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == )"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-close_square-003
+  template: "{% if x and x x == ] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ]"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-colon-002
+  template: "{% if x and x x == : %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == :"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comma-001
+  template: "{% if x and x x == , %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ,"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comparison-009
+  template: "{% if x and x x == == %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == =="'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comparison-010
+  template: "{% if x and x x == != %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == !="'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comparison-011
+  template: "{% if x and x x == < %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comparison-012
+  template: "{% if x and x x == > %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comparison-013
+  template: "{% if x and x x == <= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <="'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comparison-014
+  template: "{% if x and x x == >= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >="'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-comparison-015
+  template: "{% if x and x x == contains %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == contains"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-dash-006
+  template: "{% if x and x x == - %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == -"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-dot-007
+  template: "{% if x and x x == . %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ."'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-dotdot-008
+  template: "{% if x and x x == .. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == .."'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-eos-016
+  template: "{% if x and x x == %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-ampersand
+  template: "{% if x and x x == & %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-asterisk
+  template: "{% if x and x x == * %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-at
+  template: "{% if x and x x == @ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-backslash
+  template: "{% if x and x x == \\ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-backtick
+  template: "{% if x and x x == ` %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-caret
+  template: "{% if x and x x == ^ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-dollar
+  template: "{% if x and x x == $ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-hash
+  template: "{% if x and x x == # %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-semicolon
+  template: "{% if x and x x == ; %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-tilde
+  template: "{% if x and x x == ~ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if x and x x == "hello %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if x and x x == 'hello %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if x and x x == x[,] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[,]"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-dot_number
+  template: "{% if x and x x == x.123 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x.123"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-dot_string
+  template: '{% if x and x x == x."y" %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."y""'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-range_bad_separator
+  template: "{% if x and x x == (1, 5) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1,
+      5)"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-range_missing_end
+  template: "{% if x and x x == (1..) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..)"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-trailing_dot
+  template: "{% if x and x x == x. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-unclosed_bracket
+  template: "{% if x and x x == x[0 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[0"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-lookup-unclosed_range
+  template: "{% if x and x x == (1..5 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..5"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-pipe-000
+  template: "{% if x and x x == | %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == |"'
+  complexity: 100
+- name: if-mut-boolean_comparison_rhs-question-005
+  template: "{% if x and x x == ? %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ?"'
+  complexity: 100
+- name: if-mut-boolean_expr-close_round-004
+  template: "{% if x and x ) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x and
+      x )"'
+  complexity: 100
+- name: if-mut-boolean_expr-close_square-003
+  template: "{% if x and x ] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x and
+      x ]"'
+  complexity: 100
+- name: if-mut-boolean_expr-colon-002
+  template: "{% if x and x : %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x and x :"'
+  complexity: 100
+- name: if-mut-boolean_expr-comma-001
+  template: "{% if x and x , %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x and x ,"'
+  complexity: 100
+- name: if-mut-boolean_expr-comparison-009
+  template: "{% if x and x == %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      =="'
+  complexity: 100
+- name: if-mut-boolean_expr-comparison-010
+  template: "{% if x and x != %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      !="'
+  complexity: 100
+- name: if-mut-boolean_expr-comparison-011
+  template: "{% if x and x < %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      <"'
+  complexity: 100
+- name: if-mut-boolean_expr-comparison-012
+  template: "{% if x and x > %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      >"'
+  complexity: 100
+- name: if-mut-boolean_expr-comparison-013
+  template: "{% if x and x <= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      <="'
+  complexity: 100
+- name: if-mut-boolean_expr-comparison-014
+  template: "{% if x and x >= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      >="'
+  complexity: 100
+- name: if-mut-boolean_expr-comparison-015
+  template: "{% if x and x contains %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      contains"'
+  complexity: 100
+- name: if-mut-boolean_expr-dash-006
+  template: "{% if x and x - %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+  complexity: 100
+- name: if-mut-boolean_expr-dot-007
+  template: "{% if x and x . %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+  complexity: 100
+- name: if-mut-boolean_expr-dotdot-008
+  template: "{% if x and x .. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x .."'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-ampersand
+  template: "{% if x and x & %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x and x &"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-asterisk
+  template: "{% if x and x * %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x and x *"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-at
+  template: "{% if x and x @ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x and x @"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-backslash
+  template: "{% if x and x \\ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x and x \"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-backtick
+  template: "{% if x and x ` %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x and x `"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-caret
+  template: "{% if x and x ^ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-dollar
+  template: "{% if x and x $ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x and x $"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-hash
+  template: "{% if x and x # %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x and x #"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-semicolon
+  template: "{% if x and x ; %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-tilde
+  template: "{% if x and x ~ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-unclosed_double_quote
+  template: '{% if x and x "hello %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+  complexity: 100
+- name: if-mut-boolean_expr-lexerr-unclosed_single_quote
+  template: "{% if x and x 'hello %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-bracket_wrong_content
+  template: "{% if x and x x[,] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-dot_number
+  template: "{% if x and x x.123 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-dot_string
+  template: '{% if x and x x."y" %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-range_bad_separator
+  template: "{% if x and x (1, 5) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+      x (1, 5)"'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-range_missing_end
+  template: "{% if x and x (1..) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+      x (1..)"'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-trailing_dot
+  template: "{% if x and x x. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-unclosed_bracket
+  template: "{% if x and x x[0 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+  complexity: 100
+- name: if-mut-boolean_expr-lookup-unclosed_range
+  template: "{% if x and x (1..5 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+      x (1..5"'
+  complexity: 100
+- name: if-mut-boolean_expr-pipe-000
+  template: "{% if x and x | %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+  complexity: 100
+- name: if-mut-boolean_expr-question-005
+  template: "{% if x and x ? %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x and x
+      ?"'
+  complexity: 100
+- name: if-mut-boolean_op-eos
+  template: "{% if x and %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-ampersand
+  template: "{% if x and & %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x and &"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-asterisk
+  template: "{% if x and * %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x and *"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-at
+  template: "{% if x and @ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x and @"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-backslash
+  template: "{% if x and \\ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x and \"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-backtick
+  template: "{% if x and ` %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x and `"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-caret
+  template: "{% if x and ^ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-dollar
+  template: "{% if x and $ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x and $"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-hash
+  template: "{% if x and # %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x and #"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-semicolon
+  template: "{% if x and ; %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x and ;"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-tilde
+  template: "{% if x and ~ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-unclosed_double_quote
+  template: '{% if x and "hello %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x and "hello"'
+  complexity: 100
+- name: if-mut-boolean_op-lexerr-unclosed_single_quote
+  template: "{% if x and 'hello %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+  complexity: 100
+- name: if-mut-comparison_rhs-bare_bracket
+  template: "{% if x == [0] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x == [0]"'
+  complexity: 100
+- name: if-mut-comparison_rhs-close_round-004
+  template: "{% if x == ) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
+      )"'
+  complexity: 100
+- name: if-mut-comparison_rhs-close_square-003
+  template: "{% if x == ] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x ==
+      ]"'
+  complexity: 100
+- name: if-mut-comparison_rhs-colon-002
+  template: "{% if x == : %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+  complexity: 100
+- name: if-mut-comparison_rhs-comma-001
+  template: "{% if x == , %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+  complexity: 100
+- name: if-mut-comparison_rhs-comparison-009
+  template: "{% if x == == %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x ==
+      =="'
+  complexity: 100
+- name: if-mut-comparison_rhs-comparison-010
+  template: "{% if x == != %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x ==
+      !="'
+  complexity: 100
+- name: if-mut-comparison_rhs-comparison-011
+  template: "{% if x == < %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x ==
+      <"'
+  complexity: 100
+- name: if-mut-comparison_rhs-comparison-012
+  template: "{% if x == > %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x ==
+      >"'
+  complexity: 100
+- name: if-mut-comparison_rhs-comparison-013
+  template: "{% if x == <= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x ==
+      <="'
+  complexity: 100
+- name: if-mut-comparison_rhs-comparison-014
+  template: "{% if x == >= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x ==
+      >="'
+  complexity: 100
+- name: if-mut-comparison_rhs-comparison-015
+  template: "{% if x == contains %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x == contains"'
+  complexity: 100
+- name: if-mut-comparison_rhs-dash-006
+  template: "{% if x == - %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+  complexity: 100
+- name: if-mut-comparison_rhs-dot-007
+  template: "{% if x == . %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+  complexity: 100
+- name: if-mut-comparison_rhs-dotdot-008
+  template: "{% if x == .. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x == .."'
+  complexity: 100
+- name: if-mut-comparison_rhs-eos-016
+  template: "{% if x == %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-ampersand
+  template: "{% if x == & %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x == &"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-asterisk
+  template: "{% if x == * %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x == *"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-at
+  template: "{% if x == @ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x == @"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-backslash
+  template: "{% if x == \\ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x == \"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-backtick
+  template: "{% if x == ` %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x == `"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-caret
+  template: "{% if x == ^ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-dollar
+  template: "{% if x == $ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x == $"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-hash
+  template: "{% if x == # %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x == #"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-semicolon
+  template: "{% if x == ; %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x == ;"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-tilde
+  template: "{% if x == ~ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% if x == "hello %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x == "hello"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% if x == 'hello %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-bracket_wrong_content
+  template: "{% if x == x[,] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-dot_number
+  template: "{% if x == x.123 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x == x.123"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-dot_string
+  template: '{% if x == x."y" %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x == x."y""'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-range_bad_separator
+  template: "{% if x == (1, 5) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-range_missing_end
+  template: "{% if x == (1..) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
+      (1..)"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-trailing_dot
+  template: "{% if x == x. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-unclosed_bracket
+  template: "{% if x == x[0 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x ==
+      x[0"'
+  complexity: 100
+- name: if-mut-comparison_rhs-lookup-unclosed_range
+  template: "{% if x == (1..5 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x ==
+      (1..5"'
+  complexity: 100
+- name: if-mut-comparison_rhs-pipe-000
+  template: "{% if x == | %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+  complexity: 100
+- name: if-mut-comparison_rhs-question-005
+  template: "{% if x == ? %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x == ?"'
+  complexity: 100
+- name: if-mut-condition-bare_bracket
+  template: "{% if [0] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "[0]"'
+  complexity: 100
+- name: if-mut-condition-close_round-004
+  template: "{% if ) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  complexity: 100
+- name: if-mut-condition-close_square-003
+  template: "{% if ] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  complexity: 100
+- name: if-mut-condition-colon-002
+  template: "{% if : %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  complexity: 100
+- name: if-mut-condition-comma-001
+  template: "{% if , %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  complexity: 100
+- name: if-mut-condition-comparison-009
+  template: "{% if == %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  complexity: 100
+- name: if-mut-condition-comparison-010
+  template: "{% if != %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  complexity: 100
+- name: if-mut-condition-comparison-011
+  template: "{% if < %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  complexity: 100
+- name: if-mut-condition-comparison-012
+  template: "{% if > %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  complexity: 100
+- name: if-mut-condition-comparison-013
+  template: "{% if <= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  complexity: 100
+- name: if-mut-condition-comparison-014
+  template: "{% if >= %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  complexity: 100
+- name: if-mut-condition-comparison-015
+  template: "{% if contains %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "contains"'
+  complexity: 100
+- name: if-mut-condition-dash-006
+  template: "{% if - %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  complexity: 100
+- name: if-mut-condition-dot-007
+  template: "{% if . %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  complexity: 100
+- name: if-mut-condition-dotdot-008
+  template: "{% if .. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  complexity: 100
+- name: if-mut-condition-eos-016
+  template: "{% if  %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  complexity: 100
+- name: if-mut-condition-lexerr-ampersand
+  template: "{% if & %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: if-mut-condition-lexerr-asterisk
+  template: "{% if * %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: if-mut-condition-lexerr-at
+  template: "{% if @ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: if-mut-condition-lexerr-backslash
+  template: "{% if \\ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: if-mut-condition-lexerr-backtick
+  template: "{% if ` %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: if-mut-condition-lexerr-caret
+  template: "{% if ^ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: if-mut-condition-lexerr-dollar
+  template: "{% if $ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: if-mut-condition-lexerr-hash
+  template: "{% if # %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: if-mut-condition-lexerr-semicolon
+  template: "{% if ; %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: if-mut-condition-lexerr-tilde
+  template: "{% if ~ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: if-mut-condition-lexerr-unclosed_double_quote
+  template: '{% if "hello %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: if-mut-condition-lexerr-unclosed_single_quote
+  template: "{% if 'hello %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: if-mut-condition-lookup-bracket_wrong_content
+  template: "{% if x[,] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  complexity: 100
+- name: if-mut-condition-lookup-dot_number
+  template: "{% if x.123 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x.123"'
+  complexity: 100
+- name: if-mut-condition-lookup-dot_string
+  template: '{% if x."y" %}{% endif %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x."y""'
+  complexity: 100
+- name: if-mut-condition-lookup-range_bad_separator
+  template: "{% if (1, 5) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  complexity: 100
+- name: if-mut-condition-lookup-range_missing_end
+  template: "{% if (1..) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  complexity: 100
+- name: if-mut-condition-lookup-trailing_dot
+  template: "{% if x. %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  complexity: 100
+- name: if-mut-condition-lookup-unclosed_bracket
+  template: "{% if x[0 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  complexity: 100
+- name: if-mut-condition-lookup-unclosed_range
+  template: "{% if (1..5 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  complexity: 100
+- name: if-mut-condition-pipe-000
+  template: "{% if | %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  complexity: 100
+- name: if-mut-condition-question-005
+  template: "{% if ? %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  complexity: 100
+- name: if-mut-end-trail-close_round
+  template: "{% if x ) %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: if-mut-end-trail-close_square
+  template: "{% if x ] %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: if-mut-end-trail-colon
+  template: "{% if x : %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  complexity: 100
+- name: if-mut-end-trail-comma
+  template: "{% if x , %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  complexity: 100
+- name: if-mut-end-trail-comparison
+  template: "{% if x == %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  complexity: 100
+- name: if-mut-end-trail-dash
+  template: "{% if x - %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: if-mut-end-trail-dot
+  template: "{% if x . %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  complexity: 100
+- name: if-mut-end-trail-id
+  template: "{% if x extra %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  complexity: 100
+- name: if-mut-end-trail-number
+  template: "{% if x 42 %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: if-mut-end-trail-open_round
+  template: "{% if x ( %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: if-mut-end-trail-open_square
+  template: "{% if x [ %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  complexity: 100
+- name: if-mut-end-trail-pipe
+  template: "{% if x | %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: if-mut-end-trail-question
+  template: "{% if x ? %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: if-mut-end-trail-string
+  template: "{% if x 'hi' %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100

--- a/specs/parser_errors/if.yml
+++ b/specs/parser_errors/if.yml
@@ -3,1090 +3,1061 @@
   template: "{% if x and x x == [0] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == [0]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-close_round-004
   template: "{% if x and x x == ) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == )"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-close_square-003
   template: "{% if x and x x == ] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-colon-002
   template: "{% if x and x x == : %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == :"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comma-001
   template: "{% if x and x x == , %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ,"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comparison-009
   template: "{% if x and x x == == %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == =="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comparison-010
   template: "{% if x and x x == != %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == !="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comparison-011
   template: "{% if x and x x == < %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comparison-012
   template: "{% if x and x x == > %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comparison-013
   template: "{% if x and x x == <= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comparison-014
   template: "{% if x and x x == >= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-comparison-015
   template: "{% if x and x x == contains %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == contains"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-dash-006
   template: "{% if x and x x == - %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == -"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-dot-007
   template: "{% if x and x x == . %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-dotdot-008
   template: "{% if x and x x == .. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == .."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-eos-016
   template: "{% if x and x x == %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-ampersand
   template: "{% if x and x x == & %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+    - Unexpected character &
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-asterisk
   template: "{% if x and x x == * %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+    - Unexpected character *
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-at
   template: "{% if x and x x == @ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+    - Unexpected character @
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-backslash
   template: "{% if x and x x == \\ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+    - Unexpected character \
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-backtick
   template: "{% if x and x x == ` %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+    - Unexpected character `
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-caret
   template: "{% if x and x x == ^ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+    - Unexpected character ^
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-dollar
   template: "{% if x and x x == $ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+    - Unexpected character $
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-hash
   template: "{% if x and x x == # %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-semicolon
   template: "{% if x and x x == ; %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+    - Unexpected character ;
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-tilde
   template: "{% if x and x x == ~ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+    - Unexpected character ~
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
   template: '{% if x and x x == "hello %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+    - Unexpected character "
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
   template: "{% if x and x x == 'hello %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
   template: "{% if x and x x == x[,] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[,]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-dot_number
   template: "{% if x and x x == x.123 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x.123"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-dot_string
   template: '{% if x and x x == x."y" %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."y""'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-range_bad_separator
   template: "{% if x and x x == (1, 5) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1,
-      5)"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-range_missing_end
   template: "{% if x and x x == (1..) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..)"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-trailing_dot
   template: "{% if x and x x == x. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-unclosed_bracket
   template: "{% if x and x x == x[0 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[0"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-lookup-unclosed_range
   template: "{% if x and x x == (1..5 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..5"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-pipe-000
   template: "{% if x and x x == | %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == |"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_comparison_rhs-question-005
   template: "{% if x and x x == ? %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ?"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_expr-close_round-004
   template: "{% if x and x ) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x and
-      x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: if-mut-boolean_expr-close_square-003
   template: "{% if x and x ] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x and
-      x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: if-mut-boolean_expr-colon-002
   template: "{% if x and x : %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x and x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: if-mut-boolean_expr-comma-001
   template: "{% if x and x , %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x and x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: if-mut-boolean_expr-comparison-009
   template: "{% if x and x == %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      =="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_expr-comparison-010
   template: "{% if x and x != %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      !="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_expr-comparison-011
   template: "{% if x and x < %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      <"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_expr-comparison-012
   template: "{% if x and x > %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      >"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_expr-comparison-013
   template: "{% if x and x <= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      <="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_expr-comparison-014
   template: "{% if x and x >= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      >="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_expr-comparison-015
   template: "{% if x and x contains %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      contains"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_expr-dash-006
   template: "{% if x and x - %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: if-mut-boolean_expr-dot-007
   template: "{% if x and x . %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: if-mut-boolean_expr-dotdot-008
   template: "{% if x and x .. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x .."'
+    - Expected end_of_string but found dotdot
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-ampersand
   template: "{% if x and x & %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x and x &"'
+    - Unexpected character &
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-asterisk
   template: "{% if x and x * %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x and x *"'
+    - Unexpected character *
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-at
   template: "{% if x and x @ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x and x @"'
+    - Unexpected character @
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-backslash
   template: "{% if x and x \\ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x and x \"'
+    - Unexpected character \
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-backtick
   template: "{% if x and x ` %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x and x `"'
+    - Unexpected character `
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-caret
   template: "{% if x and x ^ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+    - Unexpected character ^
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-dollar
   template: "{% if x and x $ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x and x $"'
+    - Unexpected character $
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-hash
   template: "{% if x and x # %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x and x #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-semicolon
   template: "{% if x and x ; %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+    - Unexpected character ;
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-tilde
   template: "{% if x and x ~ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+    - Unexpected character ~
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-unclosed_double_quote
   template: '{% if x and x "hello %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+    - Unexpected character "
   complexity: 100
 - name: if-mut-boolean_expr-lexerr-unclosed_single_quote
   template: "{% if x and x 'hello %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: if-mut-boolean_expr-lookup-bracket_wrong_content
   template: "{% if x and x x[,] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_expr-lookup-dot_number
   template: "{% if x and x x.123 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_expr-lookup-dot_string
   template: '{% if x and x x."y" %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_expr-lookup-range_bad_separator
   template: "{% if x and x (1, 5) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
-      x (1, 5)"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: if-mut-boolean_expr-lookup-range_missing_end
   template: "{% if x and x (1..) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
-      x (1..)"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: if-mut-boolean_expr-lookup-trailing_dot
   template: "{% if x and x x. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_expr-lookup-unclosed_bracket
   template: "{% if x and x x[0 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-boolean_expr-lookup-unclosed_range
   template: "{% if x and x (1..5 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
-      x (1..5"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: if-mut-boolean_expr-pipe-000
   template: "{% if x and x | %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: if-mut-boolean_expr-question-005
   template: "{% if x and x ? %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x and x
-      ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: if-mut-boolean_op-eos
   template: "{% if x and %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-boolean_op-lexerr-ampersand
   template: "{% if x and & %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x and &"'
+    - Unexpected character &
   complexity: 100
 - name: if-mut-boolean_op-lexerr-asterisk
   template: "{% if x and * %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x and *"'
+    - Unexpected character *
   complexity: 100
 - name: if-mut-boolean_op-lexerr-at
   template: "{% if x and @ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x and @"'
+    - Unexpected character @
   complexity: 100
 - name: if-mut-boolean_op-lexerr-backslash
   template: "{% if x and \\ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x and \"'
+    - Unexpected character \
   complexity: 100
 - name: if-mut-boolean_op-lexerr-backtick
   template: "{% if x and ` %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x and `"'
+    - Unexpected character `
   complexity: 100
 - name: if-mut-boolean_op-lexerr-caret
   template: "{% if x and ^ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+    - Unexpected character ^
   complexity: 100
 - name: if-mut-boolean_op-lexerr-dollar
   template: "{% if x and $ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x and $"'
+    - Unexpected character $
   complexity: 100
 - name: if-mut-boolean_op-lexerr-hash
   template: "{% if x and # %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x and #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: if-mut-boolean_op-lexerr-semicolon
   template: "{% if x and ; %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x and ;"'
+    - Unexpected character ;
   complexity: 100
 - name: if-mut-boolean_op-lexerr-tilde
   template: "{% if x and ~ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+    - Unexpected character ~
   complexity: 100
 - name: if-mut-boolean_op-lexerr-unclosed_double_quote
   template: '{% if x and "hello %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x and "hello"'
+    - Unexpected character "
   complexity: 100
 - name: if-mut-boolean_op-lexerr-unclosed_single_quote
   template: "{% if x and 'hello %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: if-mut-comparison_rhs-bare_bracket
   template: "{% if x == [0] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x == [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: if-mut-comparison_rhs-close_round-004
   template: "{% if x == ) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
-      )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-close_square-003
   template: "{% if x == ] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x ==
-      ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-colon-002
   template: "{% if x == : %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comma-001
   template: "{% if x == , %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comparison-009
   template: "{% if x == == %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x ==
-      =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comparison-010
   template: "{% if x == != %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x ==
-      !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comparison-011
   template: "{% if x == < %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x ==
-      <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comparison-012
   template: "{% if x == > %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x ==
-      >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comparison-013
   template: "{% if x == <= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x ==
-      <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comparison-014
   template: "{% if x == >= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x ==
-      >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-comparison-015
   template: "{% if x == contains %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x == contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-dash-006
   template: "{% if x == - %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-dot-007
   template: "{% if x == . %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-dotdot-008
   template: "{% if x == .. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x == .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-eos-016
   template: "{% if x == %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-ampersand
   template: "{% if x == & %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x == &"'
+    - Unexpected character &
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-asterisk
   template: "{% if x == * %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x == *"'
+    - Unexpected character *
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-at
   template: "{% if x == @ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x == @"'
+    - Unexpected character @
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-backslash
   template: "{% if x == \\ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x == \"'
+    - Unexpected character \
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-backtick
   template: "{% if x == ` %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x == `"'
+    - Unexpected character `
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-caret
   template: "{% if x == ^ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+    - Unexpected character ^
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-dollar
   template: "{% if x == $ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x == $"'
+    - Unexpected character $
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-hash
   template: "{% if x == # %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x == #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-semicolon
   template: "{% if x == ; %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x == ;"'
+    - Unexpected character ;
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-tilde
   template: "{% if x == ~ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+    - Unexpected character ~
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-unclosed_double_quote
   template: '{% if x == "hello %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x == "hello"'
+    - Unexpected character "
   complexity: 100
 - name: if-mut-comparison_rhs-lexerr-unclosed_single_quote
   template: "{% if x == 'hello %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-bracket_wrong_content
   template: "{% if x == x[,] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-dot_number
   template: "{% if x == x.123 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x == x.123"'
+    - Expected id but found number
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-dot_string
   template: '{% if x == x."y" %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x == x."y""'
+    - Expected id but found string
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-range_bad_separator
   template: "{% if x == (1, 5) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-range_missing_end
   template: "{% if x == (1..) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
-      (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-trailing_dot
   template: "{% if x == x. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-unclosed_bracket
   template: "{% if x == x[0 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x ==
-      x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: if-mut-comparison_rhs-lookup-unclosed_range
   template: "{% if x == (1..5 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x ==
-      (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: if-mut-comparison_rhs-pipe-000
   template: "{% if x == | %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: if-mut-comparison_rhs-question-005
   template: "{% if x == ? %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x == ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-bare_bracket
   template: "{% if [0] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "[0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: if-mut-condition-close_round-004
   template: "{% if ) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-close_square-003
   template: "{% if ] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-colon-002
   template: "{% if : %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comma-001
   template: "{% if , %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comparison-009
   template: "{% if == %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comparison-010
   template: "{% if != %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comparison-011
   template: "{% if < %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comparison-012
   template: "{% if > %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comparison-013
   template: "{% if <= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comparison-014
   template: "{% if >= %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-comparison-015
   template: "{% if contains %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-dash-006
   template: "{% if - %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-dot-007
   template: "{% if . %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-dotdot-008
   template: "{% if .. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-eos-016
   template: "{% if  %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-condition-lexerr-ampersand
   template: "{% if & %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: if-mut-condition-lexerr-asterisk
   template: "{% if * %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: if-mut-condition-lexerr-at
   template: "{% if @ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: if-mut-condition-lexerr-backslash
   template: "{% if \\ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: if-mut-condition-lexerr-backtick
   template: "{% if ` %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: if-mut-condition-lexerr-caret
   template: "{% if ^ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: if-mut-condition-lexerr-dollar
   template: "{% if $ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: if-mut-condition-lexerr-hash
   template: "{% if # %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: if-mut-condition-lexerr-semicolon
   template: "{% if ; %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: if-mut-condition-lexerr-tilde
   template: "{% if ~ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: if-mut-condition-lexerr-unclosed_double_quote
   template: '{% if "hello %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: if-mut-condition-lexerr-unclosed_single_quote
   template: "{% if 'hello %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: if-mut-condition-lookup-bracket_wrong_content
   template: "{% if x[,] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-lookup-dot_number
   template: "{% if x.123 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x.123"'
+    - Expected id but found number
   complexity: 100
 - name: if-mut-condition-lookup-dot_string
   template: '{% if x."y" %}{% endif %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x."y""'
+    - Expected id but found string
   complexity: 100
 - name: if-mut-condition-lookup-range_bad_separator
   template: "{% if (1, 5) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: if-mut-condition-lookup-range_missing_end
   template: "{% if (1..) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-lookup-trailing_dot
   template: "{% if x. %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: if-mut-condition-lookup-unclosed_bracket
   template: "{% if x[0 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: if-mut-condition-lookup-unclosed_range
   template: "{% if (1..5 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: if-mut-condition-pipe-000
   template: "{% if | %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: if-mut-condition-question-005
   template: "{% if ? %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: if-mut-end-trail-close_round
   template: "{% if x ) %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: if-mut-end-trail-close_square
   template: "{% if x ] %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: if-mut-end-trail-colon
   template: "{% if x : %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: if-mut-end-trail-comma
   template: "{% if x , %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: if-mut-end-trail-comparison
   template: "{% if x == %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-end-trail-dash
   template: "{% if x - %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: if-mut-end-trail-dot
   template: "{% if x . %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: if-mut-end-trail-id
   template: "{% if x extra %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: if-mut-end-trail-number
   template: "{% if x 42 %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: if-mut-end-trail-open_round
   template: "{% if x ( %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: if-mut-end-trail-open_square
   template: "{% if x [ %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: if-mut-end-trail-pipe
   template: "{% if x | %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: if-mut-end-trail-question
   template: "{% if x ? %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: if-mut-end-trail-string
   template: "{% if x 'hi' %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100

--- a/specs/parser_errors/include.yml
+++ b/specs/parser_errors/include.yml
@@ -1,0 +1,964 @@
+---
+- name: include-mut-alias_name-eos
+  template: "{% include x as %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x as"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-ampersand
+  template: "{% include x as & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x as &"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-asterisk
+  template: "{% include x as * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x as *"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-at
+  template: "{% include x as @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x as @"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-backslash
+  template: "{% include x as \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x as \"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-backtick
+  template: "{% include x as ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x as `"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-caret
+  template: "{% include x as ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x as ^"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-dollar
+  template: "{% include x as $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x as $"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-hash
+  template: "{% include x as # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x as #"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-semicolon
+  template: "{% include x as ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x as ;"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-tilde
+  template: "{% include x as ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x as ~"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-unclosed_double_quote
+  template: '{% include x as "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x as "hello"'
+  complexity: 100
+- name: include-mut-alias_name-lexerr-unclosed_single_quote
+  template: "{% include x as 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x as ''hello"'
+  complexity: 100
+- name: include-mut-alias_name-number
+  template: "{% include x as 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x as 42"'
+  complexity: 100
+- name: include-mut-binding_keyword-id
+  template: "{% include x with %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x with"'
+  complexity: 100
+- name: include-mut-binding_value-bare_bracket
+  template: "{% include x for [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x for [0]"'
+  complexity: 100
+- name: include-mut-binding_value-close_round-004
+  template: "{% include x for ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x for
+      )"'
+  complexity: 100
+- name: include-mut-binding_value-close_square-003
+  template: "{% include x for ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x for
+      ]"'
+  complexity: 100
+- name: include-mut-binding_value-colon-002
+  template: "{% include x for : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x for :"'
+  complexity: 100
+- name: include-mut-binding_value-comma-001
+  template: "{% include x for , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for ,"'
+  complexity: 100
+- name: include-mut-binding_value-comparison-009
+  template: "{% include x for == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x for
+      =="'
+  complexity: 100
+- name: include-mut-binding_value-comparison-010
+  template: "{% include x for != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x for
+      !="'
+  complexity: 100
+- name: include-mut-binding_value-comparison-011
+  template: "{% include x for < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x for
+      <"'
+  complexity: 100
+- name: include-mut-binding_value-comparison-012
+  template: "{% include x for > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x for
+      >"'
+  complexity: 100
+- name: include-mut-binding_value-comparison-013
+  template: "{% include x for <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x for
+      <="'
+  complexity: 100
+- name: include-mut-binding_value-comparison-014
+  template: "{% include x for >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x for
+      >="'
+  complexity: 100
+- name: include-mut-binding_value-comparison-015
+  template: "{% include x for contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x for contains"'
+  complexity: 100
+- name: include-mut-binding_value-dash-006
+  template: "{% include x for - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x for -"'
+  complexity: 100
+- name: include-mut-binding_value-dot-007
+  template: "{% include x for . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x for ."'
+  complexity: 100
+- name: include-mut-binding_value-dotdot-008
+  template: "{% include x for .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x for .."'
+  complexity: 100
+- name: include-mut-binding_value-eos-016
+  template: "{% include x for %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x for"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-ampersand
+  template: "{% include x for & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x for &"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-asterisk
+  template: "{% include x for * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x for *"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-at
+  template: "{% include x for @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x for @"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-backslash
+  template: "{% include x for \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x for \"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-backtick
+  template: "{% include x for ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x for `"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-caret
+  template: "{% include x for ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x for ^"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-dollar
+  template: "{% include x for $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x for $"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-hash
+  template: "{% include x for # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x for #"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-semicolon
+  template: "{% include x for ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x for ;"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-tilde
+  template: "{% include x for ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x for ~"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-unclosed_double_quote
+  template: '{% include x for "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x for "hello"'
+  complexity: 100
+- name: include-mut-binding_value-lexerr-unclosed_single_quote
+  template: "{% include x for 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x for ''hello"'
+  complexity: 100
+- name: include-mut-binding_value-lookup-bracket_wrong_content
+  template: "{% include x for x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for x[,]"'
+  complexity: 100
+- name: include-mut-binding_value-lookup-dot_number
+  template: "{% include x for x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x for x.123"'
+  complexity: 100
+- name: include-mut-binding_value-lookup-dot_string
+  template: '{% include x for x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x for x."y""'
+  complexity: 100
+- name: include-mut-binding_value-lookup-range_bad_separator
+  template: "{% include x for (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x for (1, 5)"'
+  complexity: 100
+- name: include-mut-binding_value-lookup-range_missing_end
+  template: "{% include x for (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x for
+      (1..)"'
+  complexity: 100
+- name: include-mut-binding_value-lookup-trailing_dot
+  template: "{% include x for x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x for x."'
+  complexity: 100
+- name: include-mut-binding_value-lookup-unclosed_bracket
+  template: "{% include x for x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x for
+      x[0"'
+  complexity: 100
+- name: include-mut-binding_value-lookup-unclosed_range
+  template: "{% include x for (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x for
+      (1..5"'
+  complexity: 100
+- name: include-mut-binding_value-pipe-000
+  template: "{% include x for | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x for |"'
+  complexity: 100
+- name: include-mut-binding_value-question-005
+  template: "{% include x for ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x for ?"'
+  complexity: 100
+- name: include-mut-end-trail-close_round
+  template: "{% include x ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: include-mut-end-trail-close_square
+  template: "{% include x ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: include-mut-end-trail-colon
+  template: "{% include x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  complexity: 100
+- name: include-mut-end-trail-comparison
+  template: "{% include x == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  complexity: 100
+- name: include-mut-end-trail-dash
+  template: "{% include x - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: include-mut-end-trail-dot
+  template: "{% include x . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  complexity: 100
+- name: include-mut-end-trail-id
+  template: "{% include x extra %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found end_of_string in "x extra"'
+  complexity: 100
+- name: include-mut-end-trail-number
+  template: "{% include x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: include-mut-end-trail-open_round
+  template: "{% include x ( %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: include-mut-end-trail-open_square
+  template: "{% include x [ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  complexity: 100
+- name: include-mut-end-trail-pipe
+  template: "{% include x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: include-mut-end-trail-question
+  template: "{% include x ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: include-mut-end-trail-string
+  template: "{% include x 'hi' %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100
+- name: include-mut-kwarg_colon-eos
+  template: "{% include x step , x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x"'
+  complexity: 100
+- name: include-mut-kwarg_colon-number
+  template: "{% include x step , x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x 42"'
+  complexity: 100
+- name: include-mut-kwarg_name-eos
+  template: "{% include x step , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step ,"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-ampersand
+  template: "{% include x step , & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x step , &"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-asterisk
+  template: "{% include x step , * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x step , *"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-at
+  template: "{% include x step , @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x step , @"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-backslash
+  template: "{% include x step , \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x step , \"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-backtick
+  template: "{% include x step , ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x step , `"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-caret
+  template: "{% include x step , ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x step , ^"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-dollar
+  template: "{% include x step , $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x step , $"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-hash
+  template: "{% include x step , # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x step , #"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-semicolon
+  template: "{% include x step , ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x step , ;"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-tilde
+  template: "{% include x step , ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x step , ~"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-unclosed_double_quote
+  template: '{% include x step , "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x step , "hello"'
+  complexity: 100
+- name: include-mut-kwarg_name-lexerr-unclosed_single_quote
+  template: "{% include x step , 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x step , ''hello"'
+  complexity: 100
+- name: include-mut-kwarg_name-number
+  template: "{% include x step , 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , 42"'
+  complexity: 100
+- name: include-mut-kwarg_value-bare_bracket
+  template: "{% include x step , x : [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : [0]"'
+  complexity: 100
+- name: include-mut-kwarg_value-close_round-004
+  template: "{% include x step , x : ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : )"'
+  complexity: 100
+- name: include-mut-kwarg_value-close_square-003
+  template: "{% include x step , x : ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ]"'
+  complexity: 100
+- name: include-mut-kwarg_value-colon-002
+  template: "{% include x step , x : : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : :"'
+  complexity: 100
+- name: include-mut-kwarg_value-comma-001
+  template: "{% include x step , x : , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ,"'
+  complexity: 100
+- name: include-mut-kwarg_value-comparison-009
+  template: "{% include x step , x : == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : =="'
+  complexity: 100
+- name: include-mut-kwarg_value-comparison-010
+  template: "{% include x step , x : != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : !="'
+  complexity: 100
+- name: include-mut-kwarg_value-comparison-011
+  template: "{% include x step , x : < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : <"'
+  complexity: 100
+- name: include-mut-kwarg_value-comparison-012
+  template: "{% include x step , x : > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : >"'
+  complexity: 100
+- name: include-mut-kwarg_value-comparison-013
+  template: "{% include x step , x : <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : <="'
+  complexity: 100
+- name: include-mut-kwarg_value-comparison-014
+  template: "{% include x step , x : >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : >="'
+  complexity: 100
+- name: include-mut-kwarg_value-comparison-015
+  template: "{% include x step , x : contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : contains"'
+  complexity: 100
+- name: include-mut-kwarg_value-dash-006
+  template: "{% include x step , x : - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : -"'
+  complexity: 100
+- name: include-mut-kwarg_value-dot-007
+  template: "{% include x step , x : . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ."'
+  complexity: 100
+- name: include-mut-kwarg_value-dotdot-008
+  template: "{% include x step , x : .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : .."'
+  complexity: 100
+- name: include-mut-kwarg_value-eos-016
+  template: "{% include x step , x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x :"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-ampersand
+  template: "{% include x step , x : & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x step , x : &"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-asterisk
+  template: "{% include x step , x : * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x step , x : *"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-at
+  template: "{% include x step , x : @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x step , x : @"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-backslash
+  template: "{% include x step , x : \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x step , x : \"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-backtick
+  template: "{% include x step , x : ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x step , x : `"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-caret
+  template: "{% include x step , x : ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x step , x : ^"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-dollar
+  template: "{% include x step , x : $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x step , x : $"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-hash
+  template: "{% include x step , x : # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x step , x : #"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-semicolon
+  template: "{% include x step , x : ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x step , x : ;"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-tilde
+  template: "{% include x step , x : ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x step , x : ~"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% include x step , x : "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x step , x : "hello"'
+  complexity: 100
+- name: include-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% include x step , x : 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x step , x : ''hello"'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% include x step , x : x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x[,]"'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-dot_number
+  template: "{% include x step , x : x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x.123"'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-dot_string
+  template: '{% include x step , x : x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x."y""'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% include x step , x : (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : (1, 5)"'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-range_missing_end
+  template: "{% include x step , x : (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..)"'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-trailing_dot
+  template: "{% include x step , x : x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x."'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% include x step , x : x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x[0"'
+  complexity: 100
+- name: include-mut-kwarg_value-lookup-unclosed_range
+  template: "{% include x step , x : (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..5"'
+  complexity: 100
+- name: include-mut-kwarg_value-pipe-000
+  template: "{% include x step , x : | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : |"'
+  complexity: 100
+- name: include-mut-kwarg_value-question-005
+  template: "{% include x step , x : ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ?"'
+  complexity: 100
+- name: include-mut-template_expr-bare_bracket
+  template: "{% include [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "[0]"'
+  complexity: 100
+- name: include-mut-template_expr-close_round-004
+  template: "{% include ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  complexity: 100
+- name: include-mut-template_expr-close_square-003
+  template: "{% include ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  complexity: 100
+- name: include-mut-template_expr-colon-002
+  template: "{% include : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  complexity: 100
+- name: include-mut-template_expr-comma-001
+  template: "{% include , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  complexity: 100
+- name: include-mut-template_expr-comparison-009
+  template: "{% include == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  complexity: 100
+- name: include-mut-template_expr-comparison-010
+  template: "{% include != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  complexity: 100
+- name: include-mut-template_expr-comparison-011
+  template: "{% include < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  complexity: 100
+- name: include-mut-template_expr-comparison-012
+  template: "{% include > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  complexity: 100
+- name: include-mut-template_expr-comparison-013
+  template: "{% include <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  complexity: 100
+- name: include-mut-template_expr-comparison-014
+  template: "{% include >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  complexity: 100
+- name: include-mut-template_expr-comparison-015
+  template: "{% include contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "contains"'
+  complexity: 100
+- name: include-mut-template_expr-dash-006
+  template: "{% include - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  complexity: 100
+- name: include-mut-template_expr-dot-007
+  template: "{% include . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  complexity: 100
+- name: include-mut-template_expr-dotdot-008
+  template: "{% include .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  complexity: 100
+- name: include-mut-template_expr-eos-016
+  template: "{% include  %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-ampersand
+  template: "{% include & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-asterisk
+  template: "{% include * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-at
+  template: "{% include @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-backslash
+  template: "{% include \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-backtick
+  template: "{% include ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-caret
+  template: "{% include ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-dollar
+  template: "{% include $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-hash
+  template: "{% include # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-semicolon
+  template: "{% include ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-tilde
+  template: "{% include ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-unclosed_double_quote
+  template: '{% include "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: include-mut-template_expr-lexerr-unclosed_single_quote
+  template: "{% include 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: include-mut-template_expr-lookup-bracket_wrong_content
+  template: "{% include x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  complexity: 100
+- name: include-mut-template_expr-lookup-dot_number
+  template: "{% include x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x.123"'
+  complexity: 100
+- name: include-mut-template_expr-lookup-dot_string
+  template: '{% include x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x."y""'
+  complexity: 100
+- name: include-mut-template_expr-lookup-range_bad_separator
+  template: "{% include (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  complexity: 100
+- name: include-mut-template_expr-lookup-range_missing_end
+  template: "{% include (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  complexity: 100
+- name: include-mut-template_expr-lookup-trailing_dot
+  template: "{% include x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  complexity: 100
+- name: include-mut-template_expr-lookup-unclosed_bracket
+  template: "{% include x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  complexity: 100
+- name: include-mut-template_expr-lookup-unclosed_range
+  template: "{% include (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  complexity: 100
+- name: include-mut-template_expr-pipe-000
+  template: "{% include | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  complexity: 100
+- name: include-mut-template_expr-question-005
+  template: "{% include ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  complexity: 100

--- a/specs/parser_errors/include.yml
+++ b/specs/parser_errors/include.yml
@@ -3,962 +3,947 @@
   template: "{% include x as %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x as"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: include-mut-alias_name-lexerr-ampersand
   template: "{% include x as & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x as &"'
+    - Unexpected character &
   complexity: 100
 - name: include-mut-alias_name-lexerr-asterisk
   template: "{% include x as * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x as *"'
+    - Unexpected character *
   complexity: 100
 - name: include-mut-alias_name-lexerr-at
   template: "{% include x as @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x as @"'
+    - Unexpected character @
   complexity: 100
 - name: include-mut-alias_name-lexerr-backslash
   template: "{% include x as \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x as \"'
+    - Unexpected character \
   complexity: 100
 - name: include-mut-alias_name-lexerr-backtick
   template: "{% include x as ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x as `"'
+    - Unexpected character `
   complexity: 100
 - name: include-mut-alias_name-lexerr-caret
   template: "{% include x as ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x as ^"'
+    - Unexpected character ^
   complexity: 100
 - name: include-mut-alias_name-lexerr-dollar
   template: "{% include x as $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x as $"'
+    - Unexpected character $
   complexity: 100
 - name: include-mut-alias_name-lexerr-hash
   template: "{% include x as # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x as #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: include-mut-alias_name-lexerr-semicolon
   template: "{% include x as ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x as ;"'
+    - Unexpected character ;
   complexity: 100
 - name: include-mut-alias_name-lexerr-tilde
   template: "{% include x as ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x as ~"'
+    - Unexpected character ~
   complexity: 100
 - name: include-mut-alias_name-lexerr-unclosed_double_quote
   template: '{% include x as "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x as "hello"'
+    - Unexpected character "
   complexity: 100
 - name: include-mut-alias_name-lexerr-unclosed_single_quote
   template: "{% include x as 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x as ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: include-mut-alias_name-number
   template: "{% include x as 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x as 42"'
+    - Expected id but found number
   complexity: 100
 - name: include-mut-binding_keyword-id
   template: "{% include x with %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x with"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: include-mut-binding_value-bare_bracket
   template: "{% include x for [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x for [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: include-mut-binding_value-close_round-004
   template: "{% include x for ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x for
-      )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-close_square-003
   template: "{% include x for ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x for
-      ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-colon-002
   template: "{% include x for : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x for :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comma-001
   template: "{% include x for , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comparison-009
   template: "{% include x for == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x for
-      =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comparison-010
   template: "{% include x for != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x for
-      !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comparison-011
   template: "{% include x for < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x for
-      <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comparison-012
   template: "{% include x for > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x for
-      >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comparison-013
   template: "{% include x for <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x for
-      <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comparison-014
   template: "{% include x for >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x for
-      >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-comparison-015
   template: "{% include x for contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x for contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-dash-006
   template: "{% include x for - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x for -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-dot-007
   template: "{% include x for . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x for ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-dotdot-008
   template: "{% include x for .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x for .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-eos-016
   template: "{% include x for %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x for"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: include-mut-binding_value-lexerr-ampersand
   template: "{% include x for & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x for &"'
+    - Unexpected character &
   complexity: 100
 - name: include-mut-binding_value-lexerr-asterisk
   template: "{% include x for * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x for *"'
+    - Unexpected character *
   complexity: 100
 - name: include-mut-binding_value-lexerr-at
   template: "{% include x for @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x for @"'
+    - Unexpected character @
   complexity: 100
 - name: include-mut-binding_value-lexerr-backslash
   template: "{% include x for \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x for \"'
+    - Unexpected character \
   complexity: 100
 - name: include-mut-binding_value-lexerr-backtick
   template: "{% include x for ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x for `"'
+    - Unexpected character `
   complexity: 100
 - name: include-mut-binding_value-lexerr-caret
   template: "{% include x for ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x for ^"'
+    - Unexpected character ^
   complexity: 100
 - name: include-mut-binding_value-lexerr-dollar
   template: "{% include x for $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x for $"'
+    - Unexpected character $
   complexity: 100
 - name: include-mut-binding_value-lexerr-hash
   template: "{% include x for # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x for #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: include-mut-binding_value-lexerr-semicolon
   template: "{% include x for ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x for ;"'
+    - Unexpected character ;
   complexity: 100
 - name: include-mut-binding_value-lexerr-tilde
   template: "{% include x for ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x for ~"'
+    - Unexpected character ~
   complexity: 100
 - name: include-mut-binding_value-lexerr-unclosed_double_quote
   template: '{% include x for "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x for "hello"'
+    - Unexpected character "
   complexity: 100
 - name: include-mut-binding_value-lexerr-unclosed_single_quote
   template: "{% include x for 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x for ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: include-mut-binding_value-lookup-bracket_wrong_content
   template: "{% include x for x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x for x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-lookup-dot_number
   template: "{% include x for x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x for x.123"'
+    - Expected id but found number
   complexity: 100
 - name: include-mut-binding_value-lookup-dot_string
   template: '{% include x for x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x for x."y""'
+    - Expected id but found string
   complexity: 100
 - name: include-mut-binding_value-lookup-range_bad_separator
   template: "{% include x for (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x for (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: include-mut-binding_value-lookup-range_missing_end
   template: "{% include x for (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x for
-      (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-lookup-trailing_dot
   template: "{% include x for x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x for x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: include-mut-binding_value-lookup-unclosed_bracket
   template: "{% include x for x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x for
-      x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: include-mut-binding_value-lookup-unclosed_range
   template: "{% include x for (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x for
-      (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: include-mut-binding_value-pipe-000
   template: "{% include x for | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x for |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: include-mut-binding_value-question-005
   template: "{% include x for ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x for ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: include-mut-end-trail-close_round
   template: "{% include x ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: include-mut-end-trail-close_square
   template: "{% include x ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: include-mut-end-trail-colon
   template: "{% include x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: include-mut-end-trail-comparison
   template: "{% include x == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: include-mut-end-trail-dash
   template: "{% include x - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: include-mut-end-trail-dot
   template: "{% include x . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: include-mut-end-trail-id
   template: "{% include x extra %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found end_of_string in "x extra"'
+    - Expected colon but found end_of_string
   complexity: 100
 - name: include-mut-end-trail-number
   template: "{% include x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: include-mut-end-trail-open_round
   template: "{% include x ( %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: include-mut-end-trail-open_square
   template: "{% include x [ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: include-mut-end-trail-pipe
   template: "{% include x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: include-mut-end-trail-question
   template: "{% include x ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: include-mut-end-trail-string
   template: "{% include x 'hi' %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: include-mut-kwarg_colon-eos
   template: "{% include x step , x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_colon-number
   template: "{% include x step , x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x 42"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_name-eos
   template: "{% include x step , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step ,"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-ampersand
   template: "{% include x step , & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x step , &"'
+    - Unexpected character &
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-asterisk
   template: "{% include x step , * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x step , *"'
+    - Unexpected character *
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-at
   template: "{% include x step , @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x step , @"'
+    - Unexpected character @
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-backslash
   template: "{% include x step , \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x step , \"'
+    - Unexpected character \
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-backtick
   template: "{% include x step , ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x step , `"'
+    - Unexpected character `
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-caret
   template: "{% include x step , ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x step , ^"'
+    - Unexpected character ^
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-dollar
   template: "{% include x step , $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x step , $"'
+    - Unexpected character $
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-hash
   template: "{% include x step , # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x step , #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-semicolon
   template: "{% include x step , ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x step , ;"'
+    - Unexpected character ;
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-tilde
   template: "{% include x step , ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x step , ~"'
+    - Unexpected character ~
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-unclosed_double_quote
   template: '{% include x step , "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x step , "hello"'
+    - Unexpected character "
   complexity: 100
 - name: include-mut-kwarg_name-lexerr-unclosed_single_quote
   template: "{% include x step , 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x step , ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: include-mut-kwarg_name-number
   template: "{% include x step , 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , 42"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-bare_bracket
   template: "{% include x step , x : [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : [0]"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-close_round-004
   template: "{% include x step , x : ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : )"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-close_square-003
   template: "{% include x step , x : ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ]"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-colon-002
   template: "{% include x step , x : : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : :"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comma-001
   template: "{% include x step , x : , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ,"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comparison-009
   template: "{% include x step , x : == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : =="'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comparison-010
   template: "{% include x step , x : != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : !="'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comparison-011
   template: "{% include x step , x : < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : <"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comparison-012
   template: "{% include x step , x : > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : >"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comparison-013
   template: "{% include x step , x : <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : <="'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comparison-014
   template: "{% include x step , x : >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : >="'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-comparison-015
   template: "{% include x step , x : contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : contains"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-dash-006
   template: "{% include x step , x : - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : -"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-dot-007
   template: "{% include x step , x : . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ."'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-dotdot-008
   template: "{% include x step , x : .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : .."'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-eos-016
   template: "{% include x step , x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x :"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-ampersand
   template: "{% include x step , x : & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x step , x : &"'
+    - Unexpected character &
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-asterisk
   template: "{% include x step , x : * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x step , x : *"'
+    - Unexpected character *
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-at
   template: "{% include x step , x : @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x step , x : @"'
+    - Unexpected character @
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-backslash
   template: "{% include x step , x : \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x step , x : \"'
+    - Unexpected character \
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-backtick
   template: "{% include x step , x : ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x step , x : `"'
+    - Unexpected character `
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-caret
   template: "{% include x step , x : ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x step , x : ^"'
+    - Unexpected character ^
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-dollar
   template: "{% include x step , x : $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x step , x : $"'
+    - Unexpected character $
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-hash
   template: "{% include x step , x : # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x step , x : #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-semicolon
   template: "{% include x step , x : ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x step , x : ;"'
+    - Unexpected character ;
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-tilde
   template: "{% include x step , x : ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x step , x : ~"'
+    - Unexpected character ~
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-unclosed_double_quote
   template: '{% include x step , x : "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x step , x : "hello"'
+    - Unexpected character "
   complexity: 100
 - name: include-mut-kwarg_value-lexerr-unclosed_single_quote
   template: "{% include x step , x : 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x step , x : ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: include-mut-kwarg_value-lookup-bracket_wrong_content
   template: "{% include x step , x : x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x[,]"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lookup-dot_number
   template: "{% include x step , x : x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x.123"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lookup-dot_string
   template: '{% include x step , x : x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x."y""'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lookup-range_bad_separator
   template: "{% include x step , x : (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : (1, 5)"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lookup-range_missing_end
   template: "{% include x step , x : (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..)"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lookup-trailing_dot
   template: "{% include x step , x : x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x."'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lookup-unclosed_bracket
   template: "{% include x step , x : x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : x[0"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-lookup-unclosed_range
   template: "{% include x step , x : (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : (1..5"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-pipe-000
   template: "{% include x step , x : | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : |"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-kwarg_value-question-005
   template: "{% include x step , x : ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "x step , x : ?"'
+    - Expected colon but found comma
   complexity: 100
 - name: include-mut-template_expr-bare_bracket
   template: "{% include [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "[0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: include-mut-template_expr-close_round-004
   template: "{% include ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-close_square-003
   template: "{% include ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-colon-002
   template: "{% include : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comma-001
   template: "{% include , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comparison-009
   template: "{% include == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comparison-010
   template: "{% include != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comparison-011
   template: "{% include < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comparison-012
   template: "{% include > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comparison-013
   template: "{% include <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comparison-014
   template: "{% include >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-comparison-015
   template: "{% include contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-dash-006
   template: "{% include - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-dot-007
   template: "{% include . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-dotdot-008
   template: "{% include .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-eos-016
   template: "{% include  %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: include-mut-template_expr-lexerr-ampersand
   template: "{% include & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: include-mut-template_expr-lexerr-asterisk
   template: "{% include * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: include-mut-template_expr-lexerr-at
   template: "{% include @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: include-mut-template_expr-lexerr-backslash
   template: "{% include \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: include-mut-template_expr-lexerr-backtick
   template: "{% include ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: include-mut-template_expr-lexerr-caret
   template: "{% include ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: include-mut-template_expr-lexerr-dollar
   template: "{% include $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: include-mut-template_expr-lexerr-hash
   template: "{% include # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: include-mut-template_expr-lexerr-semicolon
   template: "{% include ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: include-mut-template_expr-lexerr-tilde
   template: "{% include ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: include-mut-template_expr-lexerr-unclosed_double_quote
   template: '{% include "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: include-mut-template_expr-lexerr-unclosed_single_quote
   template: "{% include 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: include-mut-template_expr-lookup-bracket_wrong_content
   template: "{% include x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-lookup-dot_number
   template: "{% include x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x.123"'
+    - Expected id but found number
   complexity: 100
 - name: include-mut-template_expr-lookup-dot_string
   template: '{% include x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x."y""'
+    - Expected id but found string
   complexity: 100
 - name: include-mut-template_expr-lookup-range_bad_separator
   template: "{% include (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: include-mut-template_expr-lookup-range_missing_end
   template: "{% include (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-lookup-trailing_dot
   template: "{% include x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: include-mut-template_expr-lookup-unclosed_bracket
   template: "{% include x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: include-mut-template_expr-lookup-unclosed_range
   template: "{% include (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: include-mut-template_expr-pipe-000
   template: "{% include | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: include-mut-template_expr-question-005
   template: "{% include ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100

--- a/specs/parser_errors/increment.yml
+++ b/specs/parser_errors/increment.yml
@@ -3,167 +3,167 @@
   template: "{% increment x ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: increment-mut-end-trail-close_square
   template: "{% increment x ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: increment-mut-end-trail-colon
   template: "{% increment x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: increment-mut-end-trail-comma
   template: "{% increment x , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: increment-mut-end-trail-comparison
   template: "{% increment x == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: increment-mut-end-trail-dash
   template: "{% increment x - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: increment-mut-end-trail-dot
   template: "{% increment x . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+    - Expected end_of_string but found dot
   complexity: 100
 - name: increment-mut-end-trail-id
   template: "{% increment x extra %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: increment-mut-end-trail-number
   template: "{% increment x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: increment-mut-end-trail-open_round
   template: "{% increment x ( %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: increment-mut-end-trail-open_square
   template: "{% increment x [ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_square in "x ["'
+    - Expected end_of_string but found open_square
   complexity: 100
 - name: increment-mut-end-trail-pipe
   template: "{% increment x | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: increment-mut-end-trail-question
   template: "{% increment x ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: increment-mut-end-trail-string
   template: "{% increment x 'hi' %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: increment-mut-variable_name-eos
   template: "{% increment  %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+    - Expected id but found end_of_string
   complexity: 100
 - name: increment-mut-variable_name-lexerr-ampersand
   template: "{% increment & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: increment-mut-variable_name-lexerr-asterisk
   template: "{% increment * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: increment-mut-variable_name-lexerr-at
   template: "{% increment @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: increment-mut-variable_name-lexerr-backslash
   template: "{% increment \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: increment-mut-variable_name-lexerr-backtick
   template: "{% increment ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: increment-mut-variable_name-lexerr-caret
   template: "{% increment ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: increment-mut-variable_name-lexerr-dollar
   template: "{% increment $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: increment-mut-variable_name-lexerr-hash
   template: "{% increment # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: increment-mut-variable_name-lexerr-semicolon
   template: "{% increment ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: increment-mut-variable_name-lexerr-tilde
   template: "{% increment ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: increment-mut-variable_name-lexerr-unclosed_double_quote
   template: '{% increment "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: increment-mut-variable_name-lexerr-unclosed_single_quote
   template: "{% increment 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: increment-mut-variable_name-number
   template: "{% increment 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "42"'
+    - Expected id but found number
   complexity: 100

--- a/specs/parser_errors/increment.yml
+++ b/specs/parser_errors/increment.yml
@@ -1,0 +1,169 @@
+---
+- name: increment-mut-end-trail-close_round
+  template: "{% increment x ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: increment-mut-end-trail-close_square
+  template: "{% increment x ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: increment-mut-end-trail-colon
+  template: "{% increment x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  complexity: 100
+- name: increment-mut-end-trail-comma
+  template: "{% increment x , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  complexity: 100
+- name: increment-mut-end-trail-comparison
+  template: "{% increment x == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x =="'
+  complexity: 100
+- name: increment-mut-end-trail-dash
+  template: "{% increment x - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: increment-mut-end-trail-dot
+  template: "{% increment x . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dot in "x ."'
+  complexity: 100
+- name: increment-mut-end-trail-id
+  template: "{% increment x extra %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  complexity: 100
+- name: increment-mut-end-trail-number
+  template: "{% increment x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: increment-mut-end-trail-open_round
+  template: "{% increment x ( %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: increment-mut-end-trail-open_square
+  template: "{% increment x [ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_square in "x ["'
+  complexity: 100
+- name: increment-mut-end-trail-pipe
+  template: "{% increment x | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: increment-mut-end-trail-question
+  template: "{% increment x ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: increment-mut-end-trail-string
+  template: "{% increment x 'hi' %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100
+- name: increment-mut-variable_name-eos
+  template: "{% increment  %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-ampersand
+  template: "{% increment & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-asterisk
+  template: "{% increment * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-at
+  template: "{% increment @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-backslash
+  template: "{% increment \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-backtick
+  template: "{% increment ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-caret
+  template: "{% increment ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-dollar
+  template: "{% increment $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-hash
+  template: "{% increment # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-semicolon
+  template: "{% increment ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-tilde
+  template: "{% increment ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% increment "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: increment-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% increment 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: increment-mut-variable_name-number
+  template: "{% increment 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "42"'
+  complexity: 100

--- a/specs/parser_errors/inline_comment.yml
+++ b/specs/parser_errors/inline_comment.yml
@@ -5,8 +5,8 @@
     foo %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
-      be prefixed by the ''#'' character'
+    - Syntax error in tag '#' - Each line of comments must be prefixed by the '#'
+      character
   complexity: 100
 - name: inline_comment-004
   template: |-
@@ -15,8 +15,8 @@
     foo %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
-      be prefixed by the ''#'' character'
+    - Syntax error in tag '#' - Each line of comments must be prefixed by the '#'
+      character
   complexity: 100
 - name: inline_comment-005
   template: |-
@@ -25,15 +25,15 @@
     foo %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
-      be prefixed by the ''#'' character'
+    - Syntax error in tag '#' - Each line of comments must be prefixed by the '#'
+      character
   complexity: 100
 - name: inline_comment-007
   template: "{% # ok\n \t foo %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
-      be prefixed by the ''#'' character'
+    - Syntax error in tag '#' - Each line of comments must be prefixed by the '#'
+      character
   complexity: 100
 - name: inline_comment-008
   template: |-
@@ -42,6 +42,6 @@
     bar %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
-      be prefixed by the ''#'' character'
+    - Syntax error in tag '#' - Each line of comments must be prefixed by the '#'
+      character
   complexity: 100

--- a/specs/parser_errors/inline_comment.yml
+++ b/specs/parser_errors/inline_comment.yml
@@ -1,0 +1,47 @@
+---
+- name: inline_comment-003
+  template: |-
+    {% # ok
+    foo %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+      be prefixed by the ''#'' character'
+  complexity: 100
+- name: inline_comment-004
+  template: |-
+    {% # ok
+    # ok
+    foo %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+      be prefixed by the ''#'' character'
+  complexity: 100
+- name: inline_comment-005
+  template: |-
+    {% # ok
+
+    foo %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+      be prefixed by the ''#'' character'
+  complexity: 100
+- name: inline_comment-007
+  template: "{% # ok\n \t foo %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+      be prefixed by the ''#'' character'
+  complexity: 100
+- name: inline_comment-008
+  template: |-
+    {% #
+    foo
+    bar %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax error in tag ''#'' - Each line of comments must
+      be prefixed by the ''#'' character'
+  complexity: 100

--- a/specs/parser_errors/liquid.yml
+++ b/specs/parser_errors/liquid.yml
@@ -1,0 +1,69 @@
+---
+- name: liquid-200
+  template: |-
+    {% liquid
+    hello world
+    %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unknown tag ''hello'''
+  complexity: 100
+- name: liquid-201
+  template: |-
+    {% liquid
+    foobar baz
+    %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unknown tag ''foobar'''
+  complexity: 100
+- name: liquid-203
+  template: |-
+    {% liquid
+    endfor
+    %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''endfor'' is not a valid delimiter for liquid tags. use
+      %}'
+  complexity: 100
+- name: liquid-204
+  template: |-
+    {% liquid
+    assign
+    %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in ""'
+  complexity: 100
+- name: liquid-205
+  template: |-
+    {% liquid
+    assign x = 1
+    assign
+    %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
+      = [source] in ""'
+  complexity: 100
+- name: liquid-207
+  template: |-
+    {% liquid
+    for i
+    %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: For loops require an ''in'' clause in "i"'
+  complexity: 100
+- name: liquid-208
+  template: |-
+    {% liquid
+    for i in (1..3)
+    echo i
+    %}
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''for'' tag was never closed'
+  complexity: 100

--- a/specs/parser_errors/liquid.yml
+++ b/specs/parser_errors/liquid.yml
@@ -6,7 +6,7 @@
     %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Unknown tag ''hello'''
+    - Unknown tag 'hello'
   complexity: 100
 - name: liquid-201
   template: |-
@@ -15,7 +15,7 @@
     %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Unknown tag ''foobar'''
+    - Unknown tag 'foobar'
   complexity: 100
 - name: liquid-203
   template: |-
@@ -24,8 +24,7 @@
     %}
   errors:
     parse_error:
-    - 'Liquid syntax error: ''endfor'' is not a valid delimiter for liquid tags. use
-      %}'
+    - "'endfor' is not a valid delimiter for liquid tags. use %}"
   complexity: 100
 - name: liquid-204
   template: |-
@@ -34,8 +33,7 @@
     %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in ""'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: liquid-205
   template: |-
@@ -45,8 +43,7 @@
     %}
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''assign'' - Valid syntax: assign [var]
-      = [source] in ""'
+    - Syntax Error in 'assign'
   complexity: 100
 - name: liquid-207
   template: |-
@@ -55,7 +52,7 @@
     %}
   errors:
     parse_error:
-    - 'Liquid syntax error: For loops require an ''in'' clause in "i"'
+    - For loops require an 'in' clause
   complexity: 100
 - name: liquid-208
   template: |-
@@ -65,5 +62,5 @@
     %}
   errors:
     parse_error:
-    - 'Liquid syntax error: ''for'' tag was never closed'
+    - "'for' tag was never closed"
   complexity: 100

--- a/specs/parser_errors/raw.yml
+++ b/specs/parser_errors/raw.yml
@@ -3,103 +3,103 @@
   template: "{% raw foo %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-002
   template: "{% raw foo bar %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-003
   template: "{% raw 123 %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-004
   template: "{% raw 'hello' %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-005
   template: "{% raw == %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-006
   template: "{% raw | %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-007
   template: "{% raw @#$ %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-008
   template: "{% raw . %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-009
   template: "{% raw : %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-010
   template: "{% raw x = 1 %}{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-011
   template: "{%- raw foo -%}{%- endraw -%}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-012
   template: "{% raw foo %}content"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+    - Syntax Error in 'raw'
   complexity: 100
 - name: raw-020
   template: "{% raw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: raw-021
   template: "{% raw %}some content"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: raw-022
   template: "{% raw %}{% if true %}{% endif %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: raw-023
   template: "{%- raw -%}content"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: raw-024
   template: "{% raw %}a{% endraw %}{% raw %}b"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: raw-025
   template: |-
@@ -108,17 +108,17 @@
     {% raw %}content
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: raw-026
   template: "{% raw %}{% raw %}content"
   errors:
     parse_error:
-    - 'Liquid syntax error: ''raw'' tag was never closed'
+    - "'raw' tag was never closed"
   complexity: 100
 - name: raw-107
   template: "{% endraw %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unknown tag ''endraw'''
+    - Unknown tag 'endraw'
   complexity: 100

--- a/specs/parser_errors/raw.yml
+++ b/specs/parser_errors/raw.yml
@@ -1,0 +1,124 @@
+---
+- name: raw-001
+  template: "{% raw foo %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-002
+  template: "{% raw foo bar %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-003
+  template: "{% raw 123 %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-004
+  template: "{% raw 'hello' %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-005
+  template: "{% raw == %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-006
+  template: "{% raw | %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-007
+  template: "{% raw @#$ %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-008
+  template: "{% raw . %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-009
+  template: "{% raw : %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-010
+  template: "{% raw x = 1 %}{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-011
+  template: "{%- raw foo -%}{%- endraw -%}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-012
+  template: "{% raw foo %}content"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax Error in ''raw'' - Valid syntax: raw'
+  complexity: 100
+- name: raw-020
+  template: "{% raw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: raw-021
+  template: "{% raw %}some content"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: raw-022
+  template: "{% raw %}{% if true %}{% endif %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: raw-023
+  template: "{%- raw -%}content"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: raw-024
+  template: "{% raw %}a{% endraw %}{% raw %}b"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: raw-025
+  template: |-
+    hello
+
+    {% raw %}content
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: raw-026
+  template: "{% raw %}{% raw %}content"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: ''raw'' tag was never closed'
+  complexity: 100
+- name: raw-107
+  template: "{% endraw %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unknown tag ''endraw'''
+  complexity: 100

--- a/specs/parser_errors/render.yml
+++ b/specs/parser_errors/render.yml
@@ -1,0 +1,794 @@
+---
+- name: render-mut-alias_name-eos
+  template: "{% render 'snippet' as %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "''snippet'' as"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-ampersand
+  template: "{% render 'snippet' as & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "''snippet'' as &"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-asterisk
+  template: "{% render 'snippet' as * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "''snippet'' as *"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-at
+  template: "{% render 'snippet' as @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "''snippet'' as @"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-backslash
+  template: "{% render 'snippet' as \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "''snippet'' as \"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-backtick
+  template: "{% render 'snippet' as ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "''snippet'' as `"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-caret
+  template: "{% render 'snippet' as ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' as ^"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-dollar
+  template: "{% render 'snippet' as $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "''snippet'' as $"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-hash
+  template: "{% render 'snippet' as # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "''snippet'' as #"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-semicolon
+  template: "{% render 'snippet' as ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "''snippet'' as ;"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-tilde
+  template: "{% render 'snippet' as ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' as ~"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' as "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "''snippet'' as "hello"'
+  complexity: 100
+- name: render-mut-alias_name-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' as 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''snippet'' as ''hello"'
+  complexity: 100
+- name: render-mut-alias_name-number
+  template: "{% render 'snippet' as 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "''snippet'' as 42"'
+  complexity: 100
+- name: render-mut-binding_keyword-id
+  template: "{% render 'snippet' with %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
+      with"'
+  complexity: 100
+- name: render-mut-binding_value-bare_bracket
+  template: "{% render 'snippet' for [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "''snippet'' for [0]"'
+  complexity: 100
+- name: render-mut-binding_value-close_round-004
+  template: "{% render 'snippet' for ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
+      for )"'
+  complexity: 100
+- name: render-mut-binding_value-close_square-003
+  template: "{% render 'snippet' for ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "''snippet''
+      for ]"'
+  complexity: 100
+- name: render-mut-binding_value-colon-002
+  template: "{% render 'snippet' for : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "''snippet''
+      for :"'
+  complexity: 100
+- name: render-mut-binding_value-comma-001
+  template: "{% render 'snippet' for , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
+      for ,"'
+  complexity: 100
+- name: render-mut-binding_value-comparison-009
+  template: "{% render 'snippet' for == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "''snippet''
+      for =="'
+  complexity: 100
+- name: render-mut-binding_value-comparison-010
+  template: "{% render 'snippet' for != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "''snippet''
+      for !="'
+  complexity: 100
+- name: render-mut-binding_value-comparison-011
+  template: "{% render 'snippet' for < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "''snippet''
+      for <"'
+  complexity: 100
+- name: render-mut-binding_value-comparison-012
+  template: "{% render 'snippet' for > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "''snippet''
+      for >"'
+  complexity: 100
+- name: render-mut-binding_value-comparison-013
+  template: "{% render 'snippet' for <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "''snippet''
+      for <="'
+  complexity: 100
+- name: render-mut-binding_value-comparison-014
+  template: "{% render 'snippet' for >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "''snippet''
+      for >="'
+  complexity: 100
+- name: render-mut-binding_value-comparison-015
+  template: "{% render 'snippet' for contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "''snippet'' for contains"'
+  complexity: 100
+- name: render-mut-binding_value-dash-006
+  template: "{% render 'snippet' for - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "''snippet''
+      for -"'
+  complexity: 100
+- name: render-mut-binding_value-dot-007
+  template: "{% render 'snippet' for . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "''snippet''
+      for ."'
+  complexity: 100
+- name: render-mut-binding_value-dotdot-008
+  template: "{% render 'snippet' for .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "''snippet''
+      for .."'
+  complexity: 100
+- name: render-mut-binding_value-eos-016
+  template: "{% render 'snippet' for %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
+      for"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-ampersand
+  template: "{% render 'snippet' for & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "''snippet'' for &"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-asterisk
+  template: "{% render 'snippet' for * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "''snippet'' for *"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-at
+  template: "{% render 'snippet' for @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "''snippet'' for @"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-backslash
+  template: "{% render 'snippet' for \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "''snippet'' for \"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-backtick
+  template: "{% render 'snippet' for ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "''snippet'' for `"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-caret
+  template: "{% render 'snippet' for ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' for ^"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-dollar
+  template: "{% render 'snippet' for $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "''snippet'' for $"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-hash
+  template: "{% render 'snippet' for # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "''snippet'' for #"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-semicolon
+  template: "{% render 'snippet' for ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "''snippet'' for ;"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-tilde
+  template: "{% render 'snippet' for ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' for ~"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' for "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "''snippet'' for "hello"'
+  complexity: 100
+- name: render-mut-binding_value-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' for 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''snippet'' for ''hello"'
+  complexity: 100
+- name: render-mut-binding_value-lookup-bracket_wrong_content
+  template: "{% render 'snippet' for x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
+      for x[,]"'
+  complexity: 100
+- name: render-mut-binding_value-lookup-dot_number
+  template: "{% render 'snippet' for x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "''snippet'' for x.123"'
+  complexity: 100
+- name: render-mut-binding_value-lookup-dot_string
+  template: '{% render ''snippet'' for x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "''snippet'' for x."y""'
+  complexity: 100
+- name: render-mut-binding_value-lookup-range_bad_separator
+  template: "{% render 'snippet' for (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "''snippet'' for (1,
+      5)"'
+  complexity: 100
+- name: render-mut-binding_value-lookup-range_missing_end
+  template: "{% render 'snippet' for (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
+      for (1..)"'
+  complexity: 100
+- name: render-mut-binding_value-lookup-trailing_dot
+  template: "{% render 'snippet' for x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "''snippet'' for
+      x."'
+  complexity: 100
+- name: render-mut-binding_value-lookup-unclosed_bracket
+  template: "{% render 'snippet' for x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "''snippet''
+      for x[0"'
+  complexity: 100
+- name: render-mut-binding_value-lookup-unclosed_range
+  template: "{% render 'snippet' for (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "''snippet''
+      for (1..5"'
+  complexity: 100
+- name: render-mut-binding_value-pipe-000
+  template: "{% render 'snippet' for | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "''snippet''
+      for |"'
+  complexity: 100
+- name: render-mut-binding_value-question-005
+  template: "{% render 'snippet' for ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "''snippet''
+      for ?"'
+  complexity: 100
+- name: render-mut-end-trail-close_round
+  template: "{% render 'snippet' ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "''snippet''
+      )"'
+  complexity: 100
+- name: render-mut-end-trail-close_square
+  template: "{% render 'snippet' ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "''snippet''
+      ]"'
+  complexity: 100
+- name: render-mut-end-trail-colon
+  template: "{% render 'snippet' : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "''snippet''
+      :"'
+  complexity: 100
+- name: render-mut-end-trail-comparison
+  template: "{% render 'snippet' == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "''snippet''
+      =="'
+  complexity: 100
+- name: render-mut-end-trail-dash
+  template: "{% render 'snippet' - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "''snippet''
+      -"'
+  complexity: 100
+- name: render-mut-end-trail-dot
+  template: "{% render 'snippet' . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dot in "''snippet'' ."'
+  complexity: 100
+- name: render-mut-end-trail-id
+  template: "{% render 'snippet' extra %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found end_of_string in "''snippet''
+      extra"'
+  complexity: 100
+- name: render-mut-end-trail-number
+  template: "{% render 'snippet' 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "''snippet''
+      42"'
+  complexity: 100
+- name: render-mut-end-trail-open_round
+  template: "{% render 'snippet' ( %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "''snippet''
+      ("'
+  complexity: 100
+- name: render-mut-end-trail-open_square
+  template: "{% render 'snippet' [ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_square in "''snippet''
+      ["'
+  complexity: 100
+- name: render-mut-end-trail-pipe
+  template: "{% render 'snippet' | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "''snippet''
+      |"'
+  complexity: 100
+- name: render-mut-end-trail-question
+  template: "{% render 'snippet' ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "''snippet''
+      ?"'
+  complexity: 100
+- name: render-mut-end-trail-string
+  template: "{% render 'snippet' 'hi' %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "''snippet''
+      ''hi''"'
+  complexity: 100
+- name: render-mut-kwarg_colon-eos
+  template: "{% render 'snippet' step , x %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x"'
+  complexity: 100
+- name: render-mut-kwarg_colon-number
+  template: "{% render 'snippet' step , x 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x 42"'
+  complexity: 100
+- name: render-mut-kwarg_name-eos
+  template: "{% render 'snippet' step , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-ampersand
+  template: "{% render 'snippet' step , & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "''snippet'' step , &"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-asterisk
+  template: "{% render 'snippet' step , * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "''snippet'' step , *"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-at
+  template: "{% render 'snippet' step , @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "''snippet'' step , @"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-backslash
+  template: "{% render 'snippet' step , \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "''snippet'' step , \"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-backtick
+  template: "{% render 'snippet' step , ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "''snippet'' step , `"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-caret
+  template: "{% render 'snippet' step , ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , ^"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-dollar
+  template: "{% render 'snippet' step , $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "''snippet'' step , $"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-hash
+  template: "{% render 'snippet' step , # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "''snippet'' step , #"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-semicolon
+  template: "{% render 'snippet' step , ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "''snippet'' step , ;"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-tilde
+  template: "{% render 'snippet' step , ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , ~"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' step , "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "''snippet'' step , "hello"'
+  complexity: 100
+- name: render-mut-kwarg_name-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' step , 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''snippet'' step , ''hello"'
+  complexity: 100
+- name: render-mut-kwarg_name-number
+  template: "{% render 'snippet' step , 42 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      42"'
+  complexity: 100
+- name: render-mut-kwarg_value-bare_bracket
+  template: "{% render 'snippet' step , x : [0] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : [0]"'
+  complexity: 100
+- name: render-mut-kwarg_value-close_round-004
+  template: "{% render 'snippet' step , x : ) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : )"'
+  complexity: 100
+- name: render-mut-kwarg_value-close_square-003
+  template: "{% render 'snippet' step , x : ] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : ]"'
+  complexity: 100
+- name: render-mut-kwarg_value-colon-002
+  template: "{% render 'snippet' step , x : : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : :"'
+  complexity: 100
+- name: render-mut-kwarg_value-comma-001
+  template: "{% render 'snippet' step , x : , %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : ,"'
+  complexity: 100
+- name: render-mut-kwarg_value-comparison-009
+  template: "{% render 'snippet' step , x : == %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : =="'
+  complexity: 100
+- name: render-mut-kwarg_value-comparison-010
+  template: "{% render 'snippet' step , x : != %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : !="'
+  complexity: 100
+- name: render-mut-kwarg_value-comparison-011
+  template: "{% render 'snippet' step , x : < %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : <"'
+  complexity: 100
+- name: render-mut-kwarg_value-comparison-012
+  template: "{% render 'snippet' step , x : > %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : >"'
+  complexity: 100
+- name: render-mut-kwarg_value-comparison-013
+  template: "{% render 'snippet' step , x : <= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : <="'
+  complexity: 100
+- name: render-mut-kwarg_value-comparison-014
+  template: "{% render 'snippet' step , x : >= %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : >="'
+  complexity: 100
+- name: render-mut-kwarg_value-comparison-015
+  template: "{% render 'snippet' step , x : contains %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : contains"'
+  complexity: 100
+- name: render-mut-kwarg_value-dash-006
+  template: "{% render 'snippet' step , x : - %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : -"'
+  complexity: 100
+- name: render-mut-kwarg_value-dot-007
+  template: "{% render 'snippet' step , x : . %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : ."'
+  complexity: 100
+- name: render-mut-kwarg_value-dotdot-008
+  template: "{% render 'snippet' step , x : .. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : .."'
+  complexity: 100
+- name: render-mut-kwarg_value-eos-016
+  template: "{% render 'snippet' step , x : %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x :"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-ampersand
+  template: "{% render 'snippet' step , x : & %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "''snippet'' step , x : &"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-asterisk
+  template: "{% render 'snippet' step , x : * %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "''snippet'' step , x : *"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-at
+  template: "{% render 'snippet' step , x : @ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "''snippet'' step , x : @"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-backslash
+  template: "{% render 'snippet' step , x : \\ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "''snippet'' step , x : \"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-backtick
+  template: "{% render 'snippet' step , x : ` %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "''snippet'' step , x : `"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-caret
+  template: "{% render 'snippet' step , x : ^ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , x : ^"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-dollar
+  template: "{% render 'snippet' step , x : $ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "''snippet'' step , x : $"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-hash
+  template: "{% render 'snippet' step , x : # %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "''snippet'' step , x : #"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-semicolon
+  template: "{% render 'snippet' step , x : ; %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "''snippet'' step , x : ;"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-tilde
+  template: "{% render 'snippet' step , x : ~ %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , x : ~"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{% render ''snippet'' step , x : "hello %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "''snippet'' step , x : "hello"'
+  complexity: 100
+- name: render-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{% render 'snippet' step , x : 'hello %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''snippet'' step , x : ''hello"'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{% render 'snippet' step , x : x[,] %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : x[,]"'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-dot_number
+  template: "{% render 'snippet' step , x : x.123 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : x.123"'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-dot_string
+  template: '{% render ''snippet'' step , x : x."y" %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : x."y""'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-range_bad_separator
+  template: "{% render 'snippet' step , x : (1, 5) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : (1, 5)"'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-range_missing_end
+  template: "{% render 'snippet' step , x : (1..) %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : (1..)"'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-trailing_dot
+  template: "{% render 'snippet' step , x : x. %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : x."'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{% render 'snippet' step , x : x[0 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : x[0"'
+  complexity: 100
+- name: render-mut-kwarg_value-lookup-unclosed_range
+  template: "{% render 'snippet' step , x : (1..5 %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : (1..5"'
+  complexity: 100
+- name: render-mut-kwarg_value-pipe-000
+  template: "{% render 'snippet' step , x : | %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : |"'
+  complexity: 100
+- name: render-mut-kwarg_value-question-005
+  template: "{% render 'snippet' step , x : ? %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
+      x : ?"'
+  complexity: 100
+- name: render-mut-template_name-eos
+  template: "{% render  %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Syntax error in tag ''render'' - Expected a string or
+      identifier, found nothing in ""'
+  complexity: 100

--- a/specs/parser_errors/render.yml
+++ b/specs/parser_errors/render.yml
@@ -3,792 +3,725 @@
   template: "{% render 'snippet' as %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "''snippet'' as"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: render-mut-alias_name-lexerr-ampersand
   template: "{% render 'snippet' as & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "''snippet'' as &"'
+    - Unexpected character &
   complexity: 100
 - name: render-mut-alias_name-lexerr-asterisk
   template: "{% render 'snippet' as * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "''snippet'' as *"'
+    - Unexpected character *
   complexity: 100
 - name: render-mut-alias_name-lexerr-at
   template: "{% render 'snippet' as @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "''snippet'' as @"'
+    - Unexpected character @
   complexity: 100
 - name: render-mut-alias_name-lexerr-backslash
   template: "{% render 'snippet' as \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "''snippet'' as \"'
+    - Unexpected character \
   complexity: 100
 - name: render-mut-alias_name-lexerr-backtick
   template: "{% render 'snippet' as ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "''snippet'' as `"'
+    - Unexpected character `
   complexity: 100
 - name: render-mut-alias_name-lexerr-caret
   template: "{% render 'snippet' as ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' as ^"'
+    - Unexpected character ^
   complexity: 100
 - name: render-mut-alias_name-lexerr-dollar
   template: "{% render 'snippet' as $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "''snippet'' as $"'
+    - Unexpected character $
   complexity: 100
 - name: render-mut-alias_name-lexerr-hash
   template: "{% render 'snippet' as # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "''snippet'' as #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: render-mut-alias_name-lexerr-semicolon
   template: "{% render 'snippet' as ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "''snippet'' as ;"'
+    - Unexpected character ;
   complexity: 100
 - name: render-mut-alias_name-lexerr-tilde
   template: "{% render 'snippet' as ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' as ~"'
+    - Unexpected character ~
   complexity: 100
 - name: render-mut-alias_name-lexerr-unclosed_double_quote
   template: '{% render ''snippet'' as "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "''snippet'' as "hello"'
+    - Unexpected character "
   complexity: 100
 - name: render-mut-alias_name-lexerr-unclosed_single_quote
   template: "{% render 'snippet' as 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''snippet'' as ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: render-mut-alias_name-number
   template: "{% render 'snippet' as 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "''snippet'' as 42"'
+    - Expected id but found number
   complexity: 100
 - name: render-mut-binding_keyword-id
   template: "{% render 'snippet' with %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
-      with"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: render-mut-binding_value-bare_bracket
   template: "{% render 'snippet' for [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "''snippet'' for [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: render-mut-binding_value-close_round-004
   template: "{% render 'snippet' for ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
-      for )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-close_square-003
   template: "{% render 'snippet' for ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "''snippet''
-      for ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-colon-002
   template: "{% render 'snippet' for : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "''snippet''
-      for :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comma-001
   template: "{% render 'snippet' for , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
-      for ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comparison-009
   template: "{% render 'snippet' for == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "''snippet''
-      for =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comparison-010
   template: "{% render 'snippet' for != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "''snippet''
-      for !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comparison-011
   template: "{% render 'snippet' for < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "''snippet''
-      for <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comparison-012
   template: "{% render 'snippet' for > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "''snippet''
-      for >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comparison-013
   template: "{% render 'snippet' for <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "''snippet''
-      for <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comparison-014
   template: "{% render 'snippet' for >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "''snippet''
-      for >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-comparison-015
   template: "{% render 'snippet' for contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "''snippet'' for contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-dash-006
   template: "{% render 'snippet' for - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "''snippet''
-      for -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-dot-007
   template: "{% render 'snippet' for . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "''snippet''
-      for ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-dotdot-008
   template: "{% render 'snippet' for .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "''snippet''
-      for .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-eos-016
   template: "{% render 'snippet' for %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "''snippet''
-      for"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: render-mut-binding_value-lexerr-ampersand
   template: "{% render 'snippet' for & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "''snippet'' for &"'
+    - Unexpected character &
   complexity: 100
 - name: render-mut-binding_value-lexerr-asterisk
   template: "{% render 'snippet' for * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "''snippet'' for *"'
+    - Unexpected character *
   complexity: 100
 - name: render-mut-binding_value-lexerr-at
   template: "{% render 'snippet' for @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "''snippet'' for @"'
+    - Unexpected character @
   complexity: 100
 - name: render-mut-binding_value-lexerr-backslash
   template: "{% render 'snippet' for \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "''snippet'' for \"'
+    - Unexpected character \
   complexity: 100
 - name: render-mut-binding_value-lexerr-backtick
   template: "{% render 'snippet' for ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "''snippet'' for `"'
+    - Unexpected character `
   complexity: 100
 - name: render-mut-binding_value-lexerr-caret
   template: "{% render 'snippet' for ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' for ^"'
+    - Unexpected character ^
   complexity: 100
 - name: render-mut-binding_value-lexerr-dollar
   template: "{% render 'snippet' for $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "''snippet'' for $"'
+    - Unexpected character $
   complexity: 100
 - name: render-mut-binding_value-lexerr-hash
   template: "{% render 'snippet' for # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "''snippet'' for #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: render-mut-binding_value-lexerr-semicolon
   template: "{% render 'snippet' for ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "''snippet'' for ;"'
+    - Unexpected character ;
   complexity: 100
 - name: render-mut-binding_value-lexerr-tilde
   template: "{% render 'snippet' for ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' for ~"'
+    - Unexpected character ~
   complexity: 100
 - name: render-mut-binding_value-lexerr-unclosed_double_quote
   template: '{% render ''snippet'' for "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "''snippet'' for "hello"'
+    - Unexpected character "
   complexity: 100
 - name: render-mut-binding_value-lexerr-unclosed_single_quote
   template: "{% render 'snippet' for 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''snippet'' for ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: render-mut-binding_value-lookup-bracket_wrong_content
   template: "{% render 'snippet' for x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "''snippet''
-      for x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-lookup-dot_number
   template: "{% render 'snippet' for x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "''snippet'' for x.123"'
+    - Expected id but found number
   complexity: 100
 - name: render-mut-binding_value-lookup-dot_string
   template: '{% render ''snippet'' for x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "''snippet'' for x."y""'
+    - Expected id but found string
   complexity: 100
 - name: render-mut-binding_value-lookup-range_bad_separator
   template: "{% render 'snippet' for (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "''snippet'' for (1,
-      5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: render-mut-binding_value-lookup-range_missing_end
   template: "{% render 'snippet' for (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "''snippet''
-      for (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-lookup-trailing_dot
   template: "{% render 'snippet' for x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "''snippet'' for
-      x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: render-mut-binding_value-lookup-unclosed_bracket
   template: "{% render 'snippet' for x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "''snippet''
-      for x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: render-mut-binding_value-lookup-unclosed_range
   template: "{% render 'snippet' for (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "''snippet''
-      for (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: render-mut-binding_value-pipe-000
   template: "{% render 'snippet' for | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "''snippet''
-      for |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: render-mut-binding_value-question-005
   template: "{% render 'snippet' for ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "''snippet''
-      for ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: render-mut-end-trail-close_round
   template: "{% render 'snippet' ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "''snippet''
-      )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: render-mut-end-trail-close_square
   template: "{% render 'snippet' ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "''snippet''
-      ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: render-mut-end-trail-colon
   template: "{% render 'snippet' : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "''snippet''
-      :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: render-mut-end-trail-comparison
   template: "{% render 'snippet' == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "''snippet''
-      =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: render-mut-end-trail-dash
   template: "{% render 'snippet' - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "''snippet''
-      -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: render-mut-end-trail-dot
   template: "{% render 'snippet' . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dot in "''snippet'' ."'
+    - Expected end_of_string but found dot
   complexity: 100
 - name: render-mut-end-trail-id
   template: "{% render 'snippet' extra %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found end_of_string in "''snippet''
-      extra"'
+    - Expected colon but found end_of_string
   complexity: 100
 - name: render-mut-end-trail-number
   template: "{% render 'snippet' 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "''snippet''
-      42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: render-mut-end-trail-open_round
   template: "{% render 'snippet' ( %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "''snippet''
-      ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: render-mut-end-trail-open_square
   template: "{% render 'snippet' [ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_square in "''snippet''
-      ["'
+    - Expected end_of_string but found open_square
   complexity: 100
 - name: render-mut-end-trail-pipe
   template: "{% render 'snippet' | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "''snippet''
-      |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: render-mut-end-trail-question
   template: "{% render 'snippet' ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "''snippet''
-      ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: render-mut-end-trail-string
   template: "{% render 'snippet' 'hi' %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "''snippet''
-      ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: render-mut-kwarg_colon-eos
   template: "{% render 'snippet' step , x %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_colon-number
   template: "{% render 'snippet' step , x 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x 42"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_name-eos
   template: "{% render 'snippet' step , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-ampersand
   template: "{% render 'snippet' step , & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "''snippet'' step , &"'
+    - Unexpected character &
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-asterisk
   template: "{% render 'snippet' step , * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "''snippet'' step , *"'
+    - Unexpected character *
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-at
   template: "{% render 'snippet' step , @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "''snippet'' step , @"'
+    - Unexpected character @
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-backslash
   template: "{% render 'snippet' step , \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "''snippet'' step , \"'
+    - Unexpected character \
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-backtick
   template: "{% render 'snippet' step , ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "''snippet'' step , `"'
+    - Unexpected character `
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-caret
   template: "{% render 'snippet' step , ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , ^"'
+    - Unexpected character ^
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-dollar
   template: "{% render 'snippet' step , $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "''snippet'' step , $"'
+    - Unexpected character $
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-hash
   template: "{% render 'snippet' step , # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "''snippet'' step , #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-semicolon
   template: "{% render 'snippet' step , ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "''snippet'' step , ;"'
+    - Unexpected character ;
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-tilde
   template: "{% render 'snippet' step , ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , ~"'
+    - Unexpected character ~
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-unclosed_double_quote
   template: '{% render ''snippet'' step , "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "''snippet'' step , "hello"'
+    - Unexpected character "
   complexity: 100
 - name: render-mut-kwarg_name-lexerr-unclosed_single_quote
   template: "{% render 'snippet' step , 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''snippet'' step , ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: render-mut-kwarg_name-number
   template: "{% render 'snippet' step , 42 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      42"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-bare_bracket
   template: "{% render 'snippet' step , x : [0] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : [0]"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-close_round-004
   template: "{% render 'snippet' step , x : ) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : )"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-close_square-003
   template: "{% render 'snippet' step , x : ] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : ]"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-colon-002
   template: "{% render 'snippet' step , x : : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : :"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comma-001
   template: "{% render 'snippet' step , x : , %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : ,"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comparison-009
   template: "{% render 'snippet' step , x : == %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : =="'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comparison-010
   template: "{% render 'snippet' step , x : != %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : !="'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comparison-011
   template: "{% render 'snippet' step , x : < %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : <"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comparison-012
   template: "{% render 'snippet' step , x : > %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : >"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comparison-013
   template: "{% render 'snippet' step , x : <= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : <="'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comparison-014
   template: "{% render 'snippet' step , x : >= %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : >="'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-comparison-015
   template: "{% render 'snippet' step , x : contains %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : contains"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-dash-006
   template: "{% render 'snippet' step , x : - %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : -"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-dot-007
   template: "{% render 'snippet' step , x : . %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : ."'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-dotdot-008
   template: "{% render 'snippet' step , x : .. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : .."'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-eos-016
   template: "{% render 'snippet' step , x : %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x :"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-ampersand
   template: "{% render 'snippet' step , x : & %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "''snippet'' step , x : &"'
+    - Unexpected character &
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-asterisk
   template: "{% render 'snippet' step , x : * %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "''snippet'' step , x : *"'
+    - Unexpected character *
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-at
   template: "{% render 'snippet' step , x : @ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "''snippet'' step , x : @"'
+    - Unexpected character @
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-backslash
   template: "{% render 'snippet' step , x : \\ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "''snippet'' step , x : \"'
+    - Unexpected character \
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-backtick
   template: "{% render 'snippet' step , x : ` %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "''snippet'' step , x : `"'
+    - Unexpected character `
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-caret
   template: "{% render 'snippet' step , x : ^ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "''snippet'' step , x : ^"'
+    - Unexpected character ^
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-dollar
   template: "{% render 'snippet' step , x : $ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "''snippet'' step , x : $"'
+    - Unexpected character $
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-hash
   template: "{% render 'snippet' step , x : # %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "''snippet'' step , x : #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-semicolon
   template: "{% render 'snippet' step , x : ; %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "''snippet'' step , x : ;"'
+    - Unexpected character ;
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-tilde
   template: "{% render 'snippet' step , x : ~ %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "''snippet'' step , x : ~"'
+    - Unexpected character ~
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-unclosed_double_quote
   template: '{% render ''snippet'' step , x : "hello %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "''snippet'' step , x : "hello"'
+    - Unexpected character "
   complexity: 100
 - name: render-mut-kwarg_value-lexerr-unclosed_single_quote
   template: "{% render 'snippet' step , x : 'hello %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''snippet'' step , x : ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: render-mut-kwarg_value-lookup-bracket_wrong_content
   template: "{% render 'snippet' step , x : x[,] %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : x[,]"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lookup-dot_number
   template: "{% render 'snippet' step , x : x.123 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : x.123"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lookup-dot_string
   template: '{% render ''snippet'' step , x : x."y" %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : x."y""'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lookup-range_bad_separator
   template: "{% render 'snippet' step , x : (1, 5) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : (1, 5)"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lookup-range_missing_end
   template: "{% render 'snippet' step , x : (1..) %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : (1..)"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lookup-trailing_dot
   template: "{% render 'snippet' step , x : x. %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : x."'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lookup-unclosed_bracket
   template: "{% render 'snippet' step , x : x[0 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : x[0"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-lookup-unclosed_range
   template: "{% render 'snippet' step , x : (1..5 %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : (1..5"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-pipe-000
   template: "{% render 'snippet' step , x : | %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : |"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-kwarg_value-question-005
   template: "{% render 'snippet' step , x : ? %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected colon but found comma in "''snippet'' step ,
-      x : ?"'
+    - Expected colon but found comma
   complexity: 100
 - name: render-mut-template_name-eos
   template: "{% render  %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Syntax error in tag ''render'' - Expected a string or
-      identifier, found nothing in ""'
+    - Syntax error in tag 'render' - Expected a string or identifier, found nothing
   complexity: 100

--- a/specs/parser_errors/suite.yml
+++ b/specs/parser_errors/suite.yml
@@ -1,0 +1,16 @@
+---
+name: "Parser Errors"
+description: "Parse error specs for error_mode: :strict2 syntax validation"
+
+default: false
+
+hint: |
+  These specs test that invalid Liquid syntax produces the correct parse errors
+  under error_mode: :strict2.
+
+features:
+  - strict2_parsing
+
+defaults:
+  error_mode: :strict2
+  render_errors: false

--- a/specs/parser_errors/table_row.yml
+++ b/specs/parser_errors/table_row.yml
@@ -3,695 +3,677 @@
   template: "{% tablerow x in x step , %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step ,"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_colon-number
   template: "{% tablerow x in x step , 42 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , 42"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-bare_bracket
   template: "{% tablerow x in x step , : [0] %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : [0]"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-close_round-004
   template: "{% tablerow x in x step , : ) %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : )"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-close_square-003
   template: "{% tablerow x in x step , : ] %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : ]"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-colon-002
   template: "{% tablerow x in x step , : : %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : :"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comma-001
   template: "{% tablerow x in x step , : , %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : ,"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comparison-009
   template: "{% tablerow x in x step , : == %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : =="'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comparison-010
   template: "{% tablerow x in x step , : != %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : !="'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comparison-011
   template: "{% tablerow x in x step , : < %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : <"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comparison-012
   template: "{% tablerow x in x step , : > %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : >"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comparison-013
   template: "{% tablerow x in x step , : <= %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : <="'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comparison-014
   template: "{% tablerow x in x step , : >= %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : >="'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-comparison-015
   template: "{% tablerow x in x step , : contains %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : contains"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-dash-006
   template: "{% tablerow x in x step , : - %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : -"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-dot-007
   template: "{% tablerow x in x step , : . %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : ."'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-dotdot-008
   template: "{% tablerow x in x step , : .. %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : .."'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-eos-016
   template: "{% tablerow x in x step , : %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , :"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-ampersand
   template: "{% tablerow x in x step , : & %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x in x step , : &"'
+    - Unexpected character &
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-asterisk
   template: "{% tablerow x in x step , : * %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x in x step , : *"'
+    - Unexpected character *
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-at
   template: "{% tablerow x in x step , : @ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x in x step , : @"'
+    - Unexpected character @
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-backslash
   template: "{% tablerow x in x step , : \\ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x in x step , : \"'
+    - Unexpected character \
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-backtick
   template: "{% tablerow x in x step , : ` %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x in x step , : `"'
+    - Unexpected character `
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-caret
   template: "{% tablerow x in x step , : ^ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x in x step , : ^"'
+    - Unexpected character ^
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-dollar
   template: "{% tablerow x in x step , : $ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x in x step , : $"'
+    - Unexpected character $
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-hash
   template: "{% tablerow x in x step , : # %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x in x step , : #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-semicolon
   template: "{% tablerow x in x step , : ; %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x in x step , : ;"'
+    - Unexpected character ;
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-tilde
   template: "{% tablerow x in x step , : ~ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x in x step , : ~"'
+    - Unexpected character ~
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-unclosed_double_quote
   template: '{% tablerow x in x step , : "hello %}{% endtablerow %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x in x step , : "hello"'
+    - Unexpected character "
   complexity: 100
 - name: table_row-mut-attr_value-lexerr-unclosed_single_quote
   template: "{% tablerow x in x step , : 'hello %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x in x step , : ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: table_row-mut-attr_value-lookup-bracket_wrong_content
   template: "{% tablerow x in x step , : x[,] %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : x[,]"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lookup-dot_number
   template: "{% tablerow x in x step , : x.123 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : x.123"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lookup-dot_string
   template: '{% tablerow x in x step , : x."y" %}{% endtablerow %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : x."y""'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lookup-range_bad_separator
   template: "{% tablerow x in x step , : (1, 5) %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : (1, 5)"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lookup-range_missing_end
   template: "{% tablerow x in x step , : (1..) %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : (1..)"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lookup-trailing_dot
   template: "{% tablerow x in x step , : x. %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : x."'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lookup-unclosed_bracket
   template: "{% tablerow x in x step , : x[0 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : x[0"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-lookup-unclosed_range
   template: "{% tablerow x in x step , : (1..5 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : (1..5"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-pipe-000
   template: "{% tablerow x in x step , : | %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : |"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-attr_value-question-005
   template: "{% tablerow x in x step , : ? %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step , : ?"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-collection-bare_bracket
   template: "{% tablerow x in [0] %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x in [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: table_row-mut-collection-close_round-004
   template: "{% tablerow x in ) %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
-      )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-close_square-003
   template: "{% tablerow x in ] %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x in
-      ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-colon-002
   template: "{% tablerow x in : %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x in :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comma-001
   template: "{% tablerow x in , %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comparison-009
   template: "{% tablerow x in == %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x in
-      =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comparison-010
   template: "{% tablerow x in != %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x in
-      !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comparison-011
   template: "{% tablerow x in < %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x in
-      <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comparison-012
   template: "{% tablerow x in > %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x in
-      >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comparison-013
   template: "{% tablerow x in <= %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x in
-      <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comparison-014
   template: "{% tablerow x in >= %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x in
-      >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-comparison-015
   template: "{% tablerow x in contains %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x in contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-dash-006
   template: "{% tablerow x in - %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x in -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-dot-007
   template: "{% tablerow x in . %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x in ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-dotdot-008
   template: "{% tablerow x in .. %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x in .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-eos-016
   template: "{% tablerow x in %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: table_row-mut-collection-lexerr-ampersand
   template: "{% tablerow x in & %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x in &"'
+    - Unexpected character &
   complexity: 100
 - name: table_row-mut-collection-lexerr-asterisk
   template: "{% tablerow x in * %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x in *"'
+    - Unexpected character *
   complexity: 100
 - name: table_row-mut-collection-lexerr-at
   template: "{% tablerow x in @ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x in @"'
+    - Unexpected character @
   complexity: 100
 - name: table_row-mut-collection-lexerr-backslash
   template: "{% tablerow x in \\ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x in \"'
+    - Unexpected character \
   complexity: 100
 - name: table_row-mut-collection-lexerr-backtick
   template: "{% tablerow x in ` %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x in `"'
+    - Unexpected character `
   complexity: 100
 - name: table_row-mut-collection-lexerr-caret
   template: "{% tablerow x in ^ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x in ^"'
+    - Unexpected character ^
   complexity: 100
 - name: table_row-mut-collection-lexerr-dollar
   template: "{% tablerow x in $ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x in $"'
+    - Unexpected character $
   complexity: 100
 - name: table_row-mut-collection-lexerr-hash
   template: "{% tablerow x in # %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x in #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: table_row-mut-collection-lexerr-semicolon
   template: "{% tablerow x in ; %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x in ;"'
+    - Unexpected character ;
   complexity: 100
 - name: table_row-mut-collection-lexerr-tilde
   template: "{% tablerow x in ~ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x in ~"'
+    - Unexpected character ~
   complexity: 100
 - name: table_row-mut-collection-lexerr-unclosed_double_quote
   template: '{% tablerow x in "hello %}{% endtablerow %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x in "hello"'
+    - Unexpected character "
   complexity: 100
 - name: table_row-mut-collection-lexerr-unclosed_single_quote
   template: "{% tablerow x in 'hello %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x in ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: table_row-mut-collection-lookup-bracket_wrong_content
   template: "{% tablerow x in x[,] %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-lookup-dot_number
   template: "{% tablerow x in x.123 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x in x.123"'
+    - Expected id but found number
   complexity: 100
 - name: table_row-mut-collection-lookup-dot_string
   template: '{% tablerow x in x."y" %}{% endtablerow %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x in x."y""'
+    - Expected id but found string
   complexity: 100
 - name: table_row-mut-collection-lookup-range_bad_separator
   template: "{% tablerow x in (1, 5) %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x in (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: table_row-mut-collection-lookup-range_missing_end
   template: "{% tablerow x in (1..) %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
-      (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-lookup-trailing_dot
   template: "{% tablerow x in x. %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x in x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: table_row-mut-collection-lookup-unclosed_bracket
   template: "{% tablerow x in x[0 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x in
-      x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: table_row-mut-collection-lookup-unclosed_range
   template: "{% tablerow x in (1..5 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x in
-      (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: table_row-mut-collection-pipe-000
   template: "{% tablerow x in | %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x in |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-collection-question-005
   template: "{% tablerow x in ? %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x in ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: table_row-mut-end-trail-close_round
   template: "{% tablerow x in x ) %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x in
-      x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: table_row-mut-end-trail-close_square
   template: "{% tablerow x in x ] %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x in
-      x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: table_row-mut-end-trail-colon
   template: "{% tablerow x in x : %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x in x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: table_row-mut-end-trail-comparison
   template: "{% tablerow x in x == %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "x in x
-      =="'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: table_row-mut-end-trail-dash
   template: "{% tablerow x in x - %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x in x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: table_row-mut-end-trail-dot
   template: "{% tablerow x in x . %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x in x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: table_row-mut-end-trail-id
   template: "{% tablerow x in x extra %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''extra'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x extra"'
+    - Invalid attribute 'extra' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-end-trail-number
   template: "{% tablerow x in x 42 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x in x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: table_row-mut-end-trail-open_round
   template: "{% tablerow x in x ( %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x in x
-      ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: table_row-mut-end-trail-open_square
   template: "{% tablerow x in x [ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in x
-      ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: table_row-mut-end-trail-pipe
   template: "{% tablerow x in x | %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x in x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: table_row-mut-end-trail-question
   template: "{% tablerow x in x ? %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x in x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: table_row-mut-end-trail-string
   template: "{% tablerow x in x 'hi' %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x in x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: table_row-mut-in_keyword-eos
   template: "{% tablerow x %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: For loops require an ''in'' clause in "x"'
+    - For loops require an 'in' clause
   complexity: 100
 - name: table_row-mut-in_keyword-id
   template: "{% tablerow x of %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: For loops require an ''in'' clause in "x of"'
+    - For loops require an 'in' clause
   complexity: 100
 - name: table_row-mut-invalid_attribute-invalid
   template: "{% tablerow x in x step , %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
-      are cols, limit, offset, and range in "x in x step ,"'
+    - Invalid attribute 'step' in tablerow loop. Valid attributes are cols, limit,
+      offset, and range
   complexity: 100
 - name: table_row-mut-variable_name-eos
   template: "{% tablerow  %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+    - Expected id but found end_of_string
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-ampersand
   template: "{% tablerow & %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-asterisk
   template: "{% tablerow * %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-at
   template: "{% tablerow @ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-backslash
   template: "{% tablerow \\ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-backtick
   template: "{% tablerow ` %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-caret
   template: "{% tablerow ^ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-dollar
   template: "{% tablerow $ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-hash
   template: "{% tablerow # %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-semicolon
   template: "{% tablerow ; %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-tilde
   template: "{% tablerow ~ %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-unclosed_double_quote
   template: '{% tablerow "hello %}{% endtablerow %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: table_row-mut-variable_name-lexerr-unclosed_single_quote
   template: "{% tablerow 'hello %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: table_row-mut-variable_name-number
   template: "{% tablerow 42 %}{% endtablerow %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "42"'
+    - Expected id but found number
   complexity: 100

--- a/specs/parser_errors/table_row.yml
+++ b/specs/parser_errors/table_row.yml
@@ -1,0 +1,697 @@
+---
+- name: table_row-mut-attr_colon-eos
+  template: "{% tablerow x in x step , %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step ,"'
+  complexity: 100
+- name: table_row-mut-attr_colon-number
+  template: "{% tablerow x in x step , 42 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , 42"'
+  complexity: 100
+- name: table_row-mut-attr_value-bare_bracket
+  template: "{% tablerow x in x step , : [0] %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : [0]"'
+  complexity: 100
+- name: table_row-mut-attr_value-close_round-004
+  template: "{% tablerow x in x step , : ) %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : )"'
+  complexity: 100
+- name: table_row-mut-attr_value-close_square-003
+  template: "{% tablerow x in x step , : ] %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : ]"'
+  complexity: 100
+- name: table_row-mut-attr_value-colon-002
+  template: "{% tablerow x in x step , : : %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : :"'
+  complexity: 100
+- name: table_row-mut-attr_value-comma-001
+  template: "{% tablerow x in x step , : , %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : ,"'
+  complexity: 100
+- name: table_row-mut-attr_value-comparison-009
+  template: "{% tablerow x in x step , : == %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : =="'
+  complexity: 100
+- name: table_row-mut-attr_value-comparison-010
+  template: "{% tablerow x in x step , : != %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : !="'
+  complexity: 100
+- name: table_row-mut-attr_value-comparison-011
+  template: "{% tablerow x in x step , : < %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : <"'
+  complexity: 100
+- name: table_row-mut-attr_value-comparison-012
+  template: "{% tablerow x in x step , : > %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : >"'
+  complexity: 100
+- name: table_row-mut-attr_value-comparison-013
+  template: "{% tablerow x in x step , : <= %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : <="'
+  complexity: 100
+- name: table_row-mut-attr_value-comparison-014
+  template: "{% tablerow x in x step , : >= %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : >="'
+  complexity: 100
+- name: table_row-mut-attr_value-comparison-015
+  template: "{% tablerow x in x step , : contains %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : contains"'
+  complexity: 100
+- name: table_row-mut-attr_value-dash-006
+  template: "{% tablerow x in x step , : - %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : -"'
+  complexity: 100
+- name: table_row-mut-attr_value-dot-007
+  template: "{% tablerow x in x step , : . %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : ."'
+  complexity: 100
+- name: table_row-mut-attr_value-dotdot-008
+  template: "{% tablerow x in x step , : .. %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : .."'
+  complexity: 100
+- name: table_row-mut-attr_value-eos-016
+  template: "{% tablerow x in x step , : %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , :"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-ampersand
+  template: "{% tablerow x in x step , : & %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x in x step , : &"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-asterisk
+  template: "{% tablerow x in x step , : * %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x in x step , : *"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-at
+  template: "{% tablerow x in x step , : @ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x in x step , : @"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-backslash
+  template: "{% tablerow x in x step , : \\ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x in x step , : \"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-backtick
+  template: "{% tablerow x in x step , : ` %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x in x step , : `"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-caret
+  template: "{% tablerow x in x step , : ^ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x in x step , : ^"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-dollar
+  template: "{% tablerow x in x step , : $ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x in x step , : $"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-hash
+  template: "{% tablerow x in x step , : # %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x in x step , : #"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-semicolon
+  template: "{% tablerow x in x step , : ; %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x in x step , : ;"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-tilde
+  template: "{% tablerow x in x step , : ~ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x in x step , : ~"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-unclosed_double_quote
+  template: '{% tablerow x in x step , : "hello %}{% endtablerow %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x in x step , : "hello"'
+  complexity: 100
+- name: table_row-mut-attr_value-lexerr-unclosed_single_quote
+  template: "{% tablerow x in x step , : 'hello %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x in x step , : ''hello"'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-bracket_wrong_content
+  template: "{% tablerow x in x step , : x[,] %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : x[,]"'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-dot_number
+  template: "{% tablerow x in x step , : x.123 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : x.123"'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-dot_string
+  template: '{% tablerow x in x step , : x."y" %}{% endtablerow %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : x."y""'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-range_bad_separator
+  template: "{% tablerow x in x step , : (1, 5) %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : (1, 5)"'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-range_missing_end
+  template: "{% tablerow x in x step , : (1..) %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : (1..)"'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-trailing_dot
+  template: "{% tablerow x in x step , : x. %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : x."'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-unclosed_bracket
+  template: "{% tablerow x in x step , : x[0 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : x[0"'
+  complexity: 100
+- name: table_row-mut-attr_value-lookup-unclosed_range
+  template: "{% tablerow x in x step , : (1..5 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : (1..5"'
+  complexity: 100
+- name: table_row-mut-attr_value-pipe-000
+  template: "{% tablerow x in x step , : | %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : |"'
+  complexity: 100
+- name: table_row-mut-attr_value-question-005
+  template: "{% tablerow x in x step , : ? %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step , : ?"'
+  complexity: 100
+- name: table_row-mut-collection-bare_bracket
+  template: "{% tablerow x in [0] %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x in [0]"'
+  complexity: 100
+- name: table_row-mut-collection-close_round-004
+  template: "{% tablerow x in ) %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
+      )"'
+  complexity: 100
+- name: table_row-mut-collection-close_square-003
+  template: "{% tablerow x in ] %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x in
+      ]"'
+  complexity: 100
+- name: table_row-mut-collection-colon-002
+  template: "{% tablerow x in : %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x in :"'
+  complexity: 100
+- name: table_row-mut-collection-comma-001
+  template: "{% tablerow x in , %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in ,"'
+  complexity: 100
+- name: table_row-mut-collection-comparison-009
+  template: "{% tablerow x in == %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x in
+      =="'
+  complexity: 100
+- name: table_row-mut-collection-comparison-010
+  template: "{% tablerow x in != %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x in
+      !="'
+  complexity: 100
+- name: table_row-mut-collection-comparison-011
+  template: "{% tablerow x in < %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x in
+      <"'
+  complexity: 100
+- name: table_row-mut-collection-comparison-012
+  template: "{% tablerow x in > %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x in
+      >"'
+  complexity: 100
+- name: table_row-mut-collection-comparison-013
+  template: "{% tablerow x in <= %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x in
+      <="'
+  complexity: 100
+- name: table_row-mut-collection-comparison-014
+  template: "{% tablerow x in >= %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x in
+      >="'
+  complexity: 100
+- name: table_row-mut-collection-comparison-015
+  template: "{% tablerow x in contains %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x in contains"'
+  complexity: 100
+- name: table_row-mut-collection-dash-006
+  template: "{% tablerow x in - %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x in -"'
+  complexity: 100
+- name: table_row-mut-collection-dot-007
+  template: "{% tablerow x in . %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x in ."'
+  complexity: 100
+- name: table_row-mut-collection-dotdot-008
+  template: "{% tablerow x in .. %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x in .."'
+  complexity: 100
+- name: table_row-mut-collection-eos-016
+  template: "{% tablerow x in %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-ampersand
+  template: "{% tablerow x in & %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x in &"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-asterisk
+  template: "{% tablerow x in * %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x in *"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-at
+  template: "{% tablerow x in @ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x in @"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-backslash
+  template: "{% tablerow x in \\ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x in \"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-backtick
+  template: "{% tablerow x in ` %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x in `"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-caret
+  template: "{% tablerow x in ^ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x in ^"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-dollar
+  template: "{% tablerow x in $ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x in $"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-hash
+  template: "{% tablerow x in # %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x in #"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-semicolon
+  template: "{% tablerow x in ; %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x in ;"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-tilde
+  template: "{% tablerow x in ~ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x in ~"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-unclosed_double_quote
+  template: '{% tablerow x in "hello %}{% endtablerow %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x in "hello"'
+  complexity: 100
+- name: table_row-mut-collection-lexerr-unclosed_single_quote
+  template: "{% tablerow x in 'hello %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x in ''hello"'
+  complexity: 100
+- name: table_row-mut-collection-lookup-bracket_wrong_content
+  template: "{% tablerow x in x[,] %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x in x[,]"'
+  complexity: 100
+- name: table_row-mut-collection-lookup-dot_number
+  template: "{% tablerow x in x.123 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x in x.123"'
+  complexity: 100
+- name: table_row-mut-collection-lookup-dot_string
+  template: '{% tablerow x in x."y" %}{% endtablerow %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x in x."y""'
+  complexity: 100
+- name: table_row-mut-collection-lookup-range_bad_separator
+  template: "{% tablerow x in (1, 5) %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x in (1, 5)"'
+  complexity: 100
+- name: table_row-mut-collection-lookup-range_missing_end
+  template: "{% tablerow x in (1..) %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x in
+      (1..)"'
+  complexity: 100
+- name: table_row-mut-collection-lookup-trailing_dot
+  template: "{% tablerow x in x. %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x in x."'
+  complexity: 100
+- name: table_row-mut-collection-lookup-unclosed_bracket
+  template: "{% tablerow x in x[0 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x in
+      x[0"'
+  complexity: 100
+- name: table_row-mut-collection-lookup-unclosed_range
+  template: "{% tablerow x in (1..5 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x in
+      (1..5"'
+  complexity: 100
+- name: table_row-mut-collection-pipe-000
+  template: "{% tablerow x in | %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x in |"'
+  complexity: 100
+- name: table_row-mut-collection-question-005
+  template: "{% tablerow x in ? %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x in ?"'
+  complexity: 100
+- name: table_row-mut-end-trail-close_round
+  template: "{% tablerow x in x ) %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x in
+      x )"'
+  complexity: 100
+- name: table_row-mut-end-trail-close_square
+  template: "{% tablerow x in x ] %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x in
+      x ]"'
+  complexity: 100
+- name: table_row-mut-end-trail-colon
+  template: "{% tablerow x in x : %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x in x :"'
+  complexity: 100
+- name: table_row-mut-end-trail-comparison
+  template: "{% tablerow x in x == %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "x in x
+      =="'
+  complexity: 100
+- name: table_row-mut-end-trail-dash
+  template: "{% tablerow x in x - %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x in x -"'
+  complexity: 100
+- name: table_row-mut-end-trail-dot
+  template: "{% tablerow x in x . %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x in x ."'
+  complexity: 100
+- name: table_row-mut-end-trail-id
+  template: "{% tablerow x in x extra %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''extra'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x extra"'
+  complexity: 100
+- name: table_row-mut-end-trail-number
+  template: "{% tablerow x in x 42 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x in x 42"'
+  complexity: 100
+- name: table_row-mut-end-trail-open_round
+  template: "{% tablerow x in x ( %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x in x
+      ("'
+  complexity: 100
+- name: table_row-mut-end-trail-open_square
+  template: "{% tablerow x in x [ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x in x
+      ["'
+  complexity: 100
+- name: table_row-mut-end-trail-pipe
+  template: "{% tablerow x in x | %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x in x |"'
+  complexity: 100
+- name: table_row-mut-end-trail-question
+  template: "{% tablerow x in x ? %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x in x ?"'
+  complexity: 100
+- name: table_row-mut-end-trail-string
+  template: "{% tablerow x in x 'hi' %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x in x ''hi''"'
+  complexity: 100
+- name: table_row-mut-in_keyword-eos
+  template: "{% tablerow x %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: For loops require an ''in'' clause in "x"'
+  complexity: 100
+- name: table_row-mut-in_keyword-id
+  template: "{% tablerow x of %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: For loops require an ''in'' clause in "x of"'
+  complexity: 100
+- name: table_row-mut-invalid_attribute-invalid
+  template: "{% tablerow x in x step , %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Invalid attribute ''step'' in tablerow loop. Valid attributes
+      are cols, limit, offset, and range in "x in x step ,"'
+  complexity: 100
+- name: table_row-mut-variable_name-eos
+  template: "{% tablerow  %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in ""'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-ampersand
+  template: "{% tablerow & %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-asterisk
+  template: "{% tablerow * %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-at
+  template: "{% tablerow @ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-backslash
+  template: "{% tablerow \\ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-backtick
+  template: "{% tablerow ` %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-caret
+  template: "{% tablerow ^ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-dollar
+  template: "{% tablerow $ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-hash
+  template: "{% tablerow # %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-semicolon
+  template: "{% tablerow ; %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-tilde
+  template: "{% tablerow ~ %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-unclosed_double_quote
+  template: '{% tablerow "hello %}{% endtablerow %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: table_row-mut-variable_name-lexerr-unclosed_single_quote
+  template: "{% tablerow 'hello %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: table_row-mut-variable_name-number
+  template: "{% tablerow 42 %}{% endtablerow %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "42"'
+  complexity: 100

--- a/specs/parser_errors/unless.yml
+++ b/specs/parser_errors/unless.yml
@@ -3,1114 +3,1085 @@
   template: "{% unless x and x x == [0] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == [0]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-close_round-004
   template: "{% unless x and x x == ) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == )"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-close_square-003
   template: "{% unless x and x x == ] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-colon-002
   template: "{% unless x and x x == : %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == :"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comma-001
   template: "{% unless x and x x == , %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ,"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comparison-009
   template: "{% unless x and x x == == %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == =="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comparison-010
   template: "{% unless x and x x == != %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == !="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comparison-011
   template: "{% unless x and x x == < %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comparison-012
   template: "{% unless x and x x == > %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comparison-013
   template: "{% unless x and x x == <= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comparison-014
   template: "{% unless x and x x == >= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-comparison-015
   template: "{% unless x and x x == contains %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == contains"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-dash-006
   template: "{% unless x and x x == - %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == -"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-dot-007
   template: "{% unless x and x x == . %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-dotdot-008
   template: "{% unless x and x x == .. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == .."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-eos-016
   template: "{% unless x and x x == %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-ampersand
   template: "{% unless x and x x == & %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+    - Unexpected character &
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-asterisk
   template: "{% unless x and x x == * %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+    - Unexpected character *
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-at
   template: "{% unless x and x x == @ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+    - Unexpected character @
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-backslash
   template: "{% unless x and x x == \\ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+    - Unexpected character \
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-backtick
   template: "{% unless x and x x == ` %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+    - Unexpected character `
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-caret
   template: "{% unless x and x x == ^ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+    - Unexpected character ^
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-dollar
   template: "{% unless x and x x == $ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+    - Unexpected character $
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-hash
   template: "{% unless x and x x == # %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-semicolon
   template: "{% unless x and x x == ; %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+    - Unexpected character ;
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-tilde
   template: "{% unless x and x x == ~ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+    - Unexpected character ~
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
   template: '{% unless x and x x == "hello %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+    - Unexpected character "
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
   template: "{% unless x and x x == 'hello %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
   template: "{% unless x and x x == x[,] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[,]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-dot_number
   template: "{% unless x and x x == x.123 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x.123"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-dot_string
   template: '{% unless x and x x == x."y" %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."y""'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-range_bad_separator
   template: "{% unless x and x x == (1, 5) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1,
-      5)"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-range_missing_end
   template: "{% unless x and x x == (1..) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..)"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-trailing_dot
   template: "{% unless x and x x == x. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-unclosed_bracket
   template: "{% unless x and x x == x[0 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[0"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-lookup-unclosed_range
   template: "{% unless x and x x == (1..5 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..5"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-pipe-000
   template: "{% unless x and x x == | %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == |"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_comparison_rhs-question-005
   template: "{% unless x and x x == ? %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ?"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_expr-close_round-004
   template: "{% unless x and x ) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x and
-      x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: unless-mut-boolean_expr-close_square-003
   template: "{% unless x and x ] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x and
-      x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: unless-mut-boolean_expr-colon-002
   template: "{% unless x and x : %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x and x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: unless-mut-boolean_expr-comma-001
   template: "{% unless x and x , %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x and x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: unless-mut-boolean_expr-comparison-009
   template: "{% unless x and x == %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      =="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_expr-comparison-010
   template: "{% unless x and x != %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      !="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_expr-comparison-011
   template: "{% unless x and x < %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      <"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_expr-comparison-012
   template: "{% unless x and x > %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      >"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_expr-comparison-013
   template: "{% unless x and x <= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      <="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_expr-comparison-014
   template: "{% unless x and x >= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      >="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_expr-comparison-015
   template: "{% unless x and x contains %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
-      contains"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_expr-dash-006
   template: "{% unless x and x - %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: unless-mut-boolean_expr-dot-007
   template: "{% unless x and x . %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: unless-mut-boolean_expr-dotdot-008
   template: "{% unless x and x .. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x .."'
+    - Expected end_of_string but found dotdot
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-ampersand
   template: "{% unless x and x & %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x and x &"'
+    - Unexpected character &
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-asterisk
   template: "{% unless x and x * %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x and x *"'
+    - Unexpected character *
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-at
   template: "{% unless x and x @ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x and x @"'
+    - Unexpected character @
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-backslash
   template: "{% unless x and x \\ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x and x \"'
+    - Unexpected character \
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-backtick
   template: "{% unless x and x ` %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x and x `"'
+    - Unexpected character `
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-caret
   template: "{% unless x and x ^ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+    - Unexpected character ^
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-dollar
   template: "{% unless x and x $ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x and x $"'
+    - Unexpected character $
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-hash
   template: "{% unless x and x # %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x and x #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-semicolon
   template: "{% unless x and x ; %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+    - Unexpected character ;
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-tilde
   template: "{% unless x and x ~ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+    - Unexpected character ~
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-unclosed_double_quote
   template: '{% unless x and x "hello %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+    - Unexpected character "
   complexity: 100
 - name: unless-mut-boolean_expr-lexerr-unclosed_single_quote
   template: "{% unless x and x 'hello %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-bracket_wrong_content
   template: "{% unless x and x x[,] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-dot_number
   template: "{% unless x and x x.123 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-dot_string
   template: '{% unless x and x x."y" %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-range_bad_separator
   template: "{% unless x and x (1, 5) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
-      x (1, 5)"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-range_missing_end
   template: "{% unless x and x (1..) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
-      x (1..)"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-trailing_dot
   template: "{% unless x and x x. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-unclosed_bracket
   template: "{% unless x and x x[0 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-boolean_expr-lookup-unclosed_range
   template: "{% unless x and x (1..5 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
-      x (1..5"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: unless-mut-boolean_expr-pipe-000
   template: "{% unless x and x | %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: unless-mut-boolean_expr-question-005
   template: "{% unless x and x ? %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x and x
-      ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: unless-mut-boolean_op-eos
   template: "{% unless x and %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-ampersand
   template: "{% unless x and & %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x and &"'
+    - Unexpected character &
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-asterisk
   template: "{% unless x and * %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x and *"'
+    - Unexpected character *
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-at
   template: "{% unless x and @ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x and @"'
+    - Unexpected character @
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-backslash
   template: "{% unless x and \\ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x and \"'
+    - Unexpected character \
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-backtick
   template: "{% unless x and ` %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x and `"'
+    - Unexpected character `
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-caret
   template: "{% unless x and ^ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+    - Unexpected character ^
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-dollar
   template: "{% unless x and $ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x and $"'
+    - Unexpected character $
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-hash
   template: "{% unless x and # %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x and #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-semicolon
   template: "{% unless x and ; %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x and ;"'
+    - Unexpected character ;
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-tilde
   template: "{% unless x and ~ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+    - Unexpected character ~
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-unclosed_double_quote
   template: '{% unless x and "hello %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x and "hello"'
+    - Unexpected character "
   complexity: 100
 - name: unless-mut-boolean_op-lexerr-unclosed_single_quote
   template: "{% unless x and 'hello %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: unless-mut-comparison_rhs-bare_bracket
   template: "{% unless x == [0] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "x == [0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: unless-mut-comparison_rhs-close_round-004
   template: "{% unless x == ) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
-      )"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-close_square-003
   template: "{% unless x == ] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x ==
-      ]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-colon-002
   template: "{% unless x == : %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comma-001
   template: "{% unless x == , %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comparison-009
   template: "{% unless x == == %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x ==
-      =="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comparison-010
   template: "{% unless x == != %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x ==
-      !="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comparison-011
   template: "{% unless x == < %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x ==
-      <"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comparison-012
   template: "{% unless x == > %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x ==
-      >"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comparison-013
   template: "{% unless x == <= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x ==
-      <="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comparison-014
   template: "{% unless x == >= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x ==
-      >="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-comparison-015
   template: "{% unless x == contains %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "x == contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-dash-006
   template: "{% unless x == - %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-dot-007
   template: "{% unless x == . %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-dotdot-008
   template: "{% unless x == .. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x == .."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-eos-016
   template: "{% unless x == %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-ampersand
   template: "{% unless x == & %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x == &"'
+    - Unexpected character &
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-asterisk
   template: "{% unless x == * %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "x == *"'
+    - Unexpected character *
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-at
   template: "{% unless x == @ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "x == @"'
+    - Unexpected character @
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-backslash
   template: "{% unless x == \\ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "x == \"'
+    - Unexpected character \
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-backtick
   template: "{% unless x == ` %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "x == `"'
+    - Unexpected character `
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-caret
   template: "{% unless x == ^ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+    - Unexpected character ^
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-dollar
   template: "{% unless x == $ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "x == $"'
+    - Unexpected character $
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-hash
   template: "{% unless x == # %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "x == #"'
+    - 'Unexpected character #'
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-semicolon
   template: "{% unless x == ; %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "x == ;"'
+    - Unexpected character ;
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-tilde
   template: "{% unless x == ~ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+    - Unexpected character ~
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-unclosed_double_quote
   template: '{% unless x == "hello %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "x == "hello"'
+    - Unexpected character "
   complexity: 100
 - name: unless-mut-comparison_rhs-lexerr-unclosed_single_quote
   template: "{% unless x == 'hello %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+    - Unexpected character '
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-bracket_wrong_content
   template: "{% unless x == x[,] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-dot_number
   template: "{% unless x == x.123 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x == x.123"'
+    - Expected id but found number
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-dot_string
   template: '{% unless x == x."y" %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x == x."y""'
+    - Expected id but found string
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-range_bad_separator
   template: "{% unless x == (1, 5) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-range_missing_end
   template: "{% unless x == (1..) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
-      (1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-trailing_dot
   template: "{% unless x == x. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-unclosed_bracket
   template: "{% unless x == x[0 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x ==
-      x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: unless-mut-comparison_rhs-lookup-unclosed_range
   template: "{% unless x == (1..5 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "x ==
-      (1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: unless-mut-comparison_rhs-pipe-000
   template: "{% unless x == | %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: unless-mut-comparison_rhs-question-005
   template: "{% unless x == ? %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x == ?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-bare_bracket
   template: "{% unless [0] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "[0]"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: unless-mut-condition-close_round-004
   template: "{% unless ) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-close_square-003
   template: "{% unless ] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-colon-002
   template: "{% unless : %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comma-001
   template: "{% unless , %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comparison-009
   template: "{% unless == %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comparison-010
   template: "{% unless != %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comparison-011
   template: "{% unless < %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comparison-012
   template: "{% unless > %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comparison-013
   template: "{% unless <= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comparison-014
   template: "{% unless >= %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-comparison-015
   template: "{% unless contains %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "contains"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-dash-006
   template: "{% unless - %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-dot-007
   template: "{% unless . %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-dotdot-008
   template: "{% unless .. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-eos-016
   template: "{% unless  %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-condition-lexerr-ampersand
   template: "{% unless & %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "&"'
+    - Unexpected character &
   complexity: 100
 - name: unless-mut-condition-lexerr-asterisk
   template: "{% unless * %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "*"'
+    - Unexpected character *
   complexity: 100
 - name: unless-mut-condition-lexerr-at
   template: "{% unless @ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "@"'
+    - Unexpected character @
   complexity: 100
 - name: unless-mut-condition-lexerr-backslash
   template: "{% unless \\ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "\"'
+    - Unexpected character \
   complexity: 100
 - name: unless-mut-condition-lexerr-backtick
   template: "{% unless ` %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "`"'
+    - Unexpected character `
   complexity: 100
 - name: unless-mut-condition-lexerr-caret
   template: "{% unless ^ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "^"'
+    - Unexpected character ^
   complexity: 100
 - name: unless-mut-condition-lexerr-dollar
   template: "{% unless $ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "$"'
+    - Unexpected character $
   complexity: 100
 - name: unless-mut-condition-lexerr-hash
   template: "{% unless # %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "#"'
+    - 'Unexpected character #'
   complexity: 100
 - name: unless-mut-condition-lexerr-semicolon
   template: "{% unless ; %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in ";"'
+    - Unexpected character ;
   complexity: 100
 - name: unless-mut-condition-lexerr-tilde
   template: "{% unless ~ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "~"'
+    - Unexpected character ~
   complexity: 100
 - name: unless-mut-condition-lexerr-unclosed_double_quote
   template: '{% unless "hello %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in ""hello"'
+    - Unexpected character "
   complexity: 100
 - name: unless-mut-condition-lexerr-unclosed_single_quote
   template: "{% unless 'hello %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+    - Unexpected character '
   complexity: 100
 - name: unless-mut-condition-lookup-bracket_wrong_content
   template: "{% unless x[,] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-lookup-dot_number
   template: "{% unless x.123 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "x.123"'
+    - Expected id but found number
   complexity: 100
 - name: unless-mut-condition-lookup-dot_string
   template: '{% unless x."y" %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "x."y""'
+    - Expected id but found string
   complexity: 100
 - name: unless-mut-condition-lookup-range_bad_separator
   template: "{% unless (1, 5) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: unless-mut-condition-lookup-range_missing_end
   template: "{% unless (1..) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-lookup-trailing_dot
   template: "{% unless x. %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: unless-mut-condition-lookup-unclosed_bracket
   template: "{% unless x[0 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: unless-mut-condition-lookup-unclosed_range
   template: "{% unless (1..5 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: unless-mut-condition-pipe-000
   template: "{% unless | %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: unless-mut-condition-question-005
   template: "{% unless ? %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: unless-mut-end-trail-close_round
   template: "{% unless x ) %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: unless-mut-end-trail-close_square
   template: "{% unless x ] %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: unless-mut-end-trail-colon
   template: "{% unless x : %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: unless-mut-end-trail-comma
   template: "{% unless x , %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: unless-mut-end-trail-comparison
   template: "{% unless x == %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-end-trail-dash
   template: "{% unless x - %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: unless-mut-end-trail-dot
   template: "{% unless x . %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+    - Expected id but found end_of_string
   complexity: 100
 - name: unless-mut-end-trail-id
   template: "{% unless x extra %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-mut-end-trail-number
   template: "{% unless x 42 %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: unless-mut-end-trail-open_round
   template: "{% unless x ( %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: unless-mut-end-trail-open_square
   template: "{% unless x [ %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: unless-mut-end-trail-pipe
   template: "{% unless x | %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: unless-mut-end-trail-question
   template: "{% unless x ? %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: unless-mut-end-trail-string
   template: "{% unless x 'hi' %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: unless-parity-js-and-operator
   template: "{% unless x && y %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "x && y"'
+    - Unexpected character &
   complexity: 100
 - name: unless-parity-js-or-operator
   template: "{% unless x || y %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found pipe in "x || y"'
+    - Expected end_of_string but found pipe
   complexity: 100
 - name: unless-parity-non-liquid-operator
   template: '{% unless x startswith "foo" %}{% endunless %}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "x startswith "foo""'
+    - Expected end_of_string but found id
   complexity: 100
 - name: unless-parity-triple-equals
   template: "{% unless x === y %}{% endunless %}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character = in "x === y"'
+    - Unexpected character =
   complexity: 100

--- a/specs/parser_errors/unless.yml
+++ b/specs/parser_errors/unless.yml
@@ -1,0 +1,1116 @@
+---
+- name: unless-mut-boolean_comparison_rhs-bare_bracket
+  template: "{% unless x and x x == [0] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == [0]"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-close_round-004
+  template: "{% unless x and x x == ) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == )"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-close_square-003
+  template: "{% unless x and x x == ] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ]"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-colon-002
+  template: "{% unless x and x x == : %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == :"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comma-001
+  template: "{% unless x and x x == , %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ,"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comparison-009
+  template: "{% unless x and x x == == %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == =="'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comparison-010
+  template: "{% unless x and x x == != %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == !="'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comparison-011
+  template: "{% unless x and x x == < %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comparison-012
+  template: "{% unless x and x x == > %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comparison-013
+  template: "{% unless x and x x == <= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == <="'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comparison-014
+  template: "{% unless x and x x == >= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == >="'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-comparison-015
+  template: "{% unless x and x x == contains %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == contains"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-dash-006
+  template: "{% unless x and x x == - %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == -"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-dot-007
+  template: "{% unless x and x x == . %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ."'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-dotdot-008
+  template: "{% unless x and x x == .. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == .."'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-eos-016
+  template: "{% unless x and x x == %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x =="'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-ampersand
+  template: "{% unless x and x x == & %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x and x x == &"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-asterisk
+  template: "{% unless x and x x == * %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x and x x == *"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-at
+  template: "{% unless x and x x == @ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x and x x == @"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-backslash
+  template: "{% unless x and x x == \\ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x and x x == \"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-backtick
+  template: "{% unless x and x x == ` %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x and x x == `"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-caret
+  template: "{% unless x and x x == ^ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x and x x == ^"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-dollar
+  template: "{% unless x and x x == $ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x and x x == $"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-hash
+  template: "{% unless x and x x == # %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x and x x == #"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-semicolon
+  template: "{% unless x and x x == ; %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x and x x == ;"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-tilde
+  template: "{% unless x and x x == ~ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x and x x == ~"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% unless x and x x == "hello %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x and x x == "hello"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% unless x and x x == 'hello %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x and x x == ''hello"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-bracket_wrong_content
+  template: "{% unless x and x x == x[,] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[,]"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-dot_number
+  template: "{% unless x and x x == x.123 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x.123"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-dot_string
+  template: '{% unless x and x x == x."y" %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."y""'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-range_bad_separator
+  template: "{% unless x and x x == (1, 5) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1,
+      5)"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-range_missing_end
+  template: "{% unless x and x x == (1..) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..)"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-trailing_dot
+  template: "{% unless x and x x == x. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x."'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-unclosed_bracket
+  template: "{% unless x and x x == x[0 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == x[0"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-lookup-unclosed_range
+  template: "{% unless x and x x == (1..5 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == (1..5"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-pipe-000
+  template: "{% unless x and x x == | %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == |"'
+  complexity: 100
+- name: unless-mut-boolean_comparison_rhs-question-005
+  template: "{% unless x and x x == ? %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x == ?"'
+  complexity: 100
+- name: unless-mut-boolean_expr-close_round-004
+  template: "{% unless x and x ) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x and
+      x )"'
+  complexity: 100
+- name: unless-mut-boolean_expr-close_square-003
+  template: "{% unless x and x ] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x and
+      x ]"'
+  complexity: 100
+- name: unless-mut-boolean_expr-colon-002
+  template: "{% unless x and x : %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x and x :"'
+  complexity: 100
+- name: unless-mut-boolean_expr-comma-001
+  template: "{% unless x and x , %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x and x ,"'
+  complexity: 100
+- name: unless-mut-boolean_expr-comparison-009
+  template: "{% unless x and x == %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      =="'
+  complexity: 100
+- name: unless-mut-boolean_expr-comparison-010
+  template: "{% unless x and x != %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      !="'
+  complexity: 100
+- name: unless-mut-boolean_expr-comparison-011
+  template: "{% unless x and x < %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      <"'
+  complexity: 100
+- name: unless-mut-boolean_expr-comparison-012
+  template: "{% unless x and x > %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      >"'
+  complexity: 100
+- name: unless-mut-boolean_expr-comparison-013
+  template: "{% unless x and x <= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      <="'
+  complexity: 100
+- name: unless-mut-boolean_expr-comparison-014
+  template: "{% unless x and x >= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      >="'
+  complexity: 100
+- name: unless-mut-boolean_expr-comparison-015
+  template: "{% unless x and x contains %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and x
+      contains"'
+  complexity: 100
+- name: unless-mut-boolean_expr-dash-006
+  template: "{% unless x and x - %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x and x -"'
+  complexity: 100
+- name: unless-mut-boolean_expr-dot-007
+  template: "{% unless x and x . %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x and x ."'
+  complexity: 100
+- name: unless-mut-boolean_expr-dotdot-008
+  template: "{% unless x and x .. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dotdot in "x and x .."'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-ampersand
+  template: "{% unless x and x & %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x and x &"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-asterisk
+  template: "{% unless x and x * %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x and x *"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-at
+  template: "{% unless x and x @ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x and x @"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-backslash
+  template: "{% unless x and x \\ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x and x \"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-backtick
+  template: "{% unless x and x ` %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x and x `"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-caret
+  template: "{% unless x and x ^ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x and x ^"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-dollar
+  template: "{% unless x and x $ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x and x $"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-hash
+  template: "{% unless x and x # %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x and x #"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-semicolon
+  template: "{% unless x and x ; %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x and x ;"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-tilde
+  template: "{% unless x and x ~ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x and x ~"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-unclosed_double_quote
+  template: '{% unless x and x "hello %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x and x "hello"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lexerr-unclosed_single_quote
+  template: "{% unless x and x 'hello %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x and x ''hello"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-bracket_wrong_content
+  template: "{% unless x and x x[,] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[,]"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-dot_number
+  template: "{% unless x and x x.123 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x.123"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-dot_string
+  template: '{% unless x and x x."y" %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."y""'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-range_bad_separator
+  template: "{% unless x and x (1, 5) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+      x (1, 5)"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-range_missing_end
+  template: "{% unless x and x (1..) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+      x (1..)"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-trailing_dot
+  template: "{% unless x and x x. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x."'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-unclosed_bracket
+  template: "{% unless x and x x[0 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x and x x[0"'
+  complexity: 100
+- name: unless-mut-boolean_expr-lookup-unclosed_range
+  template: "{% unless x and x (1..5 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x and
+      x (1..5"'
+  complexity: 100
+- name: unless-mut-boolean_expr-pipe-000
+  template: "{% unless x and x | %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x and x |"'
+  complexity: 100
+- name: unless-mut-boolean_expr-question-005
+  template: "{% unless x and x ? %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x and x
+      ?"'
+  complexity: 100
+- name: unless-mut-boolean_op-eos
+  template: "{% unless x and %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x and"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-ampersand
+  template: "{% unless x and & %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x and &"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-asterisk
+  template: "{% unless x and * %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x and *"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-at
+  template: "{% unless x and @ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x and @"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-backslash
+  template: "{% unless x and \\ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x and \"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-backtick
+  template: "{% unless x and ` %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x and `"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-caret
+  template: "{% unless x and ^ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x and ^"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-dollar
+  template: "{% unless x and $ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x and $"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-hash
+  template: "{% unless x and # %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x and #"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-semicolon
+  template: "{% unless x and ; %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x and ;"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-tilde
+  template: "{% unless x and ~ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x and ~"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-unclosed_double_quote
+  template: '{% unless x and "hello %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x and "hello"'
+  complexity: 100
+- name: unless-mut-boolean_op-lexerr-unclosed_single_quote
+  template: "{% unless x and 'hello %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x and ''hello"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-bare_bracket
+  template: "{% unless x == [0] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "x == [0]"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-close_round-004
+  template: "{% unless x == ) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
+      )"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-close_square-003
+  template: "{% unless x == ] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "x ==
+      ]"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-colon-002
+  template: "{% unless x == : %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "x == :"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comma-001
+  template: "{% unless x == , %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == ,"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comparison-009
+  template: "{% unless x == == %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "x ==
+      =="'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comparison-010
+  template: "{% unless x == != %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "x ==
+      !="'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comparison-011
+  template: "{% unless x == < %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "x ==
+      <"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comparison-012
+  template: "{% unless x == > %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "x ==
+      >"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comparison-013
+  template: "{% unless x == <= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "x ==
+      <="'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comparison-014
+  template: "{% unless x == >= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "x ==
+      >="'
+  complexity: 100
+- name: unless-mut-comparison_rhs-comparison-015
+  template: "{% unless x == contains %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "x == contains"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-dash-006
+  template: "{% unless x == - %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "x == -"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-dot-007
+  template: "{% unless x == . %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "x == ."'
+  complexity: 100
+- name: unless-mut-comparison_rhs-dotdot-008
+  template: "{% unless x == .. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "x == .."'
+  complexity: 100
+- name: unless-mut-comparison_rhs-eos-016
+  template: "{% unless x == %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-ampersand
+  template: "{% unless x == & %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x == &"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-asterisk
+  template: "{% unless x == * %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "x == *"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-at
+  template: "{% unless x == @ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "x == @"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-backslash
+  template: "{% unless x == \\ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "x == \"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-backtick
+  template: "{% unless x == ` %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "x == `"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-caret
+  template: "{% unless x == ^ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "x == ^"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-dollar
+  template: "{% unless x == $ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "x == $"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-hash
+  template: "{% unless x == # %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "x == #"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-semicolon
+  template: "{% unless x == ; %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "x == ;"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-tilde
+  template: "{% unless x == ~ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "x == ~"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-unclosed_double_quote
+  template: '{% unless x == "hello %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "x == "hello"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lexerr-unclosed_single_quote
+  template: "{% unless x == 'hello %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "x == ''hello"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-bracket_wrong_content
+  template: "{% unless x == x[,] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x == x[,]"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-dot_number
+  template: "{% unless x == x.123 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x == x.123"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-dot_string
+  template: '{% unless x == x."y" %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x == x."y""'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-range_bad_separator
+  template: "{% unless x == (1, 5) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "x == (1, 5)"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-range_missing_end
+  template: "{% unless x == (1..) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "x ==
+      (1..)"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-trailing_dot
+  template: "{% unless x == x. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x == x."'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-unclosed_bracket
+  template: "{% unless x == x[0 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x ==
+      x[0"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-lookup-unclosed_range
+  template: "{% unless x == (1..5 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "x ==
+      (1..5"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-pipe-000
+  template: "{% unless x == | %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "x == |"'
+  complexity: 100
+- name: unless-mut-comparison_rhs-question-005
+  template: "{% unless x == ? %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "x == ?"'
+  complexity: 100
+- name: unless-mut-condition-bare_bracket
+  template: "{% unless [0] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "[0]"'
+  complexity: 100
+- name: unless-mut-condition-close_round-004
+  template: "{% unless ) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in ")"'
+  complexity: 100
+- name: unless-mut-condition-close_square-003
+  template: "{% unless ] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "]"'
+  complexity: 100
+- name: unless-mut-condition-colon-002
+  template: "{% unless : %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in ":"'
+  complexity: 100
+- name: unless-mut-condition-comma-001
+  template: "{% unless , %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in ","'
+  complexity: 100
+- name: unless-mut-condition-comparison-009
+  template: "{% unless == %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "=="'
+  complexity: 100
+- name: unless-mut-condition-comparison-010
+  template: "{% unless != %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "!="'
+  complexity: 100
+- name: unless-mut-condition-comparison-011
+  template: "{% unless < %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "<"'
+  complexity: 100
+- name: unless-mut-condition-comparison-012
+  template: "{% unless > %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in ">"'
+  complexity: 100
+- name: unless-mut-condition-comparison-013
+  template: "{% unless <= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "<="'
+  complexity: 100
+- name: unless-mut-condition-comparison-014
+  template: "{% unless >= %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in ">="'
+  complexity: 100
+- name: unless-mut-condition-comparison-015
+  template: "{% unless contains %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "contains"'
+  complexity: 100
+- name: unless-mut-condition-dash-006
+  template: "{% unless - %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "-"'
+  complexity: 100
+- name: unless-mut-condition-dot-007
+  template: "{% unless . %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "."'
+  complexity: 100
+- name: unless-mut-condition-dotdot-008
+  template: "{% unless .. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in ".."'
+  complexity: 100
+- name: unless-mut-condition-eos-016
+  template: "{% unless  %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in ""'
+  complexity: 100
+- name: unless-mut-condition-lexerr-ampersand
+  template: "{% unless & %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "&"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-asterisk
+  template: "{% unless * %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "*"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-at
+  template: "{% unless @ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "@"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-backslash
+  template: "{% unless \\ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "\"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-backtick
+  template: "{% unless ` %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "`"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-caret
+  template: "{% unless ^ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "^"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-dollar
+  template: "{% unless $ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "$"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-hash
+  template: "{% unless # %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "#"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-semicolon
+  template: "{% unless ; %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in ";"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-tilde
+  template: "{% unless ~ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "~"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-unclosed_double_quote
+  template: '{% unless "hello %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in ""hello"'
+  complexity: 100
+- name: unless-mut-condition-lexerr-unclosed_single_quote
+  template: "{% unless 'hello %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "''hello"'
+  complexity: 100
+- name: unless-mut-condition-lookup-bracket_wrong_content
+  template: "{% unless x[,] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "x[,]"'
+  complexity: 100
+- name: unless-mut-condition-lookup-dot_number
+  template: "{% unless x.123 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "x.123"'
+  complexity: 100
+- name: unless-mut-condition-lookup-dot_string
+  template: '{% unless x."y" %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "x."y""'
+  complexity: 100
+- name: unless-mut-condition-lookup-range_bad_separator
+  template: "{% unless (1, 5) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "(1, 5)"'
+  complexity: 100
+- name: unless-mut-condition-lookup-range_missing_end
+  template: "{% unless (1..) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "(1..)"'
+  complexity: 100
+- name: unless-mut-condition-lookup-trailing_dot
+  template: "{% unless x. %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x."'
+  complexity: 100
+- name: unless-mut-condition-lookup-unclosed_bracket
+  template: "{% unless x[0 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "x[0"'
+  complexity: 100
+- name: unless-mut-condition-lookup-unclosed_range
+  template: "{% unless (1..5 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "(1..5"'
+  complexity: 100
+- name: unless-mut-condition-pipe-000
+  template: "{% unless | %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "|"'
+  complexity: 100
+- name: unless-mut-condition-question-005
+  template: "{% unless ? %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "?"'
+  complexity: 100
+- name: unless-mut-end-trail-close_round
+  template: "{% unless x ) %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "x )"'
+  complexity: 100
+- name: unless-mut-end-trail-close_square
+  template: "{% unless x ] %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "x ]"'
+  complexity: 100
+- name: unless-mut-end-trail-colon
+  template: "{% unless x : %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "x :"'
+  complexity: 100
+- name: unless-mut-end-trail-comma
+  template: "{% unless x , %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "x ,"'
+  complexity: 100
+- name: unless-mut-end-trail-comparison
+  template: "{% unless x == %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x =="'
+  complexity: 100
+- name: unless-mut-end-trail-dash
+  template: "{% unless x - %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "x -"'
+  complexity: 100
+- name: unless-mut-end-trail-dot
+  template: "{% unless x . %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "x ."'
+  complexity: 100
+- name: unless-mut-end-trail-id
+  template: "{% unless x extra %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x extra"'
+  complexity: 100
+- name: unless-mut-end-trail-number
+  template: "{% unless x 42 %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "x 42"'
+  complexity: 100
+- name: unless-mut-end-trail-open_round
+  template: "{% unless x ( %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "x ("'
+  complexity: 100
+- name: unless-mut-end-trail-open_square
+  template: "{% unless x [ %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "x ["'
+  complexity: 100
+- name: unless-mut-end-trail-pipe
+  template: "{% unless x | %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x |"'
+  complexity: 100
+- name: unless-mut-end-trail-question
+  template: "{% unless x ? %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "x ?"'
+  complexity: 100
+- name: unless-mut-end-trail-string
+  template: "{% unless x 'hi' %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "x ''hi''"'
+  complexity: 100
+- name: unless-parity-js-and-operator
+  template: "{% unless x && y %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "x && y"'
+  complexity: 100
+- name: unless-parity-js-or-operator
+  template: "{% unless x || y %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found pipe in "x || y"'
+  complexity: 100
+- name: unless-parity-non-liquid-operator
+  template: '{% unless x startswith "foo" %}{% endunless %}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "x startswith "foo""'
+  complexity: 100
+- name: unless-parity-triple-equals
+  template: "{% unless x === y %}{% endunless %}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character = in "x === y"'
+  complexity: 100

--- a/specs/parser_errors/variable.yml
+++ b/specs/parser_errors/variable.yml
@@ -3,1176 +3,1079 @@
   template: "{{ x ) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_round in "{{ x
-      ) }}"'
+    - Expected end_of_string but found close_round
   complexity: 100
 - name: variable-mut-end-trail-close_square
   template: "{{ x ] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found close_square in "{{ x
-      ] }}"'
+    - Expected end_of_string but found close_square
   complexity: 100
 - name: variable-mut-end-trail-colon
   template: "{{ x : }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found colon in "{{ x : }}"'
+    - Expected end_of_string but found colon
   complexity: 100
 - name: variable-mut-end-trail-comma
   template: "{{ x , }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comma in "{{ x , }}"'
+    - Expected end_of_string but found comma
   complexity: 100
 - name: variable-mut-end-trail-comparison
   template: "{{ x == }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found comparison in "{{ x ==
-      }}"'
+    - Expected end_of_string but found comparison
   complexity: 100
 - name: variable-mut-end-trail-dash
   template: "{{ x - }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found dash in "{{ x - }}"'
+    - Expected end_of_string but found dash
   complexity: 100
 - name: variable-mut-end-trail-dot
   template: "{{ x . }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x . }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: variable-mut-end-trail-id
   template: "{{ x extra }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found id in "{{ x extra }}"'
+    - Expected end_of_string but found id
   complexity: 100
 - name: variable-mut-end-trail-number
   template: "{{ x 42 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found number in "{{ x 42 }}"'
+    - Expected end_of_string but found number
   complexity: 100
 - name: variable-mut-end-trail-open_round
   template: "{{ x ( }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found open_round in "{{ x (
-      }}"'
+    - Expected end_of_string but found open_round
   complexity: 100
 - name: variable-mut-end-trail-open_square
   template: "{{ x [ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "{{ x [
-      }}"'
+    - "[:end_of_string] is not a valid expression"
   complexity: 100
 - name: variable-mut-end-trail-pipe
   template: "{{ x | }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: variable-mut-end-trail-question
   template: "{{ x ? }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found question in "{{ x ? }}"'
+    - Expected end_of_string but found question
   complexity: 100
 - name: variable-mut-end-trail-string
   template: "{{ x 'hi' }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected end_of_string but found string in "{{ x ''hi''
-      }}"'
+    - Expected end_of_string but found string
   complexity: 100
 - name: variable-mut-filter_arg_value-bare_bracket
   template: "{{ x | x : x , , [0] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , [0] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-close_round-004
   template: "{{ x | x : x , , ) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , ) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-close_square-003
   template: "{{ x | x : x , , ] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , ] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-colon-002
   template: "{{ x | x : x , , : }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , : }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comma-001
   template: "{{ x | x : x , , , }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comparison-009
   template: "{{ x | x : x , , == }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , == }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comparison-010
   template: "{{ x | x : x , , != }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , != }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comparison-011
   template: "{{ x | x : x , , < }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , < }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comparison-012
   template: "{{ x | x : x , , > }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , > }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comparison-013
   template: "{{ x | x : x , , <= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , <= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comparison-014
   template: "{{ x | x : x , , >= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , >= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-comparison-015
   template: "{{ x | x : x , , contains }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , contains }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-dash-006
   template: "{{ x | x : x , , - }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , - }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-dot-007
   template: "{{ x | x : x , , . }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , . }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-dotdot-008
   template: "{{ x | x : x , , .. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , .. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-eos-016
   template: "{{ x | x : x , , }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-ampersand
   template: "{{ x | x : x , , & }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{ x | x : x , , & }}"'
+    - Unexpected character &
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-asterisk
   template: "{{ x | x : x , , * }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{ x | x : x , , * }}"'
+    - Unexpected character *
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-at
   template: "{{ x | x : x , , @ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{ x | x : x , , @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-backslash
   template: "{{ x | x : x , , \\ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{ x | x : x , , \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-backtick
   template: "{{ x | x : x , , ` }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{ x | x : x , , ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-caret
   template: "{{ x | x : x , , ^ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{ x | x : x , , ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-dollar
   template: "{{ x | x : x , , $ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{ x | x : x , , $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-hash
   template: "{{ x | x : x , , # }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{ x | x : x , , # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-semicolon
   template: "{{ x | x : x , , ; }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{ x | x : x , , ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-tilde
   template: "{{ x | x : x , , ~ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{ x | x : x , , ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-unclosed_double_quote
   template: '{{ x | x : x , , "hello }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{ x | x : x , , "hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: variable-mut-filter_arg_value-lexerr-unclosed_single_quote
   template: "{{ x | x : x , , 'hello }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{ x | x : x , , ''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-bracket_wrong_content
   template: "{{ x | x : x , , x[,] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-dot_number
   template: "{{ x | x : x , , x.123 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x.123 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-dot_string
   template: '{{ x | x : x , , x."y" }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x."y" }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-range_bad_separator
   template: "{{ x | x : x , , (1, 5) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , (1, 5) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-range_missing_end
   template: "{{ x | x : x , , (1..) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , (1..) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-trailing_dot
   template: "{{ x | x : x , , x. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-unclosed_bracket
   template: "{{ x | x : x , , x[0 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x[0 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-lookup-unclosed_range
   template: "{{ x | x : x , , (1..5 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , (1..5 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-pipe-000
   template: "{{ x | x : x , , | }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , | }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_arg_value-question-005
   template: "{{ x | x : x , , ? }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , ? }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-bare_bracket
   template: "{{ x | x : [0] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "{{ x | x : [0] }}"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: variable-mut-filter_first_arg-close_round-004
   template: "{{ x | x : ) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ x
-      | x : ) }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-close_square-003
   template: "{{ x | x : ] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{
-      x | x : ] }}"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-colon-002
   template: "{{ x | x : : }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{ x | x :
-      : }}"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comma-001
   template: "{{ x | x : , }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comparison-009
   template: "{{ x | x : == }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{ x
-      | x : == }}"'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comparison-010
   template: "{{ x | x : != }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{ x
-      | x : != }}"'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comparison-011
   template: "{{ x | x : < }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{ x
-      | x : < }}"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comparison-012
   template: "{{ x | x : > }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{ x
-      | x : > }}"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comparison-013
   template: "{{ x | x : <= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{ x
-      | x : <= }}"'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comparison-014
   template: "{{ x | x : >= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{ x
-      | x : >= }}"'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-comparison-015
   template: "{{ x | x : contains }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "{{ x | x : contains }}"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-dash-006
   template: "{{ x | x : - }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{ x | x :
-      - }}"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-dot-007
   template: "{{ x | x : . }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{ x | x : .
-      }}"'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-dotdot-008
   template: "{{ x | x : .. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{ x | x
-      : .. }}"'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-ampersand
   template: "{{ x | x : & }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{ x | x : & }}"'
+    - Unexpected character &
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-asterisk
   template: "{{ x | x : * }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{ x | x : * }}"'
+    - Unexpected character *
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-at
   template: "{{ x | x : @ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{ x | x : @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-backslash
   template: "{{ x | x : \\ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{ x | x : \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-backtick
   template: "{{ x | x : ` }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{ x | x : ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-caret
   template: "{{ x | x : ^ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{ x | x : ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-dollar
   template: "{{ x | x : $ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{ x | x : $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-hash
   template: "{{ x | x : # }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{ x | x : # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-semicolon
   template: "{{ x | x : ; }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{ x | x : ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-tilde
   template: "{{ x | x : ~ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{ x | x : ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-unclosed_double_quote
   template: '{{ x | x : "hello }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{ x | x : "hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: variable-mut-filter_first_arg-lexerr-unclosed_single_quote
   template: "{{ x | x : 'hello }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{ x | x : ''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-bracket_wrong_content
   template: "{{ x | x : x[,] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-dot_number
   template: "{{ x | x : x.123 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "{{ x | x : x.123 }}"'
+    - Expected id but found number
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-dot_string
   template: '{{ x | x : x."y" }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "{{ x | x : x."y" }}"'
+    - Expected id but found string
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-range_bad_separator
   template: "{{ x | x : (1, 5) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "{{ x | x : (1, 5)
-      }}"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-range_missing_end
   template: "{{ x | x : (1..) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ x
-      | x : (1..) }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-trailing_dot
   template: "{{ x | x : x. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | x : x.
-      }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-unclosed_bracket
   template: "{{ x | x : x[0 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{ x
-      | x : x[0 }}"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: variable-mut-filter_first_arg-lookup-unclosed_range
   template: "{{ x | x : (1..5 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{ x
-      | x : (1..5 }}"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: variable-mut-filter_first_arg-pipe-000
   template: "{{ x | x : | }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | x : | }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: variable-mut-filter_first_arg-question-005
   template: "{{ x | x : ? }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{ x |
-      x : ? }}"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100
 - name: variable-mut-filter_name-eos
   template: "{{ x | }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: variable-mut-filter_name-lexerr-ampersand
   template: "{{ x | & }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{ x | & }}"'
+    - Unexpected character &
   complexity: 100
 - name: variable-mut-filter_name-lexerr-asterisk
   template: "{{ x | * }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{ x | * }}"'
+    - Unexpected character *
   complexity: 100
 - name: variable-mut-filter_name-lexerr-at
   template: "{{ x | @ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{ x | @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: variable-mut-filter_name-lexerr-backslash
   template: "{{ x | \\ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{ x | \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: variable-mut-filter_name-lexerr-backtick
   template: "{{ x | ` }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{ x | ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: variable-mut-filter_name-lexerr-caret
   template: "{{ x | ^ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{ x | ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: variable-mut-filter_name-lexerr-dollar
   template: "{{ x | $ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{ x | $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: variable-mut-filter_name-lexerr-hash
   template: "{{ x | # }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{ x | # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: variable-mut-filter_name-lexerr-semicolon
   template: "{{ x | ; }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{ x | ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: variable-mut-filter_name-lexerr-tilde
   template: "{{ x | ~ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{ x | ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: variable-mut-filter_name-lexerr-unclosed_double_quote
   template: '{{ x | "hello }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{ x | "hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: variable-mut-filter_name-lexerr-unclosed_single_quote
   template: "{{ x | 'hello }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{ x | ''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: variable-mut-filter_name-number
   template: "{{ x | 42 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "{{ x | 42 }}"'
+    - Expected id but found number
   complexity: 100
 - name: variable-mut-kwarg_colon-eos
   template: "{{ x | x : x , , x }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_colon-number
   template: "{{ x | x : x , , x 42 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x 42 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-bare_bracket
   template: "{{ x | x : x , , x : [0] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : [0] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-close_round-004
   template: "{{ x | x : x , , x : ) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : ) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-close_square-003
   template: "{{ x | x : x , , x : ] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : ] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-colon-002
   template: "{{ x | x : x , , x : : }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : : }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comma-001
   template: "{{ x | x : x , , x : , }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comparison-009
   template: "{{ x | x : x , , x : == }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : == }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comparison-010
   template: "{{ x | x : x , , x : != }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : != }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comparison-011
   template: "{{ x | x : x , , x : < }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : < }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comparison-012
   template: "{{ x | x : x , , x : > }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : > }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comparison-013
   template: "{{ x | x : x , , x : <= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : <= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comparison-014
   template: "{{ x | x : x , , x : >= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : >= }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-comparison-015
   template: "{{ x | x : x , , x : contains }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : contains }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-dash-006
   template: "{{ x | x : x , , x : - }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : - }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-dot-007
   template: "{{ x | x : x , , x : . }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : . }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-dotdot-008
   template: "{{ x | x : x , , x : .. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : .. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-eos-016
   template: "{{ x | x : x , , x : }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-ampersand
   template: "{{ x | x : x , , x : & }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{ x | x : x , , x : & }}"'
+    - Unexpected character &
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-asterisk
   template: "{{ x | x : x , , x : * }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{ x | x : x , , x : * }}"'
+    - Unexpected character *
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-at
   template: "{{ x | x : x , , x : @ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{ x | x : x , , x : @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-backslash
   template: "{{ x | x : x , , x : \\ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{ x | x : x , , x : \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-backtick
   template: "{{ x | x : x , , x : ` }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{ x | x : x , , x : ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-caret
   template: "{{ x | x : x , , x : ^ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{ x | x : x , , x : ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-dollar
   template: "{{ x | x : x , , x : $ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{ x | x : x , , x : $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-hash
   template: "{{ x | x : x , , x : # }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{ x | x : x , , x : # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-semicolon
   template: "{{ x | x : x , , x : ; }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{ x | x : x , , x : ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-tilde
   template: "{{ x | x : x , , x : ~ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{ x | x : x , , x : ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-unclosed_double_quote
   template: '{{ x | x : x , , x : "hello }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{ x | x : x , , x : "hello
-      }}"'
+    - Unexpected character "
   complexity: 100
 - name: variable-mut-kwarg_value-lexerr-unclosed_single_quote
   template: "{{ x | x : x , , x : 'hello }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{ x | x : x , , x : ''hello
-      }}"'
+    - Unexpected character '
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-bracket_wrong_content
   template: "{{ x | x : x , , x : x[,] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-dot_number
   template: "{{ x | x : x , , x : x.123 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : x.123 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-dot_string
   template: '{{ x | x : x , , x : x."y" }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : x."y" }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-range_bad_separator
   template: "{{ x | x : x , , x : (1, 5) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : (1, 5) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-range_missing_end
   template: "{{ x | x : x , , x : (1..) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : (1..) }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-trailing_dot
   template: "{{ x | x : x , , x : x. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : x. }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-unclosed_bracket
   template: "{{ x | x : x , , x : x[0 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : x[0 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-lookup-unclosed_range
   template: "{{ x | x : x , , x : (1..5 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : (1..5 }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-pipe-000
   template: "{{ x | x : x , , x : | }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : | }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-kwarg_value-question-005
   template: "{{ x | x : x , , x : ? }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
-      x , , x : ? }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-bare_bracket
   template: "{{ [0] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
-      self[''...''] instead in "{{ [0] }}"'
+    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
   complexity: 100
 - name: variable-mut-value-close_round-004
   template: "{{ ) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ )
-      }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-close_square-003
   template: "{{ ] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{
-      ] }}"'
+    - '[:close_square, "]"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-colon-002
   template: "{{ : }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{ : }}"'
+    - '[:colon, ":"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comma-001
   template: "{{ , }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ , }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comparison-009
   template: "{{ == }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{ ==
-      }}"'
+    - '[:comparison, "=="] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comparison-010
   template: "{{ != }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{ !=
-      }}"'
+    - '[:comparison, "!="] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comparison-011
   template: "{{ < }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{ <
-      }}"'
+    - '[:comparison, "<"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comparison-012
   template: "{{ > }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{ >
-      }}"'
+    - '[:comparison, ">"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comparison-013
   template: "{{ <= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{ <=
-      }}"'
+    - '[:comparison, "<="] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comparison-014
   template: "{{ >= }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{ >=
-      }}"'
+    - '[:comparison, ">="] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-comparison-015
   template: "{{ contains }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
-      "{{ contains }}"'
+    - '[:comparison, "contains"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-dash-006
   template: "{{ - }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{ - }}"'
+    - '[:dash, "-"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-dot-007
   template: "{{ . }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{ . }}"'
+    - '[:dot, "."] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-dotdot-008
   template: "{{ .. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{ .. }}"'
+    - '[:dotdot, ".."] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-lexerr-ampersand
   template: "{{ & }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character & in "{{ & }}"'
+    - Unexpected character &
   complexity: 100
 - name: variable-mut-value-lexerr-asterisk
   template: "{{ * }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character * in "{{ * }}"'
+    - Unexpected character *
   complexity: 100
 - name: variable-mut-value-lexerr-at
   template: "{{ @ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character @ in "{{ @ }}"'
+    - Unexpected character @
   complexity: 100
 - name: variable-mut-value-lexerr-backslash
   template: "{{ \\ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character \ in "{{ \ }}"'
+    - Unexpected character \
   complexity: 100
 - name: variable-mut-value-lexerr-backtick
   template: "{{ ` }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ` in "{{ ` }}"'
+    - Unexpected character `
   complexity: 100
 - name: variable-mut-value-lexerr-caret
   template: "{{ ^ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ^ in "{{ ^ }}"'
+    - Unexpected character ^
   complexity: 100
 - name: variable-mut-value-lexerr-dollar
   template: "{{ $ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character $ in "{{ $ }}"'
+    - Unexpected character $
   complexity: 100
 - name: variable-mut-value-lexerr-hash
   template: "{{ # }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character # in "{{ # }}"'
+    - 'Unexpected character #'
   complexity: 100
 - name: variable-mut-value-lexerr-semicolon
   template: "{{ ; }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ; in "{{ ; }}"'
+    - Unexpected character ;
   complexity: 100
 - name: variable-mut-value-lexerr-tilde
   template: "{{ ~ }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character ~ in "{{ ~ }}"'
+    - Unexpected character ~
   complexity: 100
 - name: variable-mut-value-lexerr-unclosed_double_quote
   template: '{{ "hello }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character " in "{{ "hello }}"'
+    - Unexpected character "
   complexity: 100
 - name: variable-mut-value-lexerr-unclosed_single_quote
   template: "{{ 'hello }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Unexpected character '' in "{{ ''hello }}"'
+    - Unexpected character '
   complexity: 100
 - name: variable-mut-value-lookup-bracket_wrong_content
   template: "{{ x[,] }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x[,] }}"'
+    - '[:comma, ","] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-lookup-dot_number
   template: "{{ x.123 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found number in "{{ x.123 }}"'
+    - Expected id but found number
   complexity: 100
 - name: variable-mut-value-lookup-dot_string
   template: '{{ x."y" }}'
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found string in "{{ x."y" }}"'
+    - Expected id but found string
   complexity: 100
 - name: variable-mut-value-lookup-range_bad_separator
   template: "{{ (1, 5) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected dotdot but found comma in "{{ (1, 5) }}"'
+    - Expected dotdot but found comma
   complexity: 100
 - name: variable-mut-value-lookup-range_missing_end
   template: "{{ (1..) }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ (1..)
-      }}"'
+    - '[:close_round, ")"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-lookup-trailing_dot
   template: "{{ x. }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x. }}"'
+    - Expected id but found end_of_string
   complexity: 100
 - name: variable-mut-value-lookup-unclosed_bracket
   template: "{{ x[0 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{ x[0
-      }}"'
+    - Expected close_square but found end_of_string
   complexity: 100
 - name: variable-mut-value-lookup-unclosed_range
   template: "{{ (1..5 }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{ (1..5
-      }}"'
+    - Expected close_round but found end_of_string
   complexity: 100
 - name: variable-mut-value-pipe-000
   template: "{{ | }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "{{ | }}"'
+    - '[:pipe, "|"] is not a valid expression'
   complexity: 100
 - name: variable-mut-value-question-005
   template: "{{ ? }}"
   errors:
     parse_error:
-    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{ ? }}"'
+    - '[:question, "?"] is not a valid expression'
   complexity: 100

--- a/specs/parser_errors/variable.yml
+++ b/specs/parser_errors/variable.yml
@@ -1,0 +1,1178 @@
+---
+- name: variable-mut-end-trail-close_round
+  template: "{{ x ) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_round in "{{ x
+      ) }}"'
+  complexity: 100
+- name: variable-mut-end-trail-close_square
+  template: "{{ x ] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found close_square in "{{ x
+      ] }}"'
+  complexity: 100
+- name: variable-mut-end-trail-colon
+  template: "{{ x : }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found colon in "{{ x : }}"'
+  complexity: 100
+- name: variable-mut-end-trail-comma
+  template: "{{ x , }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comma in "{{ x , }}"'
+  complexity: 100
+- name: variable-mut-end-trail-comparison
+  template: "{{ x == }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found comparison in "{{ x ==
+      }}"'
+  complexity: 100
+- name: variable-mut-end-trail-dash
+  template: "{{ x - }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found dash in "{{ x - }}"'
+  complexity: 100
+- name: variable-mut-end-trail-dot
+  template: "{{ x . }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x . }}"'
+  complexity: 100
+- name: variable-mut-end-trail-id
+  template: "{{ x extra }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found id in "{{ x extra }}"'
+  complexity: 100
+- name: variable-mut-end-trail-number
+  template: "{{ x 42 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found number in "{{ x 42 }}"'
+  complexity: 100
+- name: variable-mut-end-trail-open_round
+  template: "{{ x ( }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found open_round in "{{ x (
+      }}"'
+  complexity: 100
+- name: variable-mut-end-trail-open_square
+  template: "{{ x [ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:end_of_string] is not a valid expression in "{{ x [
+      }}"'
+  complexity: 100
+- name: variable-mut-end-trail-pipe
+  template: "{{ x | }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | }}"'
+  complexity: 100
+- name: variable-mut-end-trail-question
+  template: "{{ x ? }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found question in "{{ x ? }}"'
+  complexity: 100
+- name: variable-mut-end-trail-string
+  template: "{{ x 'hi' }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected end_of_string but found string in "{{ x ''hi''
+      }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-bare_bracket
+  template: "{{ x | x : x , , [0] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , [0] }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-close_round-004
+  template: "{{ x | x : x , , ) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , ) }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-close_square-003
+  template: "{{ x | x : x , , ] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , ] }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-colon-002
+  template: "{{ x | x : x , , : }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , : }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comma-001
+  template: "{{ x | x : x , , , }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , , }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comparison-009
+  template: "{{ x | x : x , , == }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , == }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comparison-010
+  template: "{{ x | x : x , , != }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , != }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comparison-011
+  template: "{{ x | x : x , , < }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , < }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comparison-012
+  template: "{{ x | x : x , , > }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , > }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comparison-013
+  template: "{{ x | x : x , , <= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , <= }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comparison-014
+  template: "{{ x | x : x , , >= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , >= }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-comparison-015
+  template: "{{ x | x : x , , contains }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , contains }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-dash-006
+  template: "{{ x | x : x , , - }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , - }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-dot-007
+  template: "{{ x | x : x , , . }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , . }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-dotdot-008
+  template: "{{ x | x : x , , .. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , .. }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-eos-016
+  template: "{{ x | x : x , , }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-ampersand
+  template: "{{ x | x : x , , & }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{ x | x : x , , & }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-asterisk
+  template: "{{ x | x : x , , * }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{ x | x : x , , * }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-at
+  template: "{{ x | x : x , , @ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{ x | x : x , , @ }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-backslash
+  template: "{{ x | x : x , , \\ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{ x | x : x , , \ }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-backtick
+  template: "{{ x | x : x , , ` }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{ x | x : x , , ` }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-caret
+  template: "{{ x | x : x , , ^ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{ x | x : x , , ^ }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-dollar
+  template: "{{ x | x : x , , $ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{ x | x : x , , $ }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-hash
+  template: "{{ x | x : x , , # }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{ x | x : x , , # }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-semicolon
+  template: "{{ x | x : x , , ; }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{ x | x : x , , ; }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-tilde
+  template: "{{ x | x : x , , ~ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{ x | x : x , , ~ }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-unclosed_double_quote
+  template: '{{ x | x : x , , "hello }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{ x | x : x , , "hello }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lexerr-unclosed_single_quote
+  template: "{{ x | x : x , , 'hello }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{ x | x : x , , ''hello }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-bracket_wrong_content
+  template: "{{ x | x : x , , x[,] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x[,] }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-dot_number
+  template: "{{ x | x : x , , x.123 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x.123 }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-dot_string
+  template: '{{ x | x : x , , x."y" }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x."y" }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-range_bad_separator
+  template: "{{ x | x : x , , (1, 5) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , (1, 5) }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-range_missing_end
+  template: "{{ x | x : x , , (1..) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , (1..) }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-trailing_dot
+  template: "{{ x | x : x , , x. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x. }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-unclosed_bracket
+  template: "{{ x | x : x , , x[0 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x[0 }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-lookup-unclosed_range
+  template: "{{ x | x : x , , (1..5 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , (1..5 }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-pipe-000
+  template: "{{ x | x : x , , | }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , | }}"'
+  complexity: 100
+- name: variable-mut-filter_arg_value-question-005
+  template: "{{ x | x : x , , ? }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , ? }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-bare_bracket
+  template: "{{ x | x : [0] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "{{ x | x : [0] }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-close_round-004
+  template: "{{ x | x : ) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ x
+      | x : ) }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-close_square-003
+  template: "{{ x | x : ] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{
+      x | x : ] }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-colon-002
+  template: "{{ x | x : : }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{ x | x :
+      : }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comma-001
+  template: "{{ x | x : , }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      , }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comparison-009
+  template: "{{ x | x : == }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{ x
+      | x : == }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comparison-010
+  template: "{{ x | x : != }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{ x
+      | x : != }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comparison-011
+  template: "{{ x | x : < }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{ x
+      | x : < }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comparison-012
+  template: "{{ x | x : > }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{ x
+      | x : > }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comparison-013
+  template: "{{ x | x : <= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{ x
+      | x : <= }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comparison-014
+  template: "{{ x | x : >= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{ x
+      | x : >= }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-comparison-015
+  template: "{{ x | x : contains }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "{{ x | x : contains }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-dash-006
+  template: "{{ x | x : - }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{ x | x :
+      - }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-dot-007
+  template: "{{ x | x : . }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{ x | x : .
+      }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-dotdot-008
+  template: "{{ x | x : .. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{ x | x
+      : .. }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-ampersand
+  template: "{{ x | x : & }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{ x | x : & }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-asterisk
+  template: "{{ x | x : * }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{ x | x : * }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-at
+  template: "{{ x | x : @ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{ x | x : @ }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-backslash
+  template: "{{ x | x : \\ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{ x | x : \ }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-backtick
+  template: "{{ x | x : ` }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{ x | x : ` }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-caret
+  template: "{{ x | x : ^ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{ x | x : ^ }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-dollar
+  template: "{{ x | x : $ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{ x | x : $ }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-hash
+  template: "{{ x | x : # }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{ x | x : # }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-semicolon
+  template: "{{ x | x : ; }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{ x | x : ; }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-tilde
+  template: "{{ x | x : ~ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{ x | x : ~ }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-unclosed_double_quote
+  template: '{{ x | x : "hello }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{ x | x : "hello }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lexerr-unclosed_single_quote
+  template: "{{ x | x : 'hello }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{ x | x : ''hello }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-bracket_wrong_content
+  template: "{{ x | x : x[,] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x[,] }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-dot_number
+  template: "{{ x | x : x.123 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "{{ x | x : x.123 }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-dot_string
+  template: '{{ x | x : x."y" }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "{{ x | x : x."y" }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-range_bad_separator
+  template: "{{ x | x : (1, 5) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "{{ x | x : (1, 5)
+      }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-range_missing_end
+  template: "{{ x | x : (1..) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ x
+      | x : (1..) }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-trailing_dot
+  template: "{{ x | x : x. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | x : x.
+      }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-unclosed_bracket
+  template: "{{ x | x : x[0 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{ x
+      | x : x[0 }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-lookup-unclosed_range
+  template: "{{ x | x : (1..5 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{ x
+      | x : (1..5 }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-pipe-000
+  template: "{{ x | x : | }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | x : | }}"'
+  complexity: 100
+- name: variable-mut-filter_first_arg-question-005
+  template: "{{ x | x : ? }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{ x |
+      x : ? }}"'
+  complexity: 100
+- name: variable-mut-filter_name-eos
+  template: "{{ x | }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x | }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-ampersand
+  template: "{{ x | & }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{ x | & }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-asterisk
+  template: "{{ x | * }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{ x | * }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-at
+  template: "{{ x | @ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{ x | @ }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-backslash
+  template: "{{ x | \\ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{ x | \ }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-backtick
+  template: "{{ x | ` }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{ x | ` }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-caret
+  template: "{{ x | ^ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{ x | ^ }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-dollar
+  template: "{{ x | $ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{ x | $ }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-hash
+  template: "{{ x | # }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{ x | # }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-semicolon
+  template: "{{ x | ; }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{ x | ; }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-tilde
+  template: "{{ x | ~ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{ x | ~ }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-unclosed_double_quote
+  template: '{{ x | "hello }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{ x | "hello }}"'
+  complexity: 100
+- name: variable-mut-filter_name-lexerr-unclosed_single_quote
+  template: "{{ x | 'hello }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{ x | ''hello }}"'
+  complexity: 100
+- name: variable-mut-filter_name-number
+  template: "{{ x | 42 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "{{ x | 42 }}"'
+  complexity: 100
+- name: variable-mut-kwarg_colon-eos
+  template: "{{ x | x : x , , x }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x }}"'
+  complexity: 100
+- name: variable-mut-kwarg_colon-number
+  template: "{{ x | x : x , , x 42 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x 42 }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-bare_bracket
+  template: "{{ x | x : x , , x : [0] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : [0] }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-close_round-004
+  template: "{{ x | x : x , , x : ) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : ) }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-close_square-003
+  template: "{{ x | x : x , , x : ] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : ] }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-colon-002
+  template: "{{ x | x : x , , x : : }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : : }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comma-001
+  template: "{{ x | x : x , , x : , }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : , }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comparison-009
+  template: "{{ x | x : x , , x : == }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : == }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comparison-010
+  template: "{{ x | x : x , , x : != }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : != }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comparison-011
+  template: "{{ x | x : x , , x : < }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : < }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comparison-012
+  template: "{{ x | x : x , , x : > }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : > }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comparison-013
+  template: "{{ x | x : x , , x : <= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : <= }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comparison-014
+  template: "{{ x | x : x , , x : >= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : >= }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-comparison-015
+  template: "{{ x | x : x , , x : contains }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : contains }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-dash-006
+  template: "{{ x | x : x , , x : - }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : - }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-dot-007
+  template: "{{ x | x : x , , x : . }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : . }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-dotdot-008
+  template: "{{ x | x : x , , x : .. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : .. }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-eos-016
+  template: "{{ x | x : x , , x : }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-ampersand
+  template: "{{ x | x : x , , x : & }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{ x | x : x , , x : & }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-asterisk
+  template: "{{ x | x : x , , x : * }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{ x | x : x , , x : * }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-at
+  template: "{{ x | x : x , , x : @ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{ x | x : x , , x : @ }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-backslash
+  template: "{{ x | x : x , , x : \\ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{ x | x : x , , x : \ }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-backtick
+  template: "{{ x | x : x , , x : ` }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{ x | x : x , , x : ` }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-caret
+  template: "{{ x | x : x , , x : ^ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{ x | x : x , , x : ^ }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-dollar
+  template: "{{ x | x : x , , x : $ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{ x | x : x , , x : $ }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-hash
+  template: "{{ x | x : x , , x : # }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{ x | x : x , , x : # }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-semicolon
+  template: "{{ x | x : x , , x : ; }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{ x | x : x , , x : ; }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-tilde
+  template: "{{ x | x : x , , x : ~ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{ x | x : x , , x : ~ }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-unclosed_double_quote
+  template: '{{ x | x : x , , x : "hello }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{ x | x : x , , x : "hello
+      }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lexerr-unclosed_single_quote
+  template: "{{ x | x : x , , x : 'hello }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{ x | x : x , , x : ''hello
+      }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-bracket_wrong_content
+  template: "{{ x | x : x , , x : x[,] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : x[,] }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-dot_number
+  template: "{{ x | x : x , , x : x.123 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : x.123 }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-dot_string
+  template: '{{ x | x : x , , x : x."y" }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : x."y" }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-range_bad_separator
+  template: "{{ x | x : x , , x : (1, 5) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : (1, 5) }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-range_missing_end
+  template: "{{ x | x : x , , x : (1..) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : (1..) }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-trailing_dot
+  template: "{{ x | x : x , , x : x. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : x. }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-unclosed_bracket
+  template: "{{ x | x : x , , x : x[0 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : x[0 }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-lookup-unclosed_range
+  template: "{{ x | x : x , , x : (1..5 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : (1..5 }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-pipe-000
+  template: "{{ x | x : x , , x : | }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : | }}"'
+  complexity: 100
+- name: variable-mut-kwarg_value-question-005
+  template: "{{ x | x : x , , x : ? }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x | x :
+      x , , x : ? }}"'
+  complexity: 100
+- name: variable-mut-value-bare_bracket
+  template: "{{ [0] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Bare bracket access is not allowed in strict2 mode. Use
+      self[''...''] instead in "{{ [0] }}"'
+  complexity: 100
+- name: variable-mut-value-close_round-004
+  template: "{{ ) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ )
+      }}"'
+  complexity: 100
+- name: variable-mut-value-close_square-003
+  template: "{{ ] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_square, "]"] is not a valid expression in "{{
+      ] }}"'
+  complexity: 100
+- name: variable-mut-value-colon-002
+  template: "{{ : }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:colon, ":"] is not a valid expression in "{{ : }}"'
+  complexity: 100
+- name: variable-mut-value-comma-001
+  template: "{{ , }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ , }}"'
+  complexity: 100
+- name: variable-mut-value-comparison-009
+  template: "{{ == }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "=="] is not a valid expression in "{{ ==
+      }}"'
+  complexity: 100
+- name: variable-mut-value-comparison-010
+  template: "{{ != }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "!="] is not a valid expression in "{{ !=
+      }}"'
+  complexity: 100
+- name: variable-mut-value-comparison-011
+  template: "{{ < }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<"] is not a valid expression in "{{ <
+      }}"'
+  complexity: 100
+- name: variable-mut-value-comparison-012
+  template: "{{ > }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">"] is not a valid expression in "{{ >
+      }}"'
+  complexity: 100
+- name: variable-mut-value-comparison-013
+  template: "{{ <= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "<="] is not a valid expression in "{{ <=
+      }}"'
+  complexity: 100
+- name: variable-mut-value-comparison-014
+  template: "{{ >= }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, ">="] is not a valid expression in "{{ >=
+      }}"'
+  complexity: 100
+- name: variable-mut-value-comparison-015
+  template: "{{ contains }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comparison, "contains"] is not a valid expression in
+      "{{ contains }}"'
+  complexity: 100
+- name: variable-mut-value-dash-006
+  template: "{{ - }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dash, "-"] is not a valid expression in "{{ - }}"'
+  complexity: 100
+- name: variable-mut-value-dot-007
+  template: "{{ . }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dot, "."] is not a valid expression in "{{ . }}"'
+  complexity: 100
+- name: variable-mut-value-dotdot-008
+  template: "{{ .. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:dotdot, ".."] is not a valid expression in "{{ .. }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-ampersand
+  template: "{{ & }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character & in "{{ & }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-asterisk
+  template: "{{ * }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character * in "{{ * }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-at
+  template: "{{ @ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character @ in "{{ @ }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-backslash
+  template: "{{ \\ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character \ in "{{ \ }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-backtick
+  template: "{{ ` }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ` in "{{ ` }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-caret
+  template: "{{ ^ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ^ in "{{ ^ }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-dollar
+  template: "{{ $ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character $ in "{{ $ }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-hash
+  template: "{{ # }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character # in "{{ # }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-semicolon
+  template: "{{ ; }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ; in "{{ ; }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-tilde
+  template: "{{ ~ }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character ~ in "{{ ~ }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-unclosed_double_quote
+  template: '{{ "hello }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character " in "{{ "hello }}"'
+  complexity: 100
+- name: variable-mut-value-lexerr-unclosed_single_quote
+  template: "{{ 'hello }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Unexpected character '' in "{{ ''hello }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-bracket_wrong_content
+  template: "{{ x[,] }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:comma, ","] is not a valid expression in "{{ x[,] }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-dot_number
+  template: "{{ x.123 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found number in "{{ x.123 }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-dot_string
+  template: '{{ x."y" }}'
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found string in "{{ x."y" }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-range_bad_separator
+  template: "{{ (1, 5) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected dotdot but found comma in "{{ (1, 5) }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-range_missing_end
+  template: "{{ (1..) }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:close_round, ")"] is not a valid expression in "{{ (1..)
+      }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-trailing_dot
+  template: "{{ x. }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected id but found end_of_string in "{{ x. }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-unclosed_bracket
+  template: "{{ x[0 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_square but found end_of_string in "{{ x[0
+      }}"'
+  complexity: 100
+- name: variable-mut-value-lookup-unclosed_range
+  template: "{{ (1..5 }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: Expected close_round but found end_of_string in "{{ (1..5
+      }}"'
+  complexity: 100
+- name: variable-mut-value-pipe-000
+  template: "{{ | }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:pipe, "|"] is not a valid expression in "{{ | }}"'
+  complexity: 100
+- name: variable-mut-value-question-005
+  template: "{{ ? }}"
+  errors:
+    parse_error:
+    - 'Liquid syntax error: [:question, "?"] is not a valid expression in "{{ ? }}"'
+  complexity: 100


### PR DESCRIPTION
### Overview

liquid-spec doesn't have many cases covering syntax errors. This PR adds ~2K specs covering nearly every `SyntaxError` branch across all tags — all additive YAML, no Ruby changes.

Each spec follows this shape:

```yaml
- name: "assign - missing variable name"
  template: "{% assign = 'hello' %}"
  errors:
    parse_error: "[Liquid syntax error] Syntax Error in 'assign' - Valid syntax: assign [var] = [source]"
```

### How adapters opt in

The suite is opt-in, so existing adapters see nothing new. An adapter that supports strict2 parsing enables the full suite by adding it to their suite list; the existing feature-gating system handles the rest.

### Coverage

The specs aim to cover every `raise SyntaxError` call site in the parser including unguarded `parser.consume(type)` calls.