### PR TITLE
fix: update lax BooleanDrop expected value to match StandardBooleanDrop

### DIFF
--- a/specs/liquid_ruby_lax/variable_type_filters.yml
+++ b/specs/liquid_ruby_lax/variable_type_filters.yml
@@ -500,7 +500,7 @@ specs:
 - name: lax_filter_booleandrop_first_last_size
   features: [drops]
   complexity: 520
-  hint: BooleanDrop wraps a boolean value, to_s returns Yay/Nay
+  hint: BooleanDrop wraps a boolean value, to_s returns true/false
   template: |
     drop value:{{- d }}
     drop, first:{{- d | first }}
@@ -511,7 +511,7 @@ specs:
       instantiate:BooleanDrop:
         value: true
   expected: |
-    drop value:Yay
+    drop value:true
     drop, first:
     drop, last:
     drop, size:0


### PR DESCRIPTION
## Problem

liquid-spec 2.0.0 loads `standard_drops.rb` after `liquid_ruby.rb` (line 613), so `instantiate:BooleanDrop` now creates `StandardBooleanDrop` (`to_s` → `"true"`/`"false"`) instead of the legacy `BooleanDrop` (`to_s` → `"Yay"`/`"Nay"`).

The non-lax `liquid_ruby/variable_type_filters.yml` was already updated to expect `"true"`, but the lax version (`liquid_ruby_lax/variable_type_filters.yml`) was missed — it still expects `"Yay"`.

## Confirmation

Reference liquid (Shopify/liquid) also renders `"true"`:

```ruby
require "liquid"
require "liquid/spec/deps/liquid_ruby"
f = Liquid::Spec::ClassRegistry.all["BooleanDrop"]
d = f.call({"value" => true})
Liquid::Template.parse("{{ d }}").render({"d" => d})
# => "true"
```

## Fix

2-line change: update the hint and expected value to match `StandardBooleanDrop` behavior, consistent with the non-lax suite.