### PR TITLE
Update `self` specs for environment shadowing

### DIFF
--- a/examples/liquid_ruby.rb
+++ b/examples/liquid_ruby.rb
@@ -19,7 +19,7 @@ LiquidSpec.setup do |ctx|
 end
 
 LiquidSpec.configure do |config|
-  config.missing_features = [:shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access, :activesupport, :lax_parsing]
+  config.missing_features = [:self_environment_shadowing, :shopify_filters, :shopify_includes, :shopify_blank, :shopify_error_handling, :shopify_error_format, :shopify_string_access, :activesupport, :lax_parsing]
 end
 
 LiquidSpec.compile do |ctx, source, parse_options|

--- a/lib/liquid/spec/cli/adapter_dsl.rb
+++ b/lib/liquid/spec/cli/adapter_dsl.rb
@@ -61,6 +61,7 @@ module LiquidSpec
     ruby_types: "Supports Ruby-specific types (symbols in hash keys/output)",
     lax_parsing: "Supports error_mode: :lax for lenient parsing",
     strict2_parsing: "Supports error_mode: :strict2 (Liquid 5.12+ relaxed trailing comma/colon syntax)",
+    self_environment_shadowing: "Environment variables named self shadow the synthetic SelfDrop",
     shopify_tags: "Shopify-specific tags (schema, style, section, etc.)",
     shopify_objects: "Shopify-specific objects (section, block, content_for_header)",
     shopify_filters: "Shopify-specific filters (asset_url, image_url, etc.)",

--- a/specs/liquid_ruby/bare_bracket_self.yml
+++ b/specs/liquid_ruby/bare_bracket_self.yml
@@ -387,6 +387,33 @@
     snippet sees the middle value, and a fresh self lookup in the
     inner snippet sees the inner value.
 
+- name: captured_self_distinguishes_original_and_snippet_scope_at_boundary
+  template: "{%- assign x = 'outer' -%}{%- assign s = self -%}{{- s.x -}}|{%- render 'snippet1', other_self: s -%}"
+  filesystem:
+    snippet1: "{%- assign x = 'snippet' -%}{{- other_self.x }}|{{ self.x -}}"
+  expected: "outer|outer|snippet"
+  hint: |
+    A SelfDrop captured in the outer template keeps resolving through
+    the original scope on BOTH sides of a render boundary: read before
+    the render it sees `outer`, and read again inside the snippet it
+    STILL sees `outer`, while a fresh `self` inside the snippet sees the
+    snippet's `snippet`. This is the partial-state-visibility behavior:
+    the captured self is re-evaluated against the snippet context at the
+    boundary but preserves its original variable resolution.
+
+- name: captured_self_tracks_each_scope_across_nested_render_boundaries
+  template: "{%- assign x = 1 -%}{%- assign s1 = self -%}{{- s1.x -}}|{%- render 'snippet1', outer: s1 -%}"
+  filesystem:
+    snippet1: "{%- assign x = 2 -%}{%- assign s2 = self -%}{{- outer.x }}/{{ s2.x -}}|{%- render 'snippet2', outer: outer, middle: s2 -%}"
+    snippet2: "{%- assign x = 3 -%}{{- outer.x }}/{{ middle.x }}/{{ self.x -}}"
+  expected: "1|1/2|1/2/3"
+  hint: |
+    Each captured SelfDrop preserves the scope it was captured in, read
+    repeatedly across every render boundary it crosses. The outer self
+    always sees 1, the middle self always sees 2, and a fresh self in
+    the innermost snippet sees 3 — proving per-level scope tracking is
+    stable when the same captured drops are re-read at deeper levels.
+
 - name: self_reflects_variables_assigned_after_creation
   template: "{%- assign s = self -%}{%- assign x = 42 %}{{ s.x -}}"
   expected: "42"

--- a/specs/liquid_ruby/bare_bracket_self.yml
+++ b/specs/liquid_ruby/bare_bracket_self.yml
@@ -277,6 +277,7 @@
 
 - name: self_environment_key_shadows_self_drop
   template: "{{ self }}"
+  features: [self_environment_shadowing]
   environment:
     self: env_value
   expected: "env_value"
@@ -319,6 +320,7 @@
 
 - name: self_environment_key_is_bracket_receiver
   template: "{{ self['key'] }}|{{ self.key }}"
+  features: [self_environment_shadowing]
   environment:
     self:
       key: value
@@ -330,6 +332,7 @@
 
 - name: increment_self_shadows_self_drop
   template: "{% increment self %}|{{ self }}"
+  features: [self_environment_shadowing]
   expected: "0|1"
   hint: |
     Increment writes its counter into the environment. That environment
@@ -337,6 +340,7 @@
 
 - name: decrement_self_shadows_self_drop
   template: "{% decrement self %}|{{ self }}"
+  features: [self_environment_shadowing]
   expected: "-1|-1"
   hint: |
     Decrement writes its counter into the environment. That environment
@@ -420,6 +424,7 @@
 
 - name: captured_environment_self_preserves_environment_value_across_render
   template: "{%- assign s = self -%}{%- render 'snippet1', drop: s -%}"
