### PR TITLE
Add spec for empty string truthiness in conditional attributes

### DIFF
--- a/specs/basics/specs.yml
+++ b/specs/basics/specs.yml
@@ -1831,6 +1831,23 @@ specs:
   hint: |
     IMPORTANT: Empty strings are TRUTHY in Liquid! This is different from
     many languages. Use {{ str | size }} > 0 to check for non-empty.
+- name: truthy_empty_string_renders_conditional_attribute
+  template: |-
+    {%- liquid
+      assign tag = tag | default: 'section'
+      assign value = settings.value
+    -%}
+    <{{ tag }}{% if value %} data-empty="{{ value }}"{% endif %}>content</{{ tag }}>
+  environment:
+    settings:
+      value: ""
+  expected: '<section data-empty="">content</section>'
+  complexity: 150
+  hint: |
+    IMPORTANT: Empty strings are truthy in Liquid, so {% if value %} must
+    execute even when value is "". Do not reuse host-language truthiness
+    rules that treat empty strings as falsy. Only nil and false are falsy;
+    render the attribute and let {{ value }} output the empty string.
 - name: truthy_zero
   template: "{% if 0 %}yes{% endif %}"
   expected: 'yes'


### PR DESCRIPTION
## Context

   This PR adds coverage for Liquid’s truthiness rules when an empty string is used in a conditional attribute pattern.

## Why?

   * Empty strings are truthy in Liquid, unlike in many host languages.
   * Implementations can accidentally treat `""` as falsy and skip rendering conditional attributes.
   * This captures a realistic theme-style pattern where an empty setting value should still cause the attribute to render.

## What?

   * Adds a new `truthy_empty_string_renders_conditional_attribute` spec to `specs/basics/specs.yml`.
   * Verifies that `{% if value %}` executes when `value` is an empty string.
   * Confirms the rendered output includes the attribute with an empty value: `data-empty=""`.
   * Adds a hint explaining that only `nil` and `false` are falsy in Liquid.