### PR TITLE
Update parser error expectations to match Liquid Ruby output

### DIFF
--- a/specs/parser_errors/assign.yml
+++ b/specs/parser_errors/assign.yml
@@ -315,7 +315,7 @@
   template: "{% assign x = x | x : [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: assign-mut-filter_first_arg-close_round-004
   template: "{% assign x = x | x : ) %}"
@@ -1155,7 +1155,7 @@
   template: "{% assign x = [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: assign-mut-value-close_round-004
   template: "{% assign x = ) %}"

--- a/specs/parser_errors/case.yml
+++ b/specs/parser_errors/case.yml
@@ -3,7 +3,7 @@
   template: "{% case [0] %}{% endcase %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: case-mut-case_expression-close_round-004
   template: "{% case ) %}{% endcase %}"
@@ -627,7 +627,7 @@
   template: "{% case x %}{% when [0] %}{% endcase %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: case-mut-when_value-close_round-004
   template: "{% case x %}{% when ) %}{% endcase %}"

--- a/specs/parser_errors/cycle.yml
+++ b/specs/parser_errors/cycle.yml
@@ -537,7 +537,7 @@
   template: "{% cycle x : [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: cycle-mut-first_cycle_value-close_round-004
   template: "{% cycle x : ) %}"
@@ -765,7 +765,7 @@
   template: "{% cycle [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: cycle-mut-first_value-close_round-004
   template: "{% cycle ) %}"

--- a/specs/parser_errors/echo.yml
+++ b/specs/parser_errors/echo.yml
@@ -315,7 +315,7 @@
   template: "{% echo x | x : [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: echo-mut-filter_first_arg-close_round-004
   template: "{% echo x | x : ) %}"
@@ -861,7 +861,7 @@
   template: "{% echo [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: echo-mut-value-close_round-004
   template: "{% echo ) %}"

--- a/specs/parser_errors/for.yml
+++ b/specs/parser_errors/for.yml
@@ -243,7 +243,7 @@
   template: "{% for x in [0] %}{% endfor %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: for-mut-collection-close_round-004
   template: "{% for x in ) %}{% endfor %}"

--- a/specs/parser_errors/if.yml
+++ b/specs/parser_errors/if.yml
@@ -525,7 +525,7 @@
   template: "{% if x == [0] %}{% endif %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: if-mut-comparison_rhs-close_round-004
   template: "{% if x == ) %}{% endif %}"
@@ -753,7 +753,7 @@
   template: "{% if [0] %}{% endif %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: if-mut-condition-close_round-004
   template: "{% if ) %}{% endif %}"

--- a/specs/parser_errors/include.yml
+++ b/specs/parser_errors/include.yml
@@ -93,7 +93,7 @@
   template: "{% include x for [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: include-mut-binding_value-close_round-004
   template: "{% include x for ) %}"
@@ -723,7 +723,7 @@
   template: "{% include [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: include-mut-template_expr-close_round-004
   template: "{% include ) %}"

--- a/specs/parser_errors/render.yml
+++ b/specs/parser_errors/render.yml
@@ -93,7 +93,7 @@
   template: "{% render 'snippet' for [0] %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: render-mut-binding_value-close_round-004
   template: "{% render 'snippet' for ) %}"
@@ -723,5 +723,5 @@
   template: "{% render  %}"
   errors:
     parse_error:
-    - Syntax error in tag 'render' - Expected a string or identifier, found nothing
+    - Expected string but found end_of_string
   complexity: 100

--- a/specs/parser_errors/table_row.yml
+++ b/specs/parser_errors/table_row.yml
@@ -271,7 +271,7 @@
   template: "{% tablerow x in [0] %}{% endtablerow %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: table_row-mut-collection-close_round-004
   template: "{% tablerow x in ) %}{% endtablerow %}"

--- a/specs/parser_errors/unless.yml
+++ b/specs/parser_errors/unless.yml
@@ -525,7 +525,7 @@
   template: "{% unless x == [0] %}{% endunless %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: unless-mut-comparison_rhs-close_round-004
   template: "{% unless x == ) %}{% endunless %}"
@@ -753,7 +753,7 @@
   template: "{% unless [0] %}{% endunless %}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: unless-mut-condition-close_round-004
   template: "{% unless ) %}{% endunless %}"

--- a/specs/parser_errors/variable.yml
+++ b/specs/parser_errors/variable.yml
@@ -315,7 +315,7 @@
   template: "{{ x | x : [0] }}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: variable-mut-filter_first_arg-close_round-004
   template: "{{ x | x : ) }}"
@@ -861,7 +861,7 @@
   template: "{{ [0] }}"
   errors:
     parse_error:
-    - Bare bracket access is not allowed in strict2 mode. Use self['...'] instead
+    - Bare bracket access is not allowed. Use self['...'] instead
   complexity: 100
 - name: variable-mut-value-close_round-004
   template: "{{ ) }}"


### PR DESCRIPTION
This PR fixes issues in the `specs/parser_errors` test suite.

### Before

<img width="1726" height="1209" alt="Screenshot 2026-05-20 at 21 48 35" src="https://github.com/user-attachments/assets/cdab8511-16a4-456d-b664-7bfb2c8c69ce" />

### After

<img width="1726" height="1209" alt="Screenshot 2026-05-20 at 21 48 05" src="https://github.com/user-attachments/assets/848a0254-7368-47b2-b72a-57ce9d5ad26b" />