+  features: [self_environment_shadowing]
   environment:
     self:
       value: env

--- a/specs/liquid_ruby/bare_bracket_self.yml
+++ b/specs/liquid_ruby/bare_bracket_self.yml
@@ -275,19 +275,15 @@
     self[...] works inside capture blocks. The captured value is
     rendered using the same variable lookup rules as anywhere else.
 
-- name: self_lookup_when_environment_has_self_key
-  template: "{{ self['key'] }}"
+- name: self_environment_key_shadows_self_drop
+  template: "{{ self }}"
   environment:
     self: env_value
-    key: value
-  expected: "value"
+  expected: "env_value"
   hint: |
-    Even when the environment defines a 'self' key, the `self`
-    keyword still resolves to the SelfDrop for bracket lookups.
-    SelfDrop is returned by find_variable for the 'self' key
-    before environment lookup occurs (unless 'self' was explicitly
-    assigned as a local variable). So self['key'] still does the
-    normal scope-chain lookup and finds 'key'.
+    A static environment variable named `self` shadows the synthetic
+    SelfDrop. Bare `self` only falls back to SelfDrop after normal
+    scope and environment lookup miss.
 
 - name: self_dotted_special_names_delegate_to_scope
   template: "{% assign size = 17 %}{% assign first = 18 %}{% assign last = 19 %}{{ self.size }}|{{ self.first }}|{{ self.last }}"
@@ -321,35 +317,30 @@
     SelfDrop objects. They compare equal because both point at the same
     variable context.
 
-- name: nested_self_ignores_static_environment_self_key
-  template: "{{ self.self }}|{{ self['self'] }}"
+- name: self_environment_key_is_bracket_receiver
+  template: "{{ self['key'] }}|{{ self.key }}"
   environment:
-    self: env
-  expected: "Liquid::SelfDrop|Liquid::SelfDrop"
+    self:
+      key: value
+  expected: "value|value"
   hint: |
-    Looking up self through SelfDrop re-enters Context#find_variable,
-    including the special unbound-self shortcut. A static environment
-    key named self must not shadow that shortcut.
+    When an environment defines `self`, bracket and dot access operate
+    on that environment value. The synthetic SelfDrop is only used when
+    the normal lookup chain doesn't find `self`.
 
-- name: increment_self_does_not_shadow_self_drop
-  template: "{% increment self %}|{{ self }}|{{ self['x'] }}"
-  environment:
-    x: value
-  expected: "0|Liquid::SelfDrop|value"
+- name: increment_self_shadows_self_drop
+  template: "{% increment self %}|{{ self }}"
+  expected: "0|1"
   hint: |
-    Increment counters do not count as local variable bindings for
-    the self shortcut. After increment self, bare self still resolves
-    to SelfDrop.
+    Increment writes its counter into the environment. That environment
+    value shadows the synthetic SelfDrop for later bare `self` lookups.
 
-- name: decrement_self_does_not_shadow_self_drop
-  template: "{% decrement self %}|{{ self }}|{{ self['x'] }}"
-  environment:
-    x: value
-  expected: "-1|Liquid::SelfDrop|value"
+- name: decrement_self_shadows_self_drop
+  template: "{% decrement self %}|{{ self }}"
+  expected: "-1|-1"
   hint: |
-    Decrement counters do not count as local variable bindings for
-    the self shortcut. After decrement self, bare self still resolves
-    to SelfDrop.
+    Decrement writes its counter into the environment. That environment
+    value shadows the synthetic SelfDrop for later bare `self` lookups.
 
 - name: self_in_render_without_passing_resolves_inner_scope
   template: "{%- assign var = 42 -%}{%- render 'snippet1' -%}"
@@ -427,17 +418,18 @@
     Passing SelfDrop with the generic render parameter name `drop`
     still preserves the captured context and supports normal lookup.
 
-- name: captured_self_nested_self_ignores_static_environment_self_key
+- name: captured_environment_self_preserves_environment_value_across_render
   template: "{%- assign s = self -%}{%- render 'snippet1', drop: s -%}"
   environment:
-    self: env
+    self:
+      value: env
   filesystem:
-    snippet1: "{{- drop.self }}|{{ drop['self'] -}}"
-  expected: "Liquid::SelfDrop|Liquid::SelfDrop"
+    snippet1: "{{- drop.value -}}"
+  expected: "env"
   hint: |
-    Looking up self through a captured SelfDrop re-enters the same
-    unbound-self shortcut as a fresh lookup. Static environment keys
-    named self must not shadow that shortcut, even across render.
+    If the environment defines `self`, assigning `self` captures that
+    environment value rather than the synthetic SelfDrop. Passing it
+    through render preserves the captured value as usual.
 
 - name: self_size_filter_has_no_intrinsic_size
   template: "{% assign size = 'SSS' %}{{ self.size }}|{{ self['size'] }}|{{ self | size }}"


### PR DESCRIPTION
Updates the `self` conformance specs for the new lookup behavior: environment values, including increment/decrement counters, shadow the synthetic `SelfDrop` before Liquid falls back to it.
