### PR TITLE
Add spec for captured blank comparison

### DIFF
--- a/specs/basics/blank-and-empty.yml
+++ b/specs/basics/blank-and-empty.yml
@@ -246,6 +246,26 @@ specs:
     NotEquals comparison. Empty string != empty is false, so the
     else branch executes. This is the idiomatic way to check for content.
 
+- name: "captured_conditional_whitespace_is_blank"
+  template: |-
+    {%- capture maybe_content -%}
+      {% if show %}
+        <div>content</div>
+      {% endif %}
+    {%- endcapture -%}
+    {% if maybe_content != blank %}<section>{{ maybe_content }}</section>{% endif %}
+  environment:
+    show: false
+  expected: ""
+  complexity: 160
+  features: [shopify_blank]
+  hint: |
+    capture stores the rendered output of its body, not the raw template
+    source. If an inner conditional renders no content, the captured value
+    may be empty or whitespace-only and should compare as blank. Compare
+    maybe_content != blank against the captured rendered string; do not
+    treat the presence of tags or skipped markup inside the capture as content.
+
 - name: "complex_empty_guard"
   template: "{% if user != empty and user.name != empty %}{{ user.name }}{% else %}Anonymous{% endif %}"
   environment: { user: { name: "" } }


### PR DESCRIPTION
## Why?

  * Captured Liquid output can be blank even when the capture body contains skipped tags or markup.
  * Renderer implementations can accidentally compare the raw capture body instead of the rendered captured string.
  * This regression produces empty wrapper markup in theme patterns that guard captured content with `!= blank`.

## What?

  * Adds a `captured_conditional_whitespace_is_blank` spec to `specs/basics/blank-and-empty.yml`.
  * Covers a capture whose inner conditional renders no content and is later checked with `maybe_content != blank`.
  * Expects no wrapper output when the captured value is blank.
  * Gates the spec behind `shopify_blank` because it depends on Shopify/Rails-like whitespace blank semantics.
